### PR TITLE
Multi line text output for the font addon.

### DIFF
--- a/addons/font/allegro5/allegro_font.h
+++ b/addons/font/allegro5/allegro_font.h
@@ -112,6 +112,16 @@ ALLEGRO_FONT_FUNC(uint32_t, al_get_allegro_font_version, (void));
 ALLEGRO_FONT_FUNC(int, al_get_font_ranges, (ALLEGRO_FONT *font,
    int ranges_count, int *ranges));
 
+ALLEGRO_FONT_FUNC(void, al_get_multiline_text_dimensions, (const ALLEGRO_FONT *f,
+   const char *text, float max_width, float line_height, 
+   int *bbx, int *bby, int *bbw, int *bbh));
+ALLEGRO_FONT_FUNC(void, al_get_multiline_ustr_dimensions, (const ALLEGRO_FONT *f,
+   const ALLEGRO_USTR *ustr, float line_height, float max_width,
+   int *bbx, int *bby, int *bbw, int *bbh));
+ALLEGRO_FONT_FUNC(void, al_draw_multiline_text, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *text));
+ALLEGRO_FONT_FUNC(void, al_draw_multiline_textf, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *format, ...));
+ALLEGRO_FONT_FUNC(void, al_draw_multiline_ustr, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const ALLEGRO_USTR *text));
+
 
 #ifdef __cplusplus
    }

--- a/addons/font/text.c
+++ b/addons/font/text.c
@@ -21,6 +21,7 @@
 
 
 #include <math.h>
+#include <ctype.h>
 #include "allegro5/allegro.h"
 
 #include "allegro5/allegro_font.h"
@@ -370,5 +371,266 @@ int al_get_font_ranges(ALLEGRO_FONT *f, int ranges_count, int *ranges)
 {
    return f->vtable->get_font_ranges(f, ranges_count, ranges);
 }
+
+
+
+/* This helper function helps splitting an ustr is several delimited parts. 
+ * It returns returns an ustr thet refers to
+ * the next part of the string that is delimited by the delimiters in delim.
+ * Returns NULL at the end of the string.
+ * Pos is updated to byte index of character after the delimiter or
+ * to the end of the string.
+ */
+static const ALLEGRO_USTR *ustr_split_next(const ALLEGRO_USTR *ustr,
+   ALLEGRO_USTR_INFO *info, int *pos, const char *delimiter)
+{
+   const ALLEGRO_USTR *result;
+   int end, size;
+   
+   size = al_ustr_size(ustr);
+   if (*pos >= size) {
+      return NULL;
+   }
+   
+   end = al_ustr_find_set_cstr(ustr, *pos, delimiter);
+   if (end == -1)
+      end = size;
+
+   result = al_ref_ustr(info, ustr, *pos, end);
+   /* Set pos to character AFTER delimiter */
+   al_ustr_next(ustr, &end);
+   (*pos) = end;
+   return result;
+}
+
+
+
+/* This returns the next "soft" line of text from ustr
+ * that will fit in max_with using the font font, starting at pos *pos.
+ * These are "soft" lines because they are broken up if needed at a space
+ * or tab character.
+ * This function updates pos if needed, and returns the next "soft" line,
+ * or NULL if no more soft lines.
+ * The soft line will not include the trailing space where the
+ * line was split, but pos will be set to point to after that trailing
+ * space so iteration can continue easily.
+ */
+static const ALLEGRO_USTR *get_next_soft_line(const ALLEGRO_USTR *ustr,
+   ALLEGRO_USTR_INFO *info, int *pos,
+   const ALLEGRO_FONT *font, float max_width)
+{
+   const ALLEGRO_USTR *result = NULL;
+   const char *whitespace = " \t";
+   int old_end = 0;
+   int end = 0;
+   int size = al_ustr_size(ustr);
+   bool first_word = true;  
+   
+   if (*pos >= size) {
+      return NULL;
+   }
+   
+   end = *pos;
+   old_end = end;
+   do {
+      /* On to the next word. */
+      end = al_ustr_find_set_cstr(ustr, end, whitespace);
+      if (end < 0)
+         end = size;
+         
+      /* Reference to the line that is being built. */
+      result = al_ref_ustr(info, ustr, *pos, end);
+
+      /* Check if the line is too long. If it is, return a soft line. */
+      if (al_get_ustr_width(font, result) > max_width) {
+         /* Corner case: a single word may not even fit the line.
+          * In that case, return the word/line anyway as the "soft line",
+          * the user can set a clip rectangle to cut it. */
+          
+         if (first_word) {
+            /* Set pos to character AFTER end to allow easy iteration. */
+            al_ustr_next(ustr, &end);
+            *pos = end;
+            return result;
+         }
+         else {
+            /* Not first word, return old end position without the new word */
+            result = al_ref_ustr(info, ustr, *pos, old_end);
+            /* Set pos to character AFTER end to allow easy iteration. */
+            al_ustr_next(ustr, &old_end);
+            *pos = old_end;
+            return result;
+         }
+      }
+      first_word = false;
+      old_end    = end;
+      /* Skip the character at end which normally is whitespace. */
+      al_ustr_next(ustr, &end);
+   } while (end < size);
+
+   /* If we get here the whole ustr will fit.*/
+   result = al_ref_ustr(info, ustr, *pos, size);
+   *pos = size;
+   return result;
+}
+
+
+
+/* Function: al_draw_multiline_ustr
+ */
+void al_draw_multiline_ustr(const ALLEGRO_FONT *font,
+     ALLEGRO_COLOR color, float x, float y, float max_width, float line_height,
+     int flags, const ALLEGRO_USTR *ustr)
+{
+   const char * linebreak  = "\n\r";
+   const ALLEGRO_USTR *hard_line, *soft_line;
+   ALLEGRO_USTR_INFO hard_line_info, soft_line_info;
+   int hard_line_pos = 0, soft_line_pos = 0;
+
+   if (line_height == 0)
+      line_height = al_get_font_line_height(font);
+
+   /* For every "hard" line separated by a newline character... */
+   hard_line = ustr_split_next(ustr, &hard_line_info, &hard_line_pos,
+      linebreak);
+   while (hard_line) {
+      /* For every "soft" line in the "hard" line... */
+      soft_line_pos = 0;
+      soft_line =
+      get_next_soft_line(hard_line, &soft_line_info, &soft_line_pos, font,
+         max_width);
+      /* No soft line here because it's an empty hard line. */
+      if (!soft_line)
+         y += line_height;         
+      while(soft_line) {
+         /* Draw the soft line. */
+         al_draw_ustr(font, color, x, y, flags, soft_line);
+         y += line_height;
+         soft_line = get_next_soft_line(hard_line, &soft_line_info,
+            &soft_line_pos, font, max_width);
+      }     
+      hard_line = ustr_split_next(ustr, &hard_line_info, &hard_line_pos,
+         linebreak);
+   }
+   
+}
+
+
+
+/* Function: al_get_multiline_ustr_dimensions
+ */
+void al_get_multiline_ustr_dimensions(const ALLEGRO_FONT *font,
+   const ALLEGRO_USTR *ustr, float max_width, float line_height,
+   int *bbx, int *bby, int *bbw, int *bbh)
+{
+   const char *linebreak  = "\n\r";
+   const ALLEGRO_USTR *hard_line, *soft_line;
+   ALLEGRO_USTR_INFO hard_line_info, soft_line_info;
+   int hard_line_pos = 0, soft_line_pos = 0;
+   int max_w = 0;
+   int min_x = 0;
+   float total_h;
+   int lw, lh, lx, ly;
+   ASSERT(font);
+   ASSERT(ustr);
+   ASSERT(bbx);
+   ASSERT(bby);
+   ASSERT(bbw);
+   ASSERT(bbh);
+   
+   /* Height is always at least real line height no matter line_height. */
+   total_h = al_get_font_line_height(font);
+
+   if (line_height == 0)
+      line_height = total_h;
+   
+   /* For every "hard" line separated by a newline character... */
+   hard_line = ustr_split_next(ustr, &hard_line_info, &hard_line_pos,
+      linebreak);
+   while (hard_line) {
+      /* For every "soft" line in the "hard" line... */
+      soft_line_pos = 0;
+      soft_line =
+      get_next_soft_line(hard_line, &soft_line_info, &soft_line_pos, font,
+         max_width);
+      /* No soft line here because it's an empty hard line. */
+      if (!soft_line)
+         total_h += line_height ;         
+      while(soft_line) {
+         /* Calculate the size of the soft line. */
+         al_get_ustr_dimensions(font, soft_line, &lx, &ly, &lw, &lh);
+         if (lw > max_w)
+            max_w = lw;
+         if (lx < min_x)
+            min_x = lx;
+         total_h += line_height;
+         soft_line = get_next_soft_line(hard_line, &soft_line_info,
+            &soft_line_pos, font, max_width);
+      }     
+      hard_line = ustr_split_next(ustr, &hard_line_info, &hard_line_pos,
+         linebreak);
+   }
+   (*bbw) = max_w;
+   (*bbh) = total_h - line_height;
+   (*bbx) = min_x;
+   (*bby) = 0;
+}
+
+
+
+/* Function: al_draw_multiline_text
+ */
+void al_draw_multiline_text(const ALLEGRO_FONT *font,
+     ALLEGRO_COLOR color, float x, float y, float max_width, float line_height,
+     int flags, const char *text)
+{
+   ALLEGRO_USTR_INFO info;
+   ASSERT(font);
+   ASSERT(text);
+   
+   al_draw_multiline_ustr(font, color, x, y, max_width, flags, line_height,
+      al_ref_cstr(&info, text));
+}
+
+
+
+/* Function: al_draw_multiline_textf
+ */
+void al_draw_multiline_textf(const ALLEGRO_FONT *font,
+     ALLEGRO_COLOR color, float x, float y, float max_width, float line_height,
+     int flags, const char *format, ...)
+{
+   ALLEGRO_USTR *buf;
+   va_list ap;
+   ASSERT(font);
+   ASSERT(format);
+
+   va_start(ap, format);
+   buf = al_ustr_new("");
+   al_ustr_vappendf(buf, format, ap);
+   va_end(ap);
+
+   al_draw_multiline_ustr(font, color, x, y, max_width, line_height, flags,
+      buf);
+
+   al_ustr_free(buf);
+}
+
+
+
+/* Function: al_get_multiline_text_dimensions
+ */
+void al_get_multiline_text_dimensions(const ALLEGRO_FONT *font,
+   const char *text, float max_width, float line_height,
+   int *bbx, int *bby, int *bbw, int *bbh)
+{
+   ALLEGRO_USTR_INFO info;
+   ASSERT(font);
+   ASSERT(text);
+   
+   al_get_multiline_ustr_dimensions(font, al_ref_cstr(&info, text), max_width,
+      line_height, bbx, bby, bbw, bbh); 
+}
+
 
 /* vim: set sts=3 sw=3 et: */

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -137,14 +137,18 @@ It can also be combined with this flag:
 - ALLEGRO_ALIGN_INTEGER - Always draw text aligned to an integer pixel
   position.  This is formerly the default behaviour.  Since: 5.0.8, 5.1.4
 
-See also: [al_draw_ustr], [al_draw_textf], [al_draw_justified_text]
+This function does not support newline characters (`\n`),
+but you can use [al_draw_multiline_text] for multi line text output.
+
+See also: [al_draw_ustr], [al_draw_textf], [al_draw_justified_text],
+[al_draw_multiline_text].
 
 ### API: al_draw_ustr
 
 Like [al_draw_text], except the text is passed as an ALLEGRO_USTR instead of
 a NUL-terminated char array.
 
-See also: [al_draw_text], [al_draw_justified_ustr]
+See also: [al_draw_text], [al_draw_justified_ustr], [al_draw_multiline_ustr]
 
 ### API: al_draw_justified_text
 
@@ -231,6 +235,99 @@ than *ranges_count*).
 Since: 5.1.4
 
 See also: [al_grab_font_from_bitmap]
+
+## Multiline text drawing
+
+### API: al_draw_multiline_text
+
+Like [al_draw_text], but this function supports drawing multiple lines of text.
+If will break `text` in lines based on it's contents and the `max_width`
+parameter. The lines are then layed out vertically depending on the
+`line_height` parameter and drawn each as if [al_draw_text] was called
+on them.
+
+Either newline `\n` or carriage return `\r` in the `text` will cause a "hard"
+line break after their occurrence in the string. The text after a hard break
+is placed on a new line.
+
+The `max_with` parameter controls the maximum desired width of the lines.
+This function will try to introduce a "soft" line break after the longest
+possible series of words that will fit in `max_length` when drawn
+with the given `font`. A "soft" line break can occur on either a space ` `
+or tab `\t` character.
+
+However, it is possible that `max_width` is too small, or the words in `text`
+are too long to fit `max_width` when drawn with `font`. In that case, the word
+that is too wide will simply be drawn compeltely on a line by itself. If you
+don't want the text that overflows `max_width` to be visible, then use
+[al_set_clipping_rectangle] to clip it off and hide it.
+
+The funcion [al_draw_multiline_text] will draw each of the lines using
+the `font`, `x`, `color` and `flags` parametes as they were passed
+to this function. It supports the ALLEGRO_ALIGN_LEFT, ALLEGRO_ALIGN_CENTRE,
+ALLEGRO_ALIGN_RIGHT and ALLEGRO_ALIGN_INTEGER value for `flags`.
+
+The lines that [al_draw_multiline_text] breaks the text into will be drawn
+starting at `y` and with a vertical distance between them of `line_height`.
+If `line_height` is zero (`0`), then the value returned by
+[al_get_font_line_height] on `font` will be used as the default value in stead.
+
+To calculate the size of the bounding box of text this function will draw
+beforehand, without actually drawing it, use [al_get_multiline_text_dimensions].
+
+Since: 5.1.9
+
+See also: [al_get_multiline_text_dimensions], [al_draw_multiline_text],
+[al_draw_multiline_textf]
+
+### API: al_draw_multiline_ustr
+
+Like [al_draw_multiline_text], except the text is passed as an ALLEGRO_USTR
+instead of a NUL-terminated char array.
+
+Since: 5.1.9
+
+See also: [al_draw_multiline_text], [al_draw_multiline_textf],
+[al_get_multiline_ustr_dimensions]
+
+### API: al_draw_multinline_textf
+
+Formatted text output, using a printf() style format string.
+All parameters have the same meaning as with [al_draw_multiline_text] otherwise.
+
+Since: 5.1.9
+
+See also: [al_draw_multiline_text], [al_draw_multiline_ustr],
+[al_get_multiline_text_dimensions]
+
+### API: al_get_multiline_text_dimensions
+
+This function calculates the dimensions of the bounding box of `text` if it
+is drawn by [al_draw_multiline_text] with identical `font`, `text`, `max_width`
+and `line_height` parameters.
+
+Returned variables (all in pixel):
+
+- bbx, bby - Offset to upper left corner of bounding box of the text
+             [al_draw_multiline_text] will draw.
+- bbw, bbh - Dimensions of bounding box of the text [al_draw_multiline_text]
+             will draw.
+
+This function could be useful, for example, to calculate what clipping rectangle
+to use before drawing the multiline text, or to set up some form of scrolling.
+
+Since: 5.1.9
+
+See also: [al_draw_multiline_text]
+
+### API: al_get_multiline_ustr_dimensions
+
+Like [al_get_multiline_text_dimensions], except the text is passed as
+an ALLEGRO_USTR instead of a NUL-terminated char array.
+
+Since: 5.1.9
+
+See also: [al_draw_multiline_ustr]
 
 ## Bitmap fonts
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -192,6 +192,7 @@ endif()
 
 example(ex_font ${FONT} ${IMAGE} ${DATA_IMAGES})
 example(ex_font_justify ex_font_justify.cpp ${NIHGUI} ${IMAGE} ${TTF} ${DATA_IMAGES} ${DATA_TTF})
+example(ex_font_multiline ex_font_multiline.cpp ${NIHGUI} ${IMAGE} ${TTF} ${DATA_IMAGES} ${DATA_TTF})
 example(ex_logo ${FONT} ${TTF} ${IMAGE} ${PRIM} DATA ${DATA_TTF})
 example(ex_projection ${TTF} ${IMAGE} ${DATA_IMAGES} ${DATA_TTF})
 example(ex_ttf ${TTF} ${PRIM} DATA ${DATA_TTF} ex_ttf.ini)

--- a/examples/ex_font_multiline.cpp
+++ b/examples/ex_font_multiline.cpp
@@ -1,0 +1,213 @@
+/*
+ *    Example program for the Allegro library, by Peter Wang.
+ *
+ *    Test multi line text routines.
+ */
+
+#include <string>
+#include "allegro5/allegro.h"
+#include "allegro5/allegro_font.h"
+#include "allegro5/allegro_image.h"
+#include "allegro5/allegro_ttf.h"
+#include <allegro5/allegro_primitives.h>
+#include "nihgui.hpp"
+
+#include "common.c"
+
+#define TEST_TEXT "This is utf-8 €€€€€ multi line text output with a\nhard break,\n\ntwice even!"
+
+ALLEGRO_FONT *font;
+ALLEGRO_FONT *font_ttf;
+ALLEGRO_FONT *font_bmp;
+ALLEGRO_FONT *font_gui;
+ALLEGRO_FONT *font_bin;
+
+class Prog {
+private:
+   Dialog d;
+   Label text_label;
+   Label width_label;
+   Label height_label;
+   Label align_label;
+   Label font_label;
+   
+   TextEntry text_entry;
+   HSlider width_slider;
+   VSlider height_slider;
+   List text_align;
+   List text_font;
+
+public:
+   Prog(const Theme & theme, ALLEGRO_DISPLAY *display);
+   void run();
+   void draw_text();
+};
+
+Prog::Prog(const Theme & theme, ALLEGRO_DISPLAY *display) :
+   d(Dialog(theme, display, 10, 20)),
+   text_label(Label("Text")),
+   width_label(Label("Width")),
+   height_label(Label("Height")),
+   align_label(Label("Align")),
+   font_label(Label("Font")),
+   text_entry(TextEntry(TEST_TEXT)),
+   width_slider(HSlider(200, al_get_display_width(display))),
+   height_slider(VSlider(0, 50)),
+   text_align(List(0)),
+   text_font(List(0))
+{
+   text_align.append_item("Left");
+   text_align.append_item("Center");
+   text_align.append_item("Right");
+
+   text_font.append_item("Truetype");
+   text_font.append_item("Bitmap");
+   text_font.append_item("Builtin");
+
+   d.add(text_label, 0, 14, 1, 1);
+   d.add(text_entry, 1, 14, 8, 1);
+
+   d.add(width_label,  0, 15, 1, 1);
+   d.add(width_slider, 1, 15, 8, 1);
+   
+
+   d.add(align_label,  0, 17, 1, 1);
+   d.add(text_align ,  1, 17, 1, 3);
+
+   d.add(font_label,  2, 17, 1, 1);
+   d.add(text_font ,  3, 17, 1, 3);
+
+   d.add(height_label,  4, 17, 1, 1);
+   d.add(height_slider, 5, 17, 1, 3);
+
+    
+}
+
+void Prog::run()
+{
+   d.prepare();
+
+   while (!d.is_quit_requested()) {
+      if (d.is_draw_requested()) {
+         al_clear_to_color(al_map_rgb(128, 128, 128));
+         draw_text();
+         d.draw();
+         al_flip_display();
+      }
+
+      d.run_step(true);
+   }
+}
+
+void Prog::draw_text()
+{
+   int x  = 10, y  = 10;
+   int rx = 10, ry = 10;
+   int sx = 10, sy = 10;
+   int w = width_slider.get_cur_value();
+   int h = height_slider.get_cur_value();   
+   int flags = 0;
+   int tx, ty, tw, th;
+   ALLEGRO_USTR_INFO info;
+   const ALLEGRO_USTR *ustr = al_ref_cstr(&info, text_entry.get_text());
+
+  if (text_font.get_selected_item_text() == "Truetype") {
+      font = font_ttf;
+   } else if (text_font.get_selected_item_text() == "Bitmap") {
+      font = font_bmp;
+   } else if (text_font.get_selected_item_text() == "Builtin") {
+      font = font_bin;
+   }
+
+   al_get_multiline_ustr_dimensions(font, ustr, w, h, &tx, &ty, &tw, &th);
+   
+   if (text_align.get_selected_item_text() == "Left") {
+      flags = ALLEGRO_ALIGN_LEFT | ALLEGRO_ALIGN_INTEGER;
+      rx = x + tx;
+   } else if (text_align.get_selected_item_text() == "Center") {
+      flags = ALLEGRO_ALIGN_CENTER | ALLEGRO_ALIGN_INTEGER;
+      x = 10 + w / 2;
+      rx = 10 + tx + (w - tw) / 2;
+   } else if (text_align.get_selected_item_text() == "Right") {
+      flags = ALLEGRO_ALIGN_RIGHT | ALLEGRO_ALIGN_INTEGER;
+      x  = 10 + w;
+      rx = 10 + tx + (w - tw); 
+   }
+   ry = y + ty; 
+
+ 
+
+   /* Draw a red rectangle on the top with the requested width,
+    * a blue rectangle around the real bounds of the text, 
+    * a green line for the X axis location of drawing the text
+    * and the line height, and finally the text itself.
+    */
+    
+   al_draw_rectangle(sx, sy-2, sx + w, sy - 1, al_map_rgb(255, 0, 0), 0);
+   al_draw_rectangle(rx, ry, rx + tw, ry + th, al_map_rgb(0, 0, 255), 0);
+   al_draw_line(x, y, x, y + h, al_map_rgb(0, 255, 0), 0);
+   al_draw_multiline_ustr(font, al_map_rgb_f(1, 1, 1), x, y, w, h, flags, ustr);
+   
+}
+
+int main(int argc, char *argv[])
+{
+   ALLEGRO_DISPLAY *display;
+
+   (void)argc;
+   (void)argv;
+
+   if (!al_init()) {
+      abort_example("Could not init Allegro\n");
+   }
+   al_init_primitives_addon();
+   al_install_keyboard();
+   al_install_mouse();
+
+   al_init_image_addon();
+   al_init_font_addon();
+   al_init_ttf_addon();
+   init_platform_specific();
+
+   al_set_new_display_flags(ALLEGRO_GENERATE_EXPOSE_EVENTS);
+   display = al_create_display(640, 480);
+   if (!display) {
+      abort_example("Unable to create display\n");
+   }
+
+   /* Test TTF fonts and bitmap fonts. */
+   font_ttf = al_load_font("data/DejaVuSans.ttf", 24, 0);
+   if (!font_ttf) {
+      abort_example("Failed to load data/DejaVuSans.ttf\n");
+   }
+
+   font_bmp = al_load_font("data/font.tga", 0, 0);
+   if (!font_bmp) {
+      abort_example("Failed to load data/font.tga\n");
+   }
+
+   font_bin = al_create_builtin_font();
+
+   font = font_ttf;
+
+   font_gui = al_load_font("data/DejaVuSans.ttf", 14, 0);
+   if (!font_gui) {
+      abort_example("Failed to load data/DejaVuSans.ttf\n");
+   }
+
+   /* Don't remove these braces. */
+   {
+      Theme theme(font_gui);
+      Prog prog(theme, display);
+      prog.run();
+   }
+
+   al_destroy_font(font_bmp);
+   al_destroy_font(font_ttf);
+   al_destroy_font(font_bin);
+   al_destroy_font(font_gui);
+
+   return 0;
+}
+
+/* vim: set sts=3 sw=3 et: */


### PR DESCRIPTION
This pull request is a suggestion for the often requested multi line text feature.

Text will be broken into lines either on a newline character to force
a line break, or on a space or tab if the text is wider than the
max_width parameter. The line height can be set as a parameter or when set
to 0, the font's line height is used as a default. There are also
functions that calculate the dimensions of the bounds box of a multi line
text without actually drawing it. There is support for both ALLEGRO_USTR
and char \* strings. There is an example program ex_font_multiline.cpp
to test out these functions with.
