### PR TITLE
Fix the high-precision mice on Windows never setting dz/dw to non-zero values.

### DIFF
--- a/docs/src/refman/mouse.txt
+++ b/docs/src/refman/mouse.txt
@@ -141,6 +141,50 @@ Retrieve the mouse event source.
 Returns NULL if the mouse subsystem was not installed.
 
 
+## API: al_set_mouse_wheel_precision
+
+Sets the precision of the mouse wheel (the z and w coordinates) for the
+specified display. This precision manifests itself as a multiplier on the `dz`
+and `dw` fields in mouse events. It also affects the `z` and `w` fields of
+events and [ALLEGRO_MOUSE_STATE], but not in a simple way if you alter the
+precision often, so it is suggested to reset those axes to 0 when you change
+precision. Setting this to a high value allows you to detect small changes in
+those two axes for some high precision mice. A flexible way of using this
+precision is to set it to a high value (120 is likely sufficient for most, if
+not all, mice) and use a floating point `dz` and `dw` like so:
+
+~~~~c
+al_set_mouse_wheel_precision(display, 120);
+
+ALLEGRO_EVENT event;
+al_wait_for_event(event_queue, &event);
+if (event.type == ALLEGRO_EVENT_MOUSE_AXES) {
+   /* This is a real mouse event. */
+   if (event.mouse.display) {
+      double dz =
+         (double)event.mouse.dz / al_get_mouse_wheel_precision(event.mouse.display);
+      /* Use dz in some way... */
+   }
+}
+~~~~
+
+Precision is set to 1 by default. It is impossible to set it to a lower
+precision than that.
+
+Since: 5.1.10
+
+See also: [al_get_mouse_wheel_precision]
+
+## API: al_get_mouse_wheel_precision
+
+Gets the precision of the mouse wheel (the z and w coordinates) inside the
+specified display.
+
+Since: 5.1.10
+
+See also: [al_set_mouse_wheel_precision]
+
+
 ## Mouse cursors
 
 ### API: al_create_mouse_cursor
@@ -256,4 +300,3 @@ Stop confining the mouse cursor to any display belonging to the program.
 > *Note:* not yet implemented on Mac OS X.
 
 See also: [al_grab_mouse]
-

--- a/examples/ex_mouse_events.c
+++ b/examples/ex_mouse_events.c
@@ -44,6 +44,7 @@ int main(int argc, char **argv)
    int mmy = 0;
    int mmz = 0;
    int mmw = 0;
+   int precision = 1;
    bool in = true;
    bool buttons[NUM_BUTTONS] = {false};
    int i;
@@ -105,6 +106,7 @@ int main(int argc, char **argv)
          al_draw_textf(font, black, 5, 25, 0, "x %i, y %i, z %i, w %i", mx, my, mz, mw);
          al_draw_textf(font, black, 5, 45, 0, "p = %g", p);
          al_draw_textf(font, black, 5, 65, 0, "%s", in ? "in" : "out");
+         al_draw_textf(font, black, 5, 85, 0, "wheel precision (PgUp/PgDn) %d", precision);
          al_set_blender(ALLEGRO_ADD, ALLEGRO_ONE, ALLEGRO_INVERSE_ALPHA);
          mmx = mmy = mmz = 0;
          al_flip_display();
@@ -149,6 +151,19 @@ int main(int argc, char **argv)
          case ALLEGRO_EVENT_KEY_DOWN:
             if (event.keyboard.keycode == ALLEGRO_KEY_ESCAPE) {
                goto done;
+            }
+            break;
+
+         case ALLEGRO_EVENT_KEY_CHAR:
+            if (event.keyboard.keycode == ALLEGRO_KEY_PGUP) {
+               precision++;
+               al_set_mouse_wheel_precision(display, precision);
+            }
+            else if (event.keyboard.keycode == ALLEGRO_KEY_PGDN) {
+               precision--;
+               if (precision < 1)
+                  precision = 1;
+               al_set_mouse_wheel_precision(display, precision);
             }
             break;
 

--- a/examples/ex_mouse_events.c
+++ b/examples/ex_mouse_events.c
@@ -157,13 +157,13 @@ int main(int argc, char **argv)
          case ALLEGRO_EVENT_KEY_CHAR:
             if (event.keyboard.keycode == ALLEGRO_KEY_PGUP) {
                precision++;
-               al_set_mouse_wheel_precision(display, precision);
+               al_set_mouse_wheel_precision(precision);
             }
             else if (event.keyboard.keycode == ALLEGRO_KEY_PGDN) {
                precision--;
                if (precision < 1)
                   precision = 1;
-               al_set_mouse_wheel_precision(display, precision);
+               al_set_mouse_wheel_precision(precision);
             }
             break;
 

--- a/include/allegro5/internal/aintern_display.h
+++ b/include/allegro5/internal/aintern_display.h
@@ -123,8 +123,6 @@ struct ALLEGRO_DISPLAY
    int min_w, min_h;
    int max_w, max_h;
 
-   int mouse_wheel_precision;
-   
    int backbuffer_format; /* ALLEGRO_PIXELFORMAT */
 
    ALLEGRO_EXTRA_DISPLAY_SETTINGS extra_settings;

--- a/include/allegro5/internal/aintern_display.h
+++ b/include/allegro5/internal/aintern_display.h
@@ -122,6 +122,8 @@ struct ALLEGRO_DISPLAY
    int w, h;
    int min_w, min_h;
    int max_w, max_h;
+
+   int mouse_wheel_precision;
    
    int backbuffer_format; /* ALLEGRO_PIXELFORMAT */
 

--- a/include/allegro5/internal/aintern_system.h
+++ b/include/allegro5/internal/aintern_system.h
@@ -55,6 +55,7 @@ struct ALLEGRO_SYSTEM
    _AL_VECTOR displays; /* Keep a list of all displays attached to us. */
    ALLEGRO_CONFIG *config;
    ALLEGRO_PATH *user_exe_path;
+   int mouse_wheel_precision;
    bool installed;
 };
 

--- a/include/allegro5/mouse.h
+++ b/include/allegro5/mouse.h
@@ -68,6 +68,8 @@ AL_FUNC(int,            al_get_mouse_state_axis, (const ALLEGRO_MOUSE_STATE *sta
 AL_FUNC(bool, al_get_mouse_cursor_position, (int *ret_x, int *ret_y));
 AL_FUNC(bool, al_grab_mouse, (struct ALLEGRO_DISPLAY *display));
 AL_FUNC(bool, al_ungrab_mouse, (void));
+AL_FUNC(void, al_set_mouse_wheel_precision, (struct ALLEGRO_DISPLAY *display, int precision));
+AL_FUNC(int, al_get_mouse_wheel_precision, (struct ALLEGRO_DISPLAY *display));
 
 AL_FUNC(ALLEGRO_EVENT_SOURCE *, al_get_mouse_event_source, (void));
 

--- a/include/allegro5/mouse.h
+++ b/include/allegro5/mouse.h
@@ -68,8 +68,8 @@ AL_FUNC(int,            al_get_mouse_state_axis, (const ALLEGRO_MOUSE_STATE *sta
 AL_FUNC(bool, al_get_mouse_cursor_position, (int *ret_x, int *ret_y));
 AL_FUNC(bool, al_grab_mouse, (struct ALLEGRO_DISPLAY *display));
 AL_FUNC(bool, al_ungrab_mouse, (void));
-AL_FUNC(void, al_set_mouse_wheel_precision, (struct ALLEGRO_DISPLAY *display, int precision));
-AL_FUNC(int, al_get_mouse_wheel_precision, (struct ALLEGRO_DISPLAY *display));
+AL_FUNC(void, al_set_mouse_wheel_precision, (int precision));
+AL_FUNC(int, al_get_mouse_wheel_precision, (void));
 
 AL_FUNC(ALLEGRO_EVENT_SOURCE *, al_get_mouse_event_source, (void));
 

--- a/include/allegro5/platform/aintwin.h
+++ b/include/allegro5/platform/aintwin.h
@@ -116,8 +116,8 @@ void _al_win_fix_modifiers(void);
 
 /* mouse routines */
 void _al_win_mouse_handle_move(int x, int y, bool abs, ALLEGRO_DISPLAY_WIN *win_disp);
-void _al_win_mouse_handle_wheel(int d, bool abs, ALLEGRO_DISPLAY_WIN *win_disp);
-void _al_win_mouse_handle_hwheel(int d, bool abs, ALLEGRO_DISPLAY_WIN *win_disp);
+void _al_win_mouse_handle_wheel(int raw_dz, bool abs, ALLEGRO_DISPLAY_WIN *win_disp);
+void _al_win_mouse_handle_hwheel(int raw_dw, bool abs, ALLEGRO_DISPLAY_WIN *win_disp);
 void _al_win_mouse_handle_button(int button, bool down, int x, int y, bool abs, ALLEGRO_DISPLAY_WIN *win_disp);
 void _al_win_mouse_handle_leave(ALLEGRO_DISPLAY_WIN *win_display);
 void _al_win_mouse_handle_enter(ALLEGRO_DISPLAY_WIN *win_display);

--- a/src/display.c
+++ b/src/display.c
@@ -65,8 +65,6 @@ ALLEGRO_DISPLAY *al_create_display(int w, int h)
       settings->settings[ALLEGRO_AUTO_CONVERT_BITMAPS] = 1;
    }
 
-   display->mouse_wheel_precision = 1;
-
    display->min_w = 0;
    display->min_h = 0;
    display->max_w = 0;

--- a/src/display.c
+++ b/src/display.c
@@ -65,6 +65,8 @@ ALLEGRO_DISPLAY *al_create_display(int w, int h)
       settings->settings[ALLEGRO_AUTO_CONVERT_BITMAPS] = 1;
    }
 
+   display->mouse_wheel_precision = 1;
+
    display->min_w = 0;
    display->min_h = 0;
    display->max_w = 0;

--- a/src/linux/lmseev.c
+++ b/src/linux/lmseev.c
@@ -480,6 +480,7 @@ static void process_abs(const struct input_event *event)
 static void handle_axis_event(int dx, int dy, int dz)
 {
    if (current_tool != no_tool) {
+      ALLEGRO_SYSTEM *s = al_get_system_driver();
       x_axis.out_abs = _ALLEGRO_CLAMP(x_axis.out_min, x_axis.out_abs, x_axis.out_max);
       y_axis.out_abs = _ALLEGRO_CLAMP(y_axis.out_min, y_axis.out_abs, y_axis.out_max);
       /* There's no range for z */
@@ -487,6 +488,14 @@ static void handle_axis_event(int dx, int dy, int dz)
       the_mouse.state.x = x_axis.out_abs;
       the_mouse.state.y = y_axis.out_abs;
       the_mouse.state.z = z_axis.out_abs;
+
+      if (s && s->displays._size > 0) {
+         ALLEGRO_DISPLAY *d = _al_vector_ref(&s->displays, 0);
+         if (d) {
+            dz *= d->mouse_wheel_precision;
+            the_mouse.state.z *= d->mouse_wheel_precision;
+         }
+      }
 
       generate_mouse_event(
          ALLEGRO_EVENT_MOUSE_AXES,

--- a/src/macosx/qzmouse.m
+++ b/src/macosx/qzmouse.m
@@ -131,8 +131,8 @@ void _al_osx_mouse_generate_event(NSEvent* evt, ALLEGRO_DISPLAY* dpy)
 			type = ALLEGRO_EVENT_MOUSE_AXES;
 			dx = 0;
 			dy = 0;
-			osx_mouse.w_axis += [evt deltaX];
-			osx_mouse.z_axis += [evt deltaY];
+			osx_mouse.w_axis += dpy->mouse_wheel_precision * [evt deltaX];
+			osx_mouse.z_axis += dpy->mouse_wheel_precision * [evt deltaY];
 			dw = osx_mouse.w_axis - osx_mouse.state.w;
 			dz = osx_mouse.z_axis - osx_mouse.state.z;
 			break;

--- a/src/mousenu.c
+++ b/src/mousenu.c
@@ -310,4 +310,25 @@ ALLEGRO_EVENT_SOURCE *al_get_mouse_event_source(void)
 }
 
 
+
+/* Function: al_set_mouse_wheel_precision
+ */
+void al_set_mouse_wheel_precision(ALLEGRO_DISPLAY *display, int precision)
+{
+   ASSERT(display);
+   if (precision < 1)
+      precision = 1;
+   display->mouse_wheel_precision = precision;
+}
+
+
+
+/* Function: al_get_mouse_wheel_precision
+ */
+int al_get_mouse_wheel_precision(ALLEGRO_DISPLAY *display)
+{
+   ASSERT(display);
+   return display->mouse_wheel_precision;
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/src/mousenu.c
+++ b/src/mousenu.c
@@ -313,22 +313,24 @@ ALLEGRO_EVENT_SOURCE *al_get_mouse_event_source(void)
 
 /* Function: al_set_mouse_wheel_precision
  */
-void al_set_mouse_wheel_precision(ALLEGRO_DISPLAY *display, int precision)
+void al_set_mouse_wheel_precision(int precision)
 {
-   ASSERT(display);
+   ALLEGRO_SYSTEM *alsys = al_get_system_driver();
+   ASSERT(alsys);
    if (precision < 1)
       precision = 1;
-   display->mouse_wheel_precision = precision;
+   alsys->mouse_wheel_precision = precision;
 }
 
 
 
 /* Function: al_get_mouse_wheel_precision
  */
-int al_get_mouse_wheel_precision(ALLEGRO_DISPLAY *display)
+int al_get_mouse_wheel_precision(void)
 {
-   ASSERT(display);
-   return display->mouse_wheel_precision;
+   ALLEGRO_SYSTEM *alsys = al_get_system_driver();
+   ASSERT(alsys);
+   return alsys->mouse_wheel_precision;
 }
 
 /* vim: set sts=3 sw=3 et: */

--- a/src/sdl/sdl_mouse.c
+++ b/src/sdl/sdl_mouse.c
@@ -54,13 +54,13 @@ void _al_sdl_mouse_event(SDL_Event *e)
    }
    else if (e->type == SDL_MOUSEWHEEL) {
       event.mouse.type = ALLEGRO_EVENT_MOUSE_AXES;
-      mouse->z += e->wheel.y;
-      mouse->w += e->wheel.x;
+      d = _al_sdl_find_display(e->wheel.windowID);
+      mouse->z += d->mouse_wheel_precision * e->wheel.y;
+      mouse->w += d->mouse_wheel_precision * e->wheel.x;
       event.mouse.z = mouse->z;
       event.mouse.w = mouse->w;
-      event.mouse.dz = e->wheel.y;
-      event.mouse.dw = e->wheel.x;
-      d = _al_sdl_find_display(e->wheel.windowID);
+      event.mouse.dz = d->mouse_wheel_precision * e->wheel.y;
+      event.mouse.dw = d->mouse_wheel_precision * e->wheel.x;
    }
    else {
       switch (e->button.button) {

--- a/src/system.c
+++ b/src/system.c
@@ -256,6 +256,7 @@ bool al_install_system(int version, int (*atexit_ptr)(void (*)(void)))
    
    active_sysdrv = real_system;
    active_sysdrv->config = bootstrap.config;
+   active_sysdrv->mouse_wheel_precision = 1;
 
    ALLEGRO_INFO("Allegro version: %s\n", ALLEGRO_VERSION_STR);
 

--- a/src/win/wmouse.c
+++ b/src/win/wmouse.c
@@ -43,9 +43,9 @@ static ALLEGRO_MOUSE_STATE mouse_state;
 static ALLEGRO_MOUSE the_mouse;
 static bool installed = false;
 
-// The floating point versions of z/w in the mouse_state
-static double float_mouse_z = 0.0;
-static double float_mouse_w = 0.0;
+// The raw point versions of z/w in the mouse_state. They are related to them by a scaling constant.
+static int raw_mouse_z = 0;
+static int raw_mouse_w = 0;
 
 
 static bool init_mouse(void)
@@ -189,7 +189,7 @@ static bool set_mouse_axis(int which, int val)
    if (which == 2) {
       int dz = (val - mouse_state.z);
 
-      float_mouse_z = val;
+      raw_mouse_z = WHEEL_DELTA * val / al_get_mouse_wheel_precision();
 
       if (dz != 0) {
          mouse_state.z = val;
@@ -208,7 +208,7 @@ static bool set_mouse_axis(int which, int val)
    if (which == 3) {
       int dw = (val - mouse_state.w);
 
-      float_mouse_w = val;
+      raw_mouse_w = WHEEL_DELTA * val / al_get_mouse_wheel_precision();
 
       if (dw != 0) {
          mouse_state.w = val;
@@ -332,21 +332,20 @@ void _al_win_mouse_handle_move(int x, int y, bool abs, ALLEGRO_DISPLAY_WIN *win_
 
 void _al_win_mouse_handle_wheel(int raw_dz, bool abs, ALLEGRO_DISPLAY_WIN *win_disp)
 {
-   ALLEGRO_DISPLAY *display = (ALLEGRO_DISPLAY *)win_disp;
    int d;
    int new_z;
-   double float_dz = display->mouse_wheel_precision * (double)raw_dz / WHEEL_DELTA;
 
    if (!installed)
       return;
 
    if (!abs) {
-      float_mouse_z += float_dz;
+      raw_mouse_z += raw_dz;
    }
    else {
-      float_mouse_z = float_dz;
+      raw_mouse_z = raw_dz;
    }
-   new_z = (int)float_mouse_z;
+
+   new_z = al_get_mouse_wheel_precision() * raw_mouse_z / WHEEL_DELTA;
    d = new_z - mouse_state.z;
    mouse_state.z = new_z;
 
@@ -359,21 +358,20 @@ void _al_win_mouse_handle_wheel(int raw_dz, bool abs, ALLEGRO_DISPLAY_WIN *win_d
 
 void _al_win_mouse_handle_hwheel(int raw_dw, bool abs, ALLEGRO_DISPLAY_WIN *win_disp)
 {
-   ALLEGRO_DISPLAY *display = (ALLEGRO_DISPLAY *)win_disp;
    int d;
    int new_w;
-   double float_dw = display->mouse_wheel_precision * (double)raw_dw / WHEEL_DELTA;
 
    if (!installed)
       return;
 
    if (!abs) {
-      float_mouse_w += float_dw;
+      raw_mouse_w += raw_dw;
    }
    else {
-      float_mouse_w = float_dw;
+      raw_mouse_w = raw_dw;
    }
-   new_w = (int)float_mouse_w;
+
+   new_w = al_get_mouse_wheel_precision() * raw_mouse_w / WHEEL_DELTA;
    d = new_w - mouse_state.w;
    mouse_state.w = new_w;
 

--- a/src/win/wmouse.c
+++ b/src/win/wmouse.c
@@ -43,6 +43,10 @@ static ALLEGRO_MOUSE_STATE mouse_state;
 static ALLEGRO_MOUSE the_mouse;
 static bool installed = false;
 
+// The floating point versions of z/w in the mouse_state
+static double float_mouse_z = 0.0;
+static double float_mouse_w = 0.0;
+
 
 static bool init_mouse(void)
 {
@@ -185,6 +189,8 @@ static bool set_mouse_axis(int which, int val)
    if (which == 2) {
       int dz = (val - mouse_state.z);
 
+      float_mouse_z = val;
+
       if (dz != 0) {
          mouse_state.z = val;
 
@@ -201,6 +207,8 @@ static bool set_mouse_axis(int which, int val)
    /* Horizontal mouse wheel. */
    if (which == 3) {
       int dw = (val - mouse_state.w);
+
+      float_mouse_w = val;
 
       if (dw != 0) {
          mouse_state.w = val;
@@ -322,21 +330,25 @@ void _al_win_mouse_handle_move(int x, int y, bool abs, ALLEGRO_DISPLAY_WIN *win_
 }
 
 
-void _al_win_mouse_handle_wheel(int z, bool abs, ALLEGRO_DISPLAY_WIN *win_disp)
+void _al_win_mouse_handle_wheel(int raw_dz, bool abs, ALLEGRO_DISPLAY_WIN *win_disp)
 {
+   ALLEGRO_DISPLAY *display = (ALLEGRO_DISPLAY *)win_disp;
    int d;
+   int new_z;
+   double float_dz = display->mouse_wheel_precision * (double)raw_dz / WHEEL_DELTA;
 
    if (!installed)
       return;
 
    if (!abs) {
-      mouse_state.z += z;
-      d = z;
+      float_mouse_z += float_dz;
    }
    else {
-      d = z - mouse_state.z;
-      mouse_state.z = z;
+      float_mouse_z = float_dz;
    }
+   new_z = (int)float_mouse_z;
+   d = new_z - mouse_state.z;
+   mouse_state.z = new_z;
 
    generate_mouse_event(ALLEGRO_EVENT_MOUSE_AXES,
       mouse_state.x, mouse_state.y, mouse_state.z, mouse_state.w, mouse_state.pressure,
@@ -345,21 +357,25 @@ void _al_win_mouse_handle_wheel(int z, bool abs, ALLEGRO_DISPLAY_WIN *win_disp)
 }
 
 
-void _al_win_mouse_handle_hwheel(int w, bool abs, ALLEGRO_DISPLAY_WIN *win_disp)
+void _al_win_mouse_handle_hwheel(int raw_dw, bool abs, ALLEGRO_DISPLAY_WIN *win_disp)
 {
+   ALLEGRO_DISPLAY *display = (ALLEGRO_DISPLAY *)win_disp;
    int d;
+   int new_w;
+   double float_dw = display->mouse_wheel_precision * (double)raw_dw / WHEEL_DELTA;
 
    if (!installed)
       return;
 
    if (!abs) {
-      mouse_state.w += w;
-      d = w;
+      float_mouse_w += float_dw;
    }
    else {
-      d = w - mouse_state.w;
-      mouse_state.w = w;
+      float_mouse_w = float_dw;
    }
+   new_w = (int)float_mouse_w;
+   d = new_w - mouse_state.w;
+   mouse_state.w = new_w;
 
    generate_mouse_event(ALLEGRO_EVENT_MOUSE_AXES,
       mouse_state.x, mouse_state.y, mouse_state.z, mouse_state.w, mouse_state.pressure,

--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -484,7 +484,7 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
 
           if (rm->usButtonFlags & RI_MOUSE_WHEEL) {
              SHORT z = (SHORT)rm->usButtonData;
-             _al_win_mouse_handle_wheel(z / WHEEL_DELTA, false, win_display);
+             _al_win_mouse_handle_wheel(z, false, win_display);
           }
        }
 
@@ -543,7 +543,7 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
       case WM_MOUSEWHEEL: {
          if (accept_mouse_event()) {
             int d = GET_WHEEL_DELTA_WPARAM(wParam);
-            _al_win_mouse_handle_wheel(d / WHEEL_DELTA, false, win_display);
+            _al_win_mouse_handle_wheel(d, false, win_display);
             return TRUE;
          }
          break;
@@ -551,7 +551,7 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
       case WM_MOUSEHWHEEL: {
          if (accept_mouse_event()) {
             int d = GET_WHEEL_DELTA_WPARAM(wParam);
-            _al_win_mouse_handle_hwheel(d / WHEEL_DELTA, false, win_display);
+            _al_win_mouse_handle_hwheel(d, false, win_display);
             return TRUE;
          }
          break;

--- a/src/x/xmousenu.c
+++ b/src/x/xmousenu.c
@@ -380,6 +380,9 @@ static void wheel_motion_handler(int x_button, ALLEGRO_DISPLAY *display)
    if (x_button == 7) dw = 1;
    if (dz == 0 && dw == 0) return;
 
+   dz *= display->mouse_wheel_precision;
+   dw *= display->mouse_wheel_precision;
+
    _al_event_source_lock(&the_mouse.parent.es);
    {
       the_mouse.state.z += dz;


### PR DESCRIPTION

Also add API to allow the users to set the precision of the mouse wheel, so as
to be able to take advantage of those high precision mice if they choose to.