### PR TITLE
mingw toolchain: Define CMAKE_FIND_ROOT_PATH for i686-w64-mingw32 too

### DIFF
--- a/cmake/Toolchain-mingw.cmake
+++ b/cmake/Toolchain-mingw.cmake
@@ -34,6 +34,7 @@ elseif(EXISTS /usr/i686-w64-mingw32)
     set(CMAKE_C_COMPILER i686-w64-mingw32-gcc)
     set(CMAKE_CXX_COMPILER i686-w64-mingw32-g++)
     set(CMAKE_RC_COMPILER i686-w64-mingw32-windres)
+    set(CMAKE_FIND_ROOT_PATH /usr/i686-w64-mingw32)
     set(CMAKE_AR:FILEPATH /usr/bin/i686-w64-mingw32-ar)
 elseif(EXISTS /opt/mingw)
     # You can get a MinGW environment using the script at <http://mxe.cc>.


### PR DESCRIPTION
Looks the definition of CMAKE_FIND_ROOT_PATH was just missing in this one instance
I've tested cross-compilation before and after, this solves the "directinput not found" problem reported here https://www.allegro.cc/forums/thread/615769/