### PR TITLE
Fix an issue with formating of flags.

### DIFF
--- a/docs/src/refman/native_dialog.txt
+++ b/docs/src/refman/native_dialog.txt
@@ -63,17 +63,22 @@ Parameters:
 ALLEGRO_FILECHOOSER_FILE_MUST_EXIST
 :   If supported by the native dialog, it will not allow entering new names,
     but just allow existing files to be selected. Else it is ignored.
+
 ALLEGRO_FILECHOOSER_SAVE
 :   If the native dialog system has a different dialog for saving (for example
     one which allows creating new directories), it is used. Else it is ignored.
+
 ALLEGRO_FILECHOOSER_FOLDER
 :   If there is support for a separate dialog to select a folder instead of a
     file, it will be used.
+
 ALLEGRO_FILECHOOSER_PICTURES
 :   If a different dialog is available for selecting pictures, it is used. Else
     it is ignored.
+
 ALLEGRO_FILECHOOSER_SHOW_HIDDEN
 :   If the platform supports it, also hidden files will be shown.
+
 ALLEGRO_FILECHOOSER_MULTIPLE
 :   If supported, allow selecting multiple files.
 
@@ -122,16 +127,22 @@ dialog boxes usually have on the native system. If the `buttons` parameter is
 not NULL, you can instead specify the button text in a string, with buttons
 separated by a vertical bar (|).
 
+The flags available are:
+
 ALLEGRO_MESSAGEBOX_WARN
 :   The message is a warning.
     This may cause a different icon (or other effects).
+
 ALLEGRO_MESSAGEBOX_ERROR
 :   The message is an error.
+
 ALLEGRO_MESSAGEBOX_QUESTION
 :   The message is a question.
+
 ALLEGRO_MESSAGEBOX_OK_CANCEL
 :   Display a cancel button alongside the "OK" button.
     Ignored if `buttons` is not NULL.
+
 ALLEGRO_MESSAGEBOX_YES_NO
 :   Display Yes/No buttons instead of the "OK" button.
     Ignored if `buttons` is not NULL.


### PR DESCRIPTION
On several function definitions, the listing of the flags had wrong formatting, causing the final html doc page to only show the first flag in **bold** and the other ones part of this flag. That would probably confuse some users.

![image](https://cloud.githubusercontent.com/assets/1676233/9802869/24de89ba-57e3-11e5-8309-21079f06cb86.png)

