### PR TITLE
Fix html docs sidebar generated by Pandoc

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -68,7 +68,7 @@ function(pandoc source output) # extraargs...
     add_custom_command(
         OUTPUT  ${abs_output}
         DEPENDS ${abs_source}
-        COMMAND ${PANDOC} ${abs_source_native} --toc --standalone ${ARGN}
+        COMMAND ${PANDOC} ${abs_source_native} --from markdown --toc --standalone ${ARGN}
                 -o ${abs_output}
         )
 endfunction(pandoc source output)

--- a/docs/Refman.cmake
+++ b/docs/Refman.cmake
@@ -214,7 +214,7 @@ if(WANT_DOCS_HTML)
         add_custom_command(
             OUTPUT ${inc}.html
             DEPENDS ${SRC_REFMAN_DIR}/${inc}.txt
-            COMMAND ${PANDOC} ${SRC_REFMAN_DIR}/${inc}.txt -o ${inc}.html
+            COMMAND ${PANDOC} ${SRC_REFMAN_DIR}/${inc}.txt --from markdown -o ${inc}.html
             )
     endforeach(inc)
 


### PR DESCRIPTION
Pandoc (1.12 and later on windows) wasn't detecting Markdown format from
inc.a.txt, inc.z.txt, changes-5.0.txt and changes-5.1.txt files.
Html pages ended up with a useless sidebar and changelogs with unformatted text.