### PR TITLE
Added bitmap file identification.

### DIFF
--- a/addons/image/CMakeLists.txt
+++ b/addons/image/CMakeLists.txt
@@ -1,6 +1,6 @@
 option(WANT_NATIVE_IMAGE_LOADER "Enable the native platform image loader (if available)" on)
 
-set(IMAGE_SOURCES bmp.c iio.c pcx.c tga.c dds.c)
+set(IMAGE_SOURCES bmp.c iio.c pcx.c tga.c dds.c identify.c)
 set(IMAGE_INCLUDE_FILES allegro5/allegro_image.h)
 
 set_our_header_properties(${IMAGE_INCLUDE_FILES})

--- a/addons/image/allegro5/internal/aintern_image.h
+++ b/addons/image/allegro5/internal/aintern_image.h
@@ -26,19 +26,27 @@ ALLEGRO_IIO_FUNC(ALLEGRO_BITMAP *, _al_load_pcx, (const char *filename, int flag
 ALLEGRO_IIO_FUNC(bool, _al_save_pcx, (const char *filename, ALLEGRO_BITMAP *bmp));
 ALLEGRO_IIO_FUNC(ALLEGRO_BITMAP *, _al_load_pcx_f, (ALLEGRO_FILE *f, int flags));
 ALLEGRO_IIO_FUNC(bool, _al_save_pcx_f, (ALLEGRO_FILE *f, ALLEGRO_BITMAP *bmp));
+ALLEGRO_IIO_FUNC(bool, _al_identify_pcx, (ALLEGRO_FILE *f));
 
 ALLEGRO_IIO_FUNC(ALLEGRO_BITMAP *, _al_load_bmp, (const char *filename, int flags));
 ALLEGRO_IIO_FUNC(bool, _al_save_bmp, (const char *filename, ALLEGRO_BITMAP *bmp));
 ALLEGRO_IIO_FUNC(ALLEGRO_BITMAP *, _al_load_bmp_f, (ALLEGRO_FILE *f, int flags));
 ALLEGRO_IIO_FUNC(bool, _al_save_bmp_f, (ALLEGRO_FILE *f, ALLEGRO_BITMAP *bmp));
+ALLEGRO_IIO_FUNC(bool, _al_identify_bmp, (ALLEGRO_FILE *f));
+
 
 ALLEGRO_IIO_FUNC(ALLEGRO_BITMAP *, _al_load_tga, (const char *filename, int flags));
 ALLEGRO_IIO_FUNC(bool, _al_save_tga, (const char *filename, ALLEGRO_BITMAP *bmp));
 ALLEGRO_IIO_FUNC(ALLEGRO_BITMAP *, _al_load_tga_f, (ALLEGRO_FILE *f, int flags));
 ALLEGRO_IIO_FUNC(bool, _al_save_tga_f, (ALLEGRO_FILE *f, ALLEGRO_BITMAP *bmp));
+ALLEGRO_IIO_FUNC(bool, _al_identify_tga, (ALLEGRO_FILE *f));
 
 ALLEGRO_IIO_FUNC(ALLEGRO_BITMAP *, _al_load_dds, (const char *filename, int flags));
 ALLEGRO_IIO_FUNC(ALLEGRO_BITMAP *, _al_load_dds_f, (ALLEGRO_FILE *f, int flags));
+ALLEGRO_IIO_FUNC(bool, _al_identify_dds, (ALLEGRO_FILE *f));
+
+ALLEGRO_IIO_FUNC(bool, _al_identify_png, (ALLEGRO_FILE *f));
+ALLEGRO_IIO_FUNC(bool, _al_identify_jpg, (ALLEGRO_FILE *f));
 
 #ifdef ALLEGRO_CFG_IIO_HAVE_GDIPLUS
 ALLEGRO_IIO_FUNC(bool, _al_init_gdiplus, (void));

--- a/addons/image/bmp.c
+++ b/addons/image/bmp.c
@@ -1180,4 +1180,29 @@ bool _al_save_bmp(const char *filename, ALLEGRO_BITMAP *bmp)
    return retsave && retclose;
 }
 
+
+bool _al_identify_bmp(ALLEGRO_FILE *f)
+{
+   uint16_t x;
+   uint8_t y[2];
+   al_fread(f, y, 2);
+   if (memcmp(y, "BM", 2) != 0)
+      return false;
+
+   if (!al_fseek(f, 14, ALLEGRO_SEEK_SET))
+      return false;
+
+   x = al_fread16le(f);
+   switch (x) {
+      case WININFOHEADERSIZE:
+      case WININFOHEADERSIZEV2:
+      case WININFOHEADERSIZEV3:
+      case WININFOHEADERSIZEV4:
+      case WININFOHEADERSIZEV5:
+      case OS2INFOHEADERSIZE:
+         return true;
+   }
+   return false;
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/addons/image/dds.c
+++ b/addons/image/dds.c
@@ -181,3 +181,16 @@ ALLEGRO_BITMAP *_al_load_dds(const char *filename, int flags)
 
    return bmp;
 }
+
+bool _al_identify_dds(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   uint32_t y;
+   al_fread(f, x, 4);
+   if (memcmp(x, "DDS ", 4) != 0)
+      return false;
+   y = al_fread32le(f);
+   if (y != 124)
+      return false;
+   return true;
+}

--- a/addons/image/identify.c
+++ b/addons/image/identify.c
@@ -1,0 +1,26 @@
+#include "allegro5/allegro.h"
+#include "allegro5/allegro_image.h"
+#include "allegro5/internal/aintern_image.h"
+
+bool _al_identify_png(ALLEGRO_FILE *f)
+{
+   uint8_t x[8];
+   al_fread(f, x, 8);
+   if (memcmp(x, "\x89PNG\r\n\x1a\n", 8) != 0)
+      return false;
+   return true;
+}
+
+bool _al_identify_jpg(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   uint16_t y;
+   y = al_fread16be(f);
+   if (y != 0xffd8)
+      return false;
+   al_fseek(f, 6, ALLEGRO_SEEK_SET);
+   al_fread(f, x, 4);
+   if (memcmp(x, "JFIF", 4) != 0)
+      return false;
+   return true;
+}

--- a/addons/image/iio.c
+++ b/addons/image/iio.c
@@ -24,19 +24,29 @@ bool al_init_image_addon(void)
    success |= al_register_bitmap_saver(".pcx", _al_save_pcx);
    success |= al_register_bitmap_loader_f(".pcx", _al_load_pcx_f);
    success |= al_register_bitmap_saver_f(".pcx", _al_save_pcx_f);
+   success |= al_register_bitmap_identifier(".pcx", _al_identify_pcx);
 
    success |= al_register_bitmap_loader(".bmp", _al_load_bmp);
    success |= al_register_bitmap_saver(".bmp", _al_save_bmp);
    success |= al_register_bitmap_loader_f(".bmp", _al_load_bmp_f);
    success |= al_register_bitmap_saver_f(".bmp", _al_save_bmp_f);
+   success |= al_register_bitmap_identifier(".bmp", _al_identify_bmp);
 
    success |= al_register_bitmap_loader(".tga", _al_load_tga);
    success |= al_register_bitmap_saver(".tga", _al_save_tga);
    success |= al_register_bitmap_loader_f(".tga", _al_load_tga_f);
    success |= al_register_bitmap_saver_f(".tga", _al_save_tga_f);
+   success |= al_register_bitmap_identifier(".tga", _al_identify_tga);
 
    success |= al_register_bitmap_loader(".dds", _al_load_dds);
    success |= al_register_bitmap_loader_f(".dds", _al_load_dds_f);
+   success |= al_register_bitmap_identifier(".dds", _al_identify_dds);
+
+   /* Even if we don't have libpng or libjpeg we most likely have a
+    * native reader for those instead so always identify them.
+    */
+   success |= al_register_bitmap_identifier(".png", _al_identify_png);
+   success |= al_register_bitmap_identifier(".jpg", _al_identify_jpg);
 
 /* ALLEGRO_CFG_IIO_HAVE_* is sufficient to know that the library
    should be used. i.e., ALLEGRO_CFG_IIO_HAVE_GDIPLUS and

--- a/addons/image/pcx.c
+++ b/addons/image/pcx.c
@@ -289,5 +289,21 @@ bool _al_save_pcx(const char *filename, ALLEGRO_BITMAP *bmp)
    return retsave && retclose;
 }
 
+bool _al_identify_pcx(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   al_fread(f, x, 4);
+   
+   if (x[0] != 0x0a) // PCX must start with 0x0a
+      return false;
+   if (x[1] == 1 || x[1] > 5) // version must be 0, 2, 3, 4, 5
+      return false;
+   if (x[2] > 1) // compression must be 0 or 1
+      return false;
+   if (x[3] != 8) // only 8-bit PCX files supported by Allegro!
+      return false;
+   return true;
+}
+
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/image/tga.c
+++ b/addons/image/tga.c
@@ -578,4 +578,20 @@ bool _al_save_tga(const char *filename, ALLEGRO_BITMAP *bmp)
 }
 
 
+bool _al_identify_tga(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   al_fgetc(f); // skip id length
+   al_fread(f, x, 4);
+   
+   if (x[0] > 1) // TGA colormap must be 0 or 1
+      return false;
+   if ((x[1] & 0xf7) == 0) // type must be 1, 2, 3, 9, 10 or 11
+      return false;
+   if (x[2] != 0 || x[3] != 0) // color map must start at 0
+      return false;
+   return true;
+}
+
+
 /* vim: set sts=3 sw=3 et: */

--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -1458,7 +1458,8 @@ See also: [al_register_bitmap_saver]
 ### API: al_load_bitmap
 
 Loads an image file into a new [ALLEGRO_BITMAP].
-The file type is determined by the extension.
+The file type is determined by the extension, except if the file has
+no extension in which case [al_identify_bitmap] is used instead.
 
 Returns NULL on error.
 
@@ -1475,7 +1476,8 @@ See also: [al_load_bitmap_flags], [al_load_bitmap_f],
 ### API: al_load_bitmap_flags
 
 Loads an image file into a new [ALLEGRO_BITMAP].
-The file type is determined by the extension.
+The file type is determined by the extension, except if the file has
+no extension in which case [al_identify_bitmap] is used instead.
 
 Returns NULL on error.
 
@@ -1581,7 +1583,9 @@ See also: [al_load_bitmap]
 
 Loads an image from an [ALLEGRO_FILE] stream into a new [ALLEGRO_BITMAP].
 The file type is determined by the passed 'ident' parameter, which is a file
-name extension including the leading dot.
+name extension including the leading dot. If (and only if) 'ident' is
+NULL, the file type is determined with [al_identify_bitmap_f] instead.
+
 This is the same as calling [al_load_bitmap_flags_f] with 0 for the flags
 parameter.
 
@@ -1599,7 +1603,9 @@ See also: [al_load_bitmap_flags_f], [al_load_bitmap],
 
 Loads an image from an [ALLEGRO_FILE] stream into a new [ALLEGRO_BITMAP].
 The file type is determined by the passed 'ident' parameter, which is a file
-name extension including the leading dot.
+name extension including the leading dot. If (and only if) 'ident' is
+NULL, the file type is determined with [al_identify_bitmap_f] instead.
+
 The flags parameter is the same as for [al_load_bitmap_flags].
 
 Returns NULL on error.
@@ -1641,6 +1647,59 @@ handler.
 
 See also: [al_save_bitmap], [al_register_bitmap_saver_f], [al_init_image_addon]
 
+### API: al_register_bitmap_identifier
+
+Register an identify handler for [al_identify_bitmap]. The given
+function will be used to detect files for the given extension. It will
+be called with a single argument of type [ALLEGRO_FILE] which is a
+file handle opened for reading and located at the first byte of the
+file. The handler should try to read as few bytes as possible to
+safely determine if the given file contents correspond to the type
+with the extension and return true in that case, false otherwise.
+The file handle must not be closed but there is no need to reset it
+to the beginning.
+
+The extension should include the leading dot ('.') character.
+It will be matched case-insensitively.
+
+The `identifier` argument may be NULL to unregister an entry.
+
+Returns true on success, false on error.
+Returns false if unregistering an entry that doesn't exist.
+
+Since: 5.1.12
+
+See also: [al_identify_bitmap]
+
+### API: al_identify_bitmap
+
+This works exactly as [al_identify_bitmap_f] but you specify the
+filename of the file for which to detect the type and not a file
+handle. The extension, if any, of the passed filename is not taken
+into account - only the file contents.
+
+Since: 5.1.12
+
+See also: [al_init_image_addon], [al_identify_bitmap_f],
+[al_register_bitmap_identifier]
+
+### API: al_identify_bitmap_f
+
+Tries to guess the bitmap file type of the open ALLEGRO_FILE by
+reading the first few bytes. By default Allegro cannot recognize any
+file types, but calling [al_init_image_addon] will add detection of
+(some of) the types it can read. You can also use
+[al_register_bitmap_identifier] to add identification for custom
+file types.
+
+Returns a pointer to a static string with a file extension for the
+type, including the leading dot. For example ".png" or ".jpg". Returns
+NULL if the bitmap type cannot be determined.
+
+Since: 5.1.12
+
+See also: [al_init_image_addon], [al_identify_bitmap],
+[al_register_bitmap_identifier]
 
 ## Render State
 

--- a/include/allegro5/bitmap_io.h
+++ b/include/allegro5/bitmap_io.h
@@ -21,17 +21,22 @@ typedef ALLEGRO_BITMAP *(*ALLEGRO_IIO_LOADER_FUNCTION)(const char *filename, int
 typedef ALLEGRO_BITMAP *(*ALLEGRO_IIO_FS_LOADER_FUNCTION)(ALLEGRO_FILE *fp, int flags);
 typedef bool (*ALLEGRO_IIO_SAVER_FUNCTION)(const char *filename, ALLEGRO_BITMAP *bitmap);
 typedef bool (*ALLEGRO_IIO_FS_SAVER_FUNCTION)(ALLEGRO_FILE *fp, ALLEGRO_BITMAP *bitmap);
+typedef bool (*ALLEGRO_IIO_IDENTIFIER_FUNCTION)(ALLEGRO_FILE *f);
 
 AL_FUNC(bool, al_register_bitmap_loader, (const char *ext, ALLEGRO_IIO_LOADER_FUNCTION loader));
 AL_FUNC(bool, al_register_bitmap_saver, (const char *ext, ALLEGRO_IIO_SAVER_FUNCTION saver));
 AL_FUNC(bool, al_register_bitmap_loader_f, (const char *ext, ALLEGRO_IIO_FS_LOADER_FUNCTION fs_loader));
 AL_FUNC(bool, al_register_bitmap_saver_f, (const char *ext, ALLEGRO_IIO_FS_SAVER_FUNCTION fs_saver));
+AL_FUNC(bool, al_register_bitmap_identifier, (const char *ext,
+   ALLEGRO_IIO_IDENTIFIER_FUNCTION identifier));
 AL_FUNC(ALLEGRO_BITMAP *, al_load_bitmap, (const char *filename));
 AL_FUNC(ALLEGRO_BITMAP *, al_load_bitmap_flags, (const char *filename, int flags));
 AL_FUNC(ALLEGRO_BITMAP *, al_load_bitmap_f, (ALLEGRO_FILE *fp, const char *ident));
 AL_FUNC(ALLEGRO_BITMAP *, al_load_bitmap_flags_f, (ALLEGRO_FILE *fp, const char *ident, int flags));
 AL_FUNC(bool, al_save_bitmap, (const char *filename, ALLEGRO_BITMAP *bitmap));
 AL_FUNC(bool, al_save_bitmap_f, (ALLEGRO_FILE *fp, const char *ident, ALLEGRO_BITMAP *bitmap));
+AL_FUNC(char const *, al_identify_bitmap_f, (ALLEGRO_FILE *fp));
+AL_FUNC(char const *, al_identify_bitmap, (char const *filename));
 
 #ifdef __cplusplus
    }

--- a/tests/test_driver.c
+++ b/tests/test_driver.c
@@ -1139,6 +1139,13 @@ static void do_test(ALLEGRO_CONFIG *cfg, char const *testname,
          }
          continue;
       }
+      if (SCANLVAL("al_identify_bitmap", 1)) {
+         char const *ext = al_identify_bitmap(V(0));
+         if (!ext)
+            ext = "NULL";
+         al_set_config_value(cfg, testname, lval, ext);
+         continue;
+      }
 
       if (SCAN("al_hold_bitmap_drawing", 1)) {
          al_hold_bitmap_drawing(get_bool(V(0)));

--- a/tests/test_image.ini
+++ b/tests/test_image.ini
@@ -1,6 +1,9 @@
 [bitmaps]
 allegro=../examples/data/allegro.pcx
 
+[fonts]
+builtin=al_create_builtin_font()
+
 # We can't assume that a backbuffer with alpha is available, so draw
 # to a temporary bitmap.
 [template]
@@ -118,3 +121,38 @@ hash=c44929e5
 extend=save template
 filename=tmp.tga
 hash=c44929e5
+
+[identify]
+op0=al_set_blender(ALLEGRO_ADD, ALLEGRO_ONE, ALLEGRO_INVERSE_ALPHA)
+op1=ext = al_identify_bitmap(filename)
+op2=al_draw_text(builtin, yellow, 0, 0, 0, ext)
+
+[test identify bmp]
+extend = identify
+filename=../examples/data/fakeamp.bmp
+hash=b5436ae7
+
+[test identify png]
+extend = identify
+filename=../examples/data/alexlogo.png
+hash=05da299b
+
+[test identify jpg]
+extend = identify
+filename=../examples/data/obp.jpg
+hash=6e2b0f7d
+
+[test identify pcx]
+extend = identify
+filename=../examples/data/allegro.pcx
+hash=5d1d24db
+
+[test identify tga]
+extend = identify
+filename=../examples/data/fixed_font.tga
+hash=fca11c13
+
+[test identify dds]
+extend = identify
+filename=../examples/data/mysha_dxt5.dds
+hash=84ab6fb5


### PR DESCRIPTION
Fixes #461. Identification is only done when opening a file with no
extension, or passing NULL as identification name to the _f variants. If
a file has an extension, or an extension is passed to a _f function, no
attempt to autodetect is made even if loading fails. This way there
should be little problems with backwards compatibility - those cases
meant an immediate failure to load before with no attempt to even open
the file.