### PR TITLE
Allow injection of allegro events into a queue.

### DIFF
--- a/docs/src/refman/events.txt
+++ b/docs/src/refman/events.txt
@@ -817,7 +817,7 @@ See also: [ALLEGRO_EVENT_SOURCE]
 
 ## API: al_emit_user_event
 
-Emit a user event.
+Emit an event from a user event source.
 The event source must have been initialised with [al_init_user_event_source].
 Returns `false` if the event source isn't registered with any queues,
 hence the event wouldn't have been delivered into any queues.
@@ -839,6 +839,12 @@ the event, but *not* the event itself (since it is just a copy).
 If `dtor` is NULL then reference counting will not be performed.
 It is safe, but unnecessary, to call [al_unref_user_event] on non-reference
 counted user events.
+
+You can use al_emit_user_event to emit both user and non-user events from your
+user event source. Note that emitting input events will not update the
+corresponding input device states. For example, you may emit an event of type
+[ALLEGRO_EVENT_KEY_DOWN], but it will not update the [ALLEGRO_KEYBOARD_STATE]
+returned by [al_get_keyboard_state].
 
 See also: [ALLEGRO_USER_EVENT], [al_unref_user_event]
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -101,6 +101,7 @@ example(ex_monitorinfo)
 example(ex_path)
 example(ex_path_test)
 example(ex_user_events)
+example(ex_inject_events)
 
 if(NOT MSVC)
     # UTF-8 strings are problematic under MSVC.

--- a/examples/ex_inject_events.c
+++ b/examples/ex_inject_events.c
@@ -1,0 +1,74 @@
+/*
+ * Ryan Roden-Corrent
+ * Example that injects regular (non-user-type) allegro events into a queue.
+ * This could be useful for 'faking' certain event sources.
+ * For example, you could imitate joystick events without a * joystick.
+ *
+ * Based on the ex_user_events.c example.
+ */
+
+#include <stdio.h>
+#include "allegro5/allegro.h"
+
+#include "common.c"
+
+int main(int argc, char **argv)
+{
+   ALLEGRO_EVENT_SOURCE fake_src;
+   ALLEGRO_EVENT_QUEUE *queue;
+   ALLEGRO_EVENT fake_keydown_event, fake_joystick_event;
+   ALLEGRO_EVENT event;
+
+   (void)argc;
+   (void)argv;
+
+   if (!al_init()) {
+      abort_example("Could not init Allegro.\n");
+   }
+
+   open_log();
+
+   /* register our 'fake' event source with the queue */
+   al_init_user_event_source(&fake_src);
+   queue = al_create_event_queue();
+   al_register_event_source(queue, &fake_src);
+
+   /* fake a joystick event */
+   fake_joystick_event.any.type = ALLEGRO_EVENT_JOYSTICK_AXIS;
+   fake_joystick_event.joystick.stick = 1;
+   fake_joystick_event.joystick.axis = 0;
+   fake_joystick_event.joystick.pos = 0.5;
+   al_emit_user_event(&fake_src, &fake_joystick_event, NULL);
+
+   /* fake a keyboard event */
+   fake_keydown_event.any.type = ALLEGRO_EVENT_KEY_DOWN;
+   fake_keydown_event.keyboard.keycode = ALLEGRO_KEY_ENTER;
+   al_emit_user_event(&fake_src, &fake_keydown_event, NULL);
+
+   /* poll for the events we injected */
+   while (!al_is_event_queue_empty(queue)) {
+      al_wait_for_event(queue, &event);
+
+      switch (event.type) {
+         case ALLEGRO_EVENT_KEY_DOWN:
+            ALLEGRO_ASSERT(event.user.source == &fake_src);
+            log_printf("Got keydown: %d\n", event.keyboard.keycode);
+            break;
+         case ALLEGRO_EVENT_JOYSTICK_AXIS:
+            ALLEGRO_ASSERT(event.user.source == &fake_src);
+            log_printf("Got joystick axis: stick=%d axis=%d pos=%f\n",
+               event.joystick.stick, event.joystick.axis, event.joystick.pos);
+            break;
+      }
+   }
+
+   al_destroy_user_event_source(&fake_src);
+   al_destroy_event_queue(queue);
+
+   log_printf("Done.\n");
+   close_log(true);
+
+   return 0;
+}
+
+/* vim: set sts=3 sw=3 et: */

--- a/src/evtsrc.c
+++ b/src/evtsrc.c
@@ -222,7 +222,6 @@ bool al_emit_user_event(ALLEGRO_EVENT_SOURCE *src,
 
    ASSERT(src);
    ASSERT(event);
-   ASSERT(ALLEGRO_EVENT_TYPE_IS_USER(event->any.type));
 
    if (dtor) {
       ALLEGRO_USER_EVENT_DESCRIPTOR *descr = al_malloc(sizeof(*descr));
@@ -240,7 +239,7 @@ bool al_emit_user_event(ALLEGRO_EVENT_SOURCE *src,
 
       num_queues = _al_vector_size(&rsrc->queues);
       if (num_queues > 0) {
-         event->user.timestamp = al_get_time();
+         event->any.timestamp = al_get_time();
          _al_event_source_emit_event(src, event);
          rc = true;
       }


### PR DESCRIPTION
Previously, an ASSERT in al_emit_user_event checked that the event was in the
user space.

However, there doesn't seem to be a good reason to limit users from injecting
regular allegro events into the queue.
This could be useful for testing and simulating input devices.

As a matter of fact, this is already possible in release builds, as the only
thing stopping you is the ASSERT.
I say we get rid of it unless there's a good reason for it to be there.

This was discussed in a forum thread a few months ago:
https://www.allegro.cc/forums/thread/615220

Everyone seemed to agree that it would be useful, and the changes this patch
applies to the source were suggested by Edgar Reynaldo in that thread.

This also includes an example of 'faking' events in ex_inject_events.