### PR TITLE
Fix possible random crashes on Windows restoring DirectDraw surfaces

### DIFF
--- a/src/win/wddbmpl.c
+++ b/src/win/wddbmpl.c
@@ -113,10 +113,12 @@ void unregister_all_ddraw_surfaces(void)
  */
 int restore_all_ddraw_surfaces(void)
 {
-   DDRAW_SURFACE *item = ddraw_surface_list;
+   DDRAW_SURFACE *item;
    HRESULT hr;
 
    _enter_gfx_critical();
+
+   item = ddraw_surface_list;
 
    while (item) {
       hr = IDirectDrawSurface2_Restore(item->id);


### PR DESCRIPTION
This fix was introduced in my own Allegro 4.4 port included in Aseprite here:
https://github.com/aseprite/aseprite/commit/434059d517d786078c8cf528fd8bea70aa62fb73

There were several crash reports (memory dumps) about this specific problem so I think other people using Allegro 4.4 would love this fix.