### PR TITLE
Multi line text output for the font addon. Take 3.

### DIFF
--- a/addons/font/allegro5/allegro_font.h
+++ b/addons/font/allegro5/allegro_font.h
@@ -112,6 +112,20 @@ ALLEGRO_FONT_FUNC(uint32_t, al_get_allegro_font_version, (void));
 ALLEGRO_FONT_FUNC(int, al_get_font_ranges, (ALLEGRO_FONT *font,
    int ranges_count, int *ranges));
 
+ALLEGRO_FONT_FUNC(void, al_draw_multiline_text, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *text));
+ALLEGRO_FONT_FUNC(void, al_draw_multiline_textf, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *format, ...));
+ALLEGRO_FONT_FUNC(void, al_draw_multiline_ustr, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const ALLEGRO_USTR *text));
+
+ALLEGRO_FONT_FUNC(void, al_do_multiline_text, (const ALLEGRO_FONT *font,
+   float max_width, const char *text,
+   bool (*cb)(int line_num, const char *line, int size, void *extra),
+   void *extra));
+
+ALLEGRO_FONT_FUNC(void, al_do_multiline_ustr, (const ALLEGRO_FONT *font,
+   float max_width, const ALLEGRO_USTR *ustr,
+   bool (*cb)(int line_num, const ALLEGRO_USTR *line, void *extra),
+   void *extra));
+
 
 #ifdef __cplusplus
    }

--- a/addons/font/text.c
+++ b/addons/font/text.c
@@ -21,6 +21,7 @@
 
 
 #include <math.h>
+#include <ctype.h>
 #include "allegro5/allegro.h"
 
 #include "allegro5/allegro_font.h"
@@ -370,5 +371,292 @@ int al_get_font_ranges(ALLEGRO_FONT *f, int ranges_count, int *ranges)
 {
    return f->vtable->get_font_ranges(f, ranges_count, ranges);
 }
+
+
+
+/* This helper function helps splitting an ustr in several delimited parts. 
+ * It returns an ustr that refers to the next part of the string that
+ * is delimited by the delimiters in delimiter.
+ * Returns NULL at the end of the string.
+ * Pos is updated to byte index of character after the delimiter or
+ * to the end of the string.
+ */
+static const ALLEGRO_USTR *ustr_split_next(const ALLEGRO_USTR *ustr,
+   ALLEGRO_USTR_INFO *info, int *pos, const char *delimiter)
+{
+   const ALLEGRO_USTR *result;
+   int end, size;
+   
+   size = al_ustr_size(ustr);
+   if (*pos >= size) {
+      return NULL;
+   }
+   
+   end = al_ustr_find_set_cstr(ustr, *pos, delimiter);
+   if (end == -1)
+      end = size;
+
+   result = al_ref_ustr(info, ustr, *pos, end);
+   /* Set pos to character AFTER delimiter */
+   al_ustr_next(ustr, &end);
+   (*pos) = end;
+   return result;
+}
+
+
+
+/* This returns the next "soft" line of text from ustr
+ * that will fit in max_with using the font font, starting at pos *pos.
+ * These are "soft" lines because they are broken up if needed at a space
+ * or tab character.
+ * This function updates pos if needed, and returns the next "soft" line,
+ * or NULL if no more soft lines.
+ * The soft line will not include the trailing space where the
+ * line was split, but pos will be set to point to after that trailing
+ * space so iteration can continue easily.
+ */
+static const ALLEGRO_USTR *get_next_soft_line(const ALLEGRO_USTR *ustr,
+   ALLEGRO_USTR_INFO *info, int *pos,
+   const ALLEGRO_FONT *font, float max_width)
+{
+   const ALLEGRO_USTR *result = NULL;
+   const char *whitespace = " \t";
+   int old_end = 0;
+   int end = 0;
+   int size = al_ustr_size(ustr);
+   bool first_word = true;  
+   
+   if (*pos >= size) {
+      return NULL;
+   }
+   
+   end = *pos;
+   old_end = end;
+   do {
+      /* On to the next word. */
+      end = al_ustr_find_set_cstr(ustr, end, whitespace);
+      if (end < 0)
+         end = size;
+         
+      /* Reference to the line that is being built. */
+      result = al_ref_ustr(info, ustr, *pos, end);
+
+      /* Check if the line is too long. If it is, return a soft line. */
+      if (al_get_ustr_width(font, result) > max_width) {
+         /* Corner case: a single word may not even fit the line.
+          * In that case, return the word/line anyway as the "soft line",
+          * the user can set a clip rectangle to cut it. */
+          
+         if (first_word) {
+            /* Set pos to character AFTER end to allow easy iteration. */
+            al_ustr_next(ustr, &end);
+            *pos = end;
+            return result;
+         }
+         else {
+            /* Not first word, return old end position without the new word */
+            result = al_ref_ustr(info, ustr, *pos, old_end);
+            /* Set pos to character AFTER end to allow easy iteration. */
+            al_ustr_next(ustr, &old_end);
+            *pos = old_end;
+            return result;
+         }
+      }
+      first_word = false;
+      old_end    = end;
+      /* Skip the character at end which normally is whitespace. */
+      al_ustr_next(ustr, &end);
+   } while (end < size);
+
+   /* If we get here the whole ustr will fit.*/
+   result = al_ref_ustr(info, ustr, *pos, size);
+   *pos = size;
+   return result;
+}
+
+
+/* Function: al_do_multiline_ustr
+ */
+void al_do_multiline_ustr(const ALLEGRO_FONT *font, float max_width,
+   const ALLEGRO_USTR *ustr,
+   bool (*cb)(int line_num, const ALLEGRO_USTR * line, void *extra),
+   void *extra)
+{
+   const char *linebreak  = "\n";
+   const ALLEGRO_USTR *hard_line, *soft_line;
+   ALLEGRO_USTR_INFO hard_line_info, soft_line_info;
+   int hard_line_pos = 0, soft_line_pos = 0;
+   int line_num = 0;
+   bool proceed;
+
+   /* For every "hard" line separated by a newline character... */
+   hard_line = ustr_split_next(ustr, &hard_line_info, &hard_line_pos,
+      linebreak);
+   while (hard_line) {
+      /* For every "soft" line in the "hard" line... */
+      soft_line_pos = 0;
+      soft_line =
+      get_next_soft_line(hard_line, &soft_line_info, &soft_line_pos, font,
+         max_width);
+      /* No soft line here because it's an empty hard line. */
+      if (!soft_line) { 
+         /* Call the callback with empty string to indicate an empty line. */
+         proceed = cb(line_num, al_ustr_empty_string(), extra);
+         if (!proceed) return;
+         line_num ++;
+      }
+      while(soft_line) {
+         /* Call the callback on the next soft line. */
+         proceed = cb(line_num, soft_line, extra);
+         if (!proceed) return;
+         line_num++;
+   
+         soft_line = get_next_soft_line(hard_line, &soft_line_info,
+            &soft_line_pos, font, max_width);
+      }     
+      hard_line = ustr_split_next(ustr, &hard_line_info, &hard_line_pos,
+         linebreak);
+   }
+}
+
+
+
+/* Helper struct for al_do_multiline_text. */
+typedef struct DO_MULTILINE_TEXT_EXTRA {
+   bool (*callback)(int line_num, const char *line, int size, void *extra);
+   void *extra;
+} DO_MULTILINE_TEXT_EXTRA;
+
+
+
+/* The functions do_multiline_text_cb is the helper callback
+ * that "adapts" al_do_multiline_ustr to al_do_multiline_text. 
+ */
+static bool do_multiline_text_cb(int line_num, const ALLEGRO_USTR *line,
+   void *extra) {
+   DO_MULTILINE_TEXT_EXTRA *s = extra;
+   
+   return s->callback(line_num, al_cstr(line), al_ustr_size(line), s->extra);
+}
+
+
+
+/*  Function: al_do_multiline_text
+ */
+void al_do_multiline_text(const ALLEGRO_FONT *font,
+   float max_width, const char *text,
+   bool (*cb)(int line_num, const char *line, int size, void *extra),
+   void *extra)
+{
+   ALLEGRO_USTR_INFO info;      
+   DO_MULTILINE_TEXT_EXTRA extra2;
+   ASSERT(font);
+   ASSERT(text);
+   
+   extra2.callback = cb;
+   extra2.extra = extra;
+   al_do_multiline_ustr(font, max_width, al_ref_cstr(&info, text),
+      do_multiline_text_cb, &extra2);
+}
+
+
+
+/* Helper struct for al_draw_multiline_ustr. */
+typedef struct DRAW_MULTILINE_USTR_EXTRA {
+   const ALLEGRO_FONT *font;
+   ALLEGRO_COLOR color;
+   float x;
+   float y;
+   float line_height;
+   int flags;
+} DRAW_MULTILINE_USTR_EXTRA;
+
+
+
+/* The function draw_multiline_ustr_cb is the helper callback
+ * that implements the actual drawing for al_draw_multiline_ustr. 
+ */
+static bool draw_multiline_ustr_cb(int line_num, const ALLEGRO_USTR *line,
+   void *extra) {
+   DRAW_MULTILINE_USTR_EXTRA *s = extra;
+   float y;
+   
+   y  = s->y + (s->line_height * line_num);
+   al_draw_ustr(s->font, s->color, s->x, y, s->flags, line);
+   return true;
+}
+
+
+
+/* Function: al_draw_multiline_ustr
+ */
+void al_draw_multiline_ustr(const ALLEGRO_FONT *font,
+     ALLEGRO_COLOR color, float x, float y, float max_width, float line_height,
+     int flags, const ALLEGRO_USTR *ustr)
+{
+   DRAW_MULTILINE_USTR_EXTRA extra;
+   ASSERT(font);
+   ASSERT(ustr);
+   
+   extra.font = font;
+   extra.color = color;
+   extra.x = x;
+   extra.y = y;
+   if (line_height < 1) { 
+      extra.line_height =  al_get_font_line_height(font);
+   }
+   else {
+      extra.line_height = line_height;
+   }
+   extra.flags = flags;
+
+   al_do_multiline_ustr(font, max_width, ustr, draw_multiline_ustr_cb, &extra);
+}
+
+
+
+/* Function: al_draw_multiline_text
+ */
+void al_draw_multiline_text(const ALLEGRO_FONT *font,
+     ALLEGRO_COLOR color, float x, float y, float max_width, float line_height,
+     int flags, const char *text)
+{
+   ALLEGRO_USTR_INFO info;
+   ASSERT(font);
+   ASSERT(text);
+   
+   al_draw_multiline_ustr(font, color, x, y, max_width, line_height, flags, 
+      al_ref_cstr(&info, text));
+}
+
+
+
+/* Function: al_draw_multiline_textf
+ */
+void al_draw_multiline_textf(const ALLEGRO_FONT *font,
+     ALLEGRO_COLOR color, float x, float y, float max_width, float line_height,
+     int flags, const char *format, ...)
+{
+   ALLEGRO_USTR *buf;
+   va_list ap;
+   ASSERT(font);
+   ASSERT(format);
+
+   va_start(ap, format);
+   buf = al_ustr_new("");
+   al_ustr_vappendf(buf, format, ap);
+   va_end(ap);
+
+   al_draw_multiline_ustr(font, color, x, y, max_width, line_height, flags,
+      buf);
+
+   al_ustr_free(buf);
+}
+
+
+
+
+
+
 
 /* vim: set sts=3 sw=3 et: */

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -137,14 +137,18 @@ It can also be combined with this flag:
 - ALLEGRO_ALIGN_INTEGER - Always draw text aligned to an integer pixel
   position.  This is formerly the default behaviour.  Since: 5.0.8, 5.1.4
 
-See also: [al_draw_ustr], [al_draw_textf], [al_draw_justified_text]
+This function does not support newline characters (`\n`),
+but you can use [al_draw_multiline_text] for multi line text output.
+
+See also: [al_draw_ustr], [al_draw_textf], [al_draw_justified_text],
+[al_draw_multiline_text].
 
 ### API: al_draw_ustr
 
 Like [al_draw_text], except the text is passed as an ALLEGRO_USTR instead of
 a NUL-terminated char array.
 
-See also: [al_draw_text], [al_draw_justified_ustr]
+See also: [al_draw_text], [al_draw_justified_ustr], [al_draw_multiline_ustr]
 
 ### API: al_draw_justified_text
 
@@ -231,6 +235,168 @@ than *ranges_count*).
 Since: 5.1.4
 
 See also: [al_grab_font_from_bitmap]
+
+## Multiline text drawing
+
+### API: al_draw_multiline_text
+
+Like [al_draw_text], but this function supports drawing multiple lines of text.
+It will break `text` in lines based on it's contents and the `max_width`
+parameter. The lines are then layed out vertically depending on the
+`line_height` parameter and drawn each as if [al_draw_text] was called
+on them.
+
+A newline `\n` in the `text` will cause a "hard" line break after its
+occurrence in the string. The text after a hard break is placed on a new line.
+Carriage return `\r` is not supported, will not cause a line break, and will
+likely be drawn as a square or a space depending on the font.
+
+The `max_with` parameter controls the maximum desired width of the lines.
+This function will try to introduce a "soft" line break after the longest
+possible series of words that will fit in `max_length` when drawn
+with the given `font`. A "soft" line break can occur on either a space ` `
+or tab `\t` character.
+
+However, it is possible that `max_width` is too small, or the words in `text`
+are too long to fit `max_width` when drawn with `font`. In that case, the word
+that is too wide will simply be drawn compeltely on a line by itself. If you
+don't want the text that overflows `max_width` to be visible, then use
+[al_set_clipping_rectangle] to clip it off and hide it.
+
+The funcion [al_draw_multiline_text] will draw each of the lines using
+the `font`, `x`, `color` and `flags` parametes as they were passed
+to this function. It supports the ALLEGRO_ALIGN_LEFT, ALLEGRO_ALIGN_CENTRE,
+ALLEGRO_ALIGN_RIGHT and ALLEGRO_ALIGN_INTEGER value for `flags`.
+
+The lines that [al_draw_multiline_text] breaks the text into will be drawn
+starting at `y` and with a vertical distance between them of `line_height`.
+If `line_height` is zero (`0`), then the value returned by
+[al_get_font_line_height] on `font` will be used as the default value in stead.
+
+For complex or custom text layout that [al_draw_multiline_text] does not
+provide, or for calculating the size of what this function will draw
+without actually drawing it, you can use use [al_do_multiline_text].
+
+Since: 5.1.9
+
+See also: [al_do_multiline_text], [al_draw_multiline_text],
+[al_draw_multiline_textf]
+
+### API: al_draw_multiline_ustr
+
+Like [al_draw_multiline_text], except the text is passed as an ALLEGRO_USTR
+instead of a NUL-terminated char array.
+
+Since: 5.1.9
+
+See also: [al_draw_multiline_text], [al_draw_multiline_textf],
+[al_do_multiline_text]
+
+### API: al_draw_multinline_textf
+
+Formatted text output, using a printf() style format string.
+All parameters have the same meaning as with [al_draw_multiline_text] otherwise.
+
+Since: 5.1.9
+
+See also: [al_draw_multiline_text], [al_draw_multiline_ustr],
+[al_do_multiline_text]
+
+### API: al_do_multiline_text
+
+This function processes the `text` and splits it into lines as
+[al_draw_multiline_text] would, and then calls the callback `cb` once
+for every line. This is useful for custom drawing of multiline text,
+or for calculating the size of multiline text ahead of time.
+
+It will break `text` in lines based on it's contents and the `max_width`
+parameter. A newline `\n` in the `text` will cause a "hard" line break after
+its occurrence in the string. The text after a hard break is placed on a new
+line. Carriage return `\r` is not supported and will not cause a line break.
+
+The `max_with` parameter controls the maximum desired width of the lines.
+This function will try to introduce a "soft" line break after the longest
+possible series of words that would fit in `max_length` when drawn
+with the given `font`. A "soft" line break can occur on either a space ` `
+or tab `\t` character.
+
+However, it is possible that `max_width` is too small, or the words in `text`
+are too long to fit `max_width` when drawn with `font`. In that case, the word
+that is too wide will simply be placed compeltely on a line by itself.
+
+For every line that this function splits `text` into , the callback `cb`
+will be called once.  This callback `cb` must be of type
+`bool callback(int line_num, const char *line, int size, void *extra)`.
+
+The callback `cb` will be called with the number of the line starting from zero
+and counting up in `line_num`, a pointer to the beginning character of the line
+in `line`, the size of the line in `size`, and the pointer passed in the
+`extra` parameter to [al_do_multiline_text].
+
+Note that while the `line` pointer points to the beginning of the line,
+however, `line` is NOT guaranteed to be a NUL terminated string.
+In stead, `line` is simply a pointer, normally to a character in `text`,
+or to an empty string in case of an empty line. If you need a NUL terminated
+string, you will have to copy `line` to a buffer and NUL terminate it yourself.
+
+The pointer `line` is not guaranteed to be valid after the callback `cb`
+has returned. So in case you still need the contents of `line` after that,
+you must also make a copy of it yourself. In case of an empty line
+the parameter `size` to the callback will be zero and `line` will point
+to an empty string.
+
+When `cb` returns true, [al_do_multiline_text] will continue on
+to the next line. And when `cb` returns false, this function will
+stop immediately and not call `cb` anymore.
+
+Since: 5.1.9
+
+See also: [al_draw_multiline_text]
+
+### API: al_do_multiline_ustr
+
+This function processes the `ustr` and splits it into lines as
+[al_draw_multiline_ustr] would, and then calls the callback `cb` once
+for every line. This is useful for custom drawing of multiline text,
+or for calculating the size of multiline text ahead of time.
+
+It will break `ustr` in lines based on it's contents and the `max_width`
+parameter. Either newline `\n` or carriage return `\r` in the `ustr` will
+cause a "hard" line break after their occurrence in the string. The text
+after a hard break is placed on a new line.
+
+The `max_with` parameter controls the maximum desired width of the lines.
+This function will try to introduce a "soft" line break after the longest
+possible series of words that would fit in `max_length` when drawn
+with the given `font`. A "soft" line break can occur on either a space ` `
+or tab `\t` character.
+
+However, it is possible that `max_width` is too small, or the words in `text`
+are too long to fit `max_width` when drawn with `font`. In that case, the word
+that is too wide will simply be placed compeltely on a line by itself.
+
+For every line that this function splits `ustr` into , the callback `cb`
+will be called once.  This callback `cb` must be of type
+`bool callback(int line_num, const ALLEGRO_USTR *line, void *extra)`.
+
+The callback `cb` will be called with the number of the line starting from zero
+and counting up in `line_num`, a pointer to an ALLEGRO_USTR that represents the
+Unicode text of the line in `line` and the pointer passed in the
+`extra` parameter to [al_do_multiline_text].
+
+The pointer `line` is not guaranteed to be valid after the callback `cb`
+has returned. So in case you still need the contents of `line` after that,
+you must make a copy of it yourself. In case of an empty line
+the parameter `size` to the callback will be zero and `line` will
+be set to the result of calling [al_ustr_empty_string].
+
+When `cb` returns true, [al_do_multiline_text] will continue on
+to the next line. And when `cb` returns false, this function will
+stop immediately and not call `cb` anymore.
+
+Since: 5.1.9
+
+See also: [al_draw_multiline_ustr]
 
 ## Bitmap fonts
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -192,6 +192,7 @@ endif()
 
 example(ex_font ${FONT} ${IMAGE} ${DATA_IMAGES})
 example(ex_font_justify ex_font_justify.cpp ${NIHGUI} ${IMAGE} ${TTF} ${DATA_IMAGES} ${DATA_TTF})
+example(ex_font_multiline ex_font_multiline.cpp ${NIHGUI} ${IMAGE} ${TTF} ${DATA_IMAGES} ${DATA_TTF})
 example(ex_logo ${FONT} ${TTF} ${IMAGE} ${PRIM} DATA ${DATA_TTF})
 example(ex_projection ${TTF} ${IMAGE} ${DATA_IMAGES} ${DATA_TTF})
 example(ex_ttf ${TTF} ${PRIM} DATA ${DATA_TTF} ex_ttf.ini)

--- a/examples/ex_font_multiline.cpp
+++ b/examples/ex_font_multiline.cpp
@@ -1,0 +1,255 @@
+/*
+ *    Example program for the Allegro library, by Peter Wang.
+ *
+ *    Test multi line text routines.
+ */
+
+#include <string>
+#include <cmath>
+#include "allegro5/allegro.h"
+#include "allegro5/allegro_font.h"
+#include "allegro5/allegro_image.h"
+#include "allegro5/allegro_ttf.h"
+#include <allegro5/allegro_primitives.h>
+#include "nihgui.hpp"
+
+#include "common.c"
+
+#define TEST_TEXT "This is utf-8 €€€€€ multi line text output with a\nhard break,\n\ntwice even!"
+
+/* This is a custom mult line output function that demonstrates
+ * al_do_multiline_text. See below for the implementation. */
+static void draw_custom_multiline(ALLEGRO_FONT * font, int x, int y,
+   int max_width, int line_height, const char * text);
+
+ALLEGRO_FONT *font;
+ALLEGRO_FONT *font_ttf;
+ALLEGRO_FONT *font_bmp;
+ALLEGRO_FONT *font_gui;
+ALLEGRO_FONT *font_bin;
+
+class Prog {
+private:
+   Dialog d;
+   Label text_label;
+   Label width_label;
+   Label height_label;
+   Label align_label;
+   Label font_label;
+   
+   TextEntry text_entry;
+   HSlider width_slider;
+   VSlider height_slider;
+   List text_align;
+   List text_font;
+
+public:
+   Prog(const Theme & theme, ALLEGRO_DISPLAY *display);
+   void run();
+   void draw_text();
+};
+
+Prog::Prog(const Theme & theme, ALLEGRO_DISPLAY *display) :
+   d(Dialog(theme, display, 10, 20)),
+   text_label(Label("Text")),
+   width_label(Label("Width")),
+   height_label(Label("Height")),
+   align_label(Label("Align")),
+   font_label(Label("Font")),
+   text_entry(TextEntry(TEST_TEXT)),
+   width_slider(HSlider(200, al_get_display_width(display))),
+   height_slider(VSlider(0, 50)),
+   text_align(List(0)),
+   text_font(List(0))
+{
+   text_align.append_item("Left");
+   text_align.append_item("Center");
+   text_align.append_item("Right");
+
+   text_font.append_item("Truetype");
+   text_font.append_item("Bitmap");
+   text_font.append_item("Builtin");
+
+   d.add(text_label, 0, 14, 1, 1);
+   d.add(text_entry, 1, 14, 8, 1);
+
+   d.add(width_label,  0, 15, 1, 1);
+   d.add(width_slider, 1, 15, 8, 1);
+   
+
+   d.add(align_label,  0, 17, 1, 1);
+   d.add(text_align ,  1, 17, 1, 3);
+
+   d.add(font_label,  2, 17, 1, 1);
+   d.add(text_font ,  3, 17, 1, 3);
+
+   d.add(height_label,  4, 17, 1, 1);
+   d.add(height_slider, 5, 17, 1, 3);
+
+    
+}
+
+void Prog::run()
+{
+   d.prepare();
+
+   while (!d.is_quit_requested()) {
+      if (d.is_draw_requested()) {
+         al_clear_to_color(al_map_rgb(128, 128, 128));
+         draw_text();
+         d.draw();
+         al_flip_display();
+      }
+
+      d.run_step(true);
+   }
+}
+
+void Prog::draw_text()
+{
+   int x  = 10, y  = 10;
+   int sx = 10, sy = 10;
+   int w = width_slider.get_cur_value();
+   int h = height_slider.get_cur_value();   
+   int flags = 0;
+   const char * text = text_entry.get_text();
+
+  if (text_font.get_selected_item_text() == "Truetype") {
+      font = font_ttf;
+   } else if (text_font.get_selected_item_text() == "Bitmap") {
+      font = font_bmp;
+   } else if (text_font.get_selected_item_text() == "Builtin") {
+      font = font_bin;
+   }
+   
+   if (text_align.get_selected_item_text() == "Left") {
+      flags = ALLEGRO_ALIGN_LEFT | ALLEGRO_ALIGN_INTEGER;
+   } else if (text_align.get_selected_item_text() == "Center") {
+      flags = ALLEGRO_ALIGN_CENTER | ALLEGRO_ALIGN_INTEGER;
+      x = 10 + w / 2;
+   } else if (text_align.get_selected_item_text() == "Right") {
+      flags = ALLEGRO_ALIGN_RIGHT | ALLEGRO_ALIGN_INTEGER;
+      x  = 10 + w;
+   }
+  
+
+   /* Draw a red rectangle on the top with the requested width,
+    * a blue rectangle around the real bounds of the text, 
+    * a green line for the X axis location of drawing the text
+    * and the line height, and finally the text itself.
+    */
+    
+   al_draw_rectangle(sx, sy-2, sx + w, sy - 1, al_map_rgb(255, 0, 0), 0);
+   al_draw_line(x, y, x, y + h, al_map_rgb(0, 255, 0), 0);
+   al_draw_multiline_text(font, al_map_rgb_f(1, 1, 1), x, y, w, h, flags, text);
+
+   /* also do some custom bultiline drawing */
+   al_draw_text(font, al_map_rgb_f(0, 1, 1), x + w + 10, y, 0, "Custom multiline text:" );
+   draw_custom_multiline(font, x + w + 10 , y + 30, w, h, text);
+  
+   
+}
+
+int main(int argc, char *argv[])
+{
+   ALLEGRO_DISPLAY *display;
+
+   (void)argc;
+   (void)argv;
+
+   if (!al_init()) {
+      abort_example("Could not init Allegro\n");
+   }
+   al_init_primitives_addon();
+   al_install_keyboard();
+   al_install_mouse();
+
+   al_init_image_addon();
+   al_init_font_addon();
+   al_init_ttf_addon();
+   init_platform_specific();
+
+   al_set_new_display_flags(ALLEGRO_GENERATE_EXPOSE_EVENTS);
+   display = al_create_display(640, 480);
+   if (!display) {
+      abort_example("Unable to create display\n");
+   }
+
+   /* Test TTF fonts and bitmap fonts. */
+   font_ttf = al_load_font("data/DejaVuSans.ttf", 24, 0);
+   if (!font_ttf) {
+      abort_example("Failed to load data/DejaVuSans.ttf\n");
+   }
+
+   font_bmp = al_load_font("data/font.tga", 0, 0);
+   if (!font_bmp) {
+      abort_example("Failed to load data/font.tga\n");
+   }
+
+   font_bin = al_create_builtin_font();
+
+   font = font_ttf;
+
+   font_gui = al_load_font("data/DejaVuSans.ttf", 14, 0);
+   if (!font_gui) {
+      abort_example("Failed to load data/DejaVuSans.ttf\n");
+   }
+
+   /* Don't remove these braces. */
+   {
+      Theme theme(font_gui);
+      Prog prog(theme, display);
+      prog.run();
+   }
+
+   al_destroy_font(font_bmp);
+   al_destroy_font(font_ttf);
+   al_destroy_font(font_bin);
+   al_destroy_font(font_gui);
+
+   return 0;
+}
+
+
+/* Helper struct for draw_custom_multiline. */
+typedef struct DRAW_CUSTOM_LINE_EXTRA {
+   const ALLEGRO_FONT *font;
+   float x;
+   float y;
+   float line_height;
+   int flags;
+} DRAW_CUSTOM_LINE_EXTRA;
+
+
+/* This function is the helper callback that implements the actual drawing
+ * for draw_custom_multiline. 
+ */
+static bool draw_custom_multiline_cb(int line_num, const char *line, int size,
+   void *extra) {
+   DRAW_CUSTOM_LINE_EXTRA *s = (DRAW_CUSTOM_LINE_EXTRA *) extra;
+   float x, y;
+   ALLEGRO_USTR_INFO info;
+   ALLEGRO_COLOR c = al_map_rgb(255 - ((line_num * 64) % 255), 0, 0);
+   x  = s->x + sin(line_num) * 10; 
+   y  = s->y + (s->line_height * line_num);
+   al_draw_ustr(s->font, c, x, y, 0, al_ref_buffer(&info, line, size));
+   return (line_num < 5);
+}
+
+/* This is a custom mult line output function that demonstrates
+ * al_do_multiline_text. */
+static void draw_custom_multiline(ALLEGRO_FONT * font, int x, int y,
+   int max_width, int line_height, const char * text) {
+   DRAW_CUSTOM_LINE_EXTRA extra;
+
+   extra.font = font;
+   extra.x = x;
+   extra.y = y;
+   extra.line_height = line_height + al_get_font_line_height(font);
+   
+   al_do_multiline_text(font, max_width, text,
+      draw_custom_multiline_cb, (void *)&extra);
+}
+
+
+/* vim: set sts=3 sw=3 et: */


### PR DESCRIPTION
Add al_draw_multiline_text, al_draw_multiline_textf, and
al_draw_multiline_ustr.  Text will be broken into lines either on
a newline character '\n' (but not carriage return '\r'), to force
a line break, or on a space or tab if the text is wider than
the max_width parameter. The line height can be set as a parameter
or when set to 0, the font's line height is used as a default.
There are also al_do_multiline_ustr and al_do_multiline_text
for advanced text layout needs.  There is an example program
ex_font_multiline.cpp to test out these functions with.
