### PR TITLE
Implemented get_monitor_info for Android

### DIFF
--- a/android/allegro_activity/src/AllegroActivity.java
+++ b/android/allegro_activity/src/AllegroActivity.java
@@ -10,7 +10,9 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.graphics.Rect;
 import android.util.Log;
+import android.view.Display;
 import android.view.SurfaceHolder;
 import android.view.ViewGroup;
 import android.view.Window;
@@ -95,6 +97,26 @@ public class AllegroActivity extends Activity
    String getManufacturer()
    {
       return android.os.Build.MANUFACTURER;
+   }
+
+   Rect getDisplaySize()
+   {
+      Display display = getWindowManager().getDefaultDisplay();
+      Rect size = new Rect();
+   
+      if (android.os.Build.VERSION.SDK_INT >= 13)
+      {
+         display.getRectSize(size);
+      }
+      else
+      {
+         size.left = 0;
+         size.top = 0;
+         size.right = display.getWidth();
+         size.bottom = display.getHeight();
+      }
+
+      return size;
    }
 
    void postRunnable(Runnable runme)

--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -494,7 +494,9 @@ static bool android_get_monitor_info(int adapter, ALLEGRO_MONITOR_INFO *info)
    info->x1 = 0;
    info->y1 = 0;
    info->x2 = _jni_callIntMethod(env, rect, "width");
-   info->x2 = _jni_callIntMethod(env, rect, "height");
+   info->y2 = _jni_callIntMethod(env, rect, "height");
+
+   ALLEGRO_DEBUG("Monitor Info: %d:%d", info->x2, info->y2);
 
    return true;
 }

--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -483,6 +483,22 @@ static int android_get_num_video_adapters(void)
    return 1;
 }
 
+static bool android_get_monitor_info(int adapter, ALLEGRO_MONITOR_INFO *info)
+{
+   if (adapter > android_get_num_video_adapters())
+      return false;
+
+   JNIEnv * env = (JNIEnv *)_al_android_get_jnienv();
+   jobject rect = _jni_callObjectMethod(env, _al_android_activity_object(), "getDisplaySize", "()Landroid/graphics/Rect;");
+
+   info->x1 = 0;
+   info->y1 = 0;
+   info->x2 = _jni_callIntMethod(env, rect, "width");
+   info->x2 = _jni_callIntMethod(env, rect, "height");
+
+   return true;
+}
+
 static void android_shutdown_system(void)
 {
    ALLEGRO_SYSTEM *s = al_get_system_driver();
@@ -517,6 +533,7 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_android_interface()
    android_vt->get_touch_input_driver = _al_get_android_touch_input_driver;
    android_vt->get_joystick_driver = android_get_joystick_driver;
    android_vt->get_num_video_adapters = android_get_num_video_adapters;
+   android_vt->get_monitor_info = android_get_monitor_info;
    android_vt->get_path = _al_android_get_path;
    android_vt->shutdown_system = android_shutdown_system;
    android_vt->inhibit_screensaver = android_inhibit_screensaver;

--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -485,7 +485,7 @@ static int android_get_num_video_adapters(void)
 
 static bool android_get_monitor_info(int adapter, ALLEGRO_MONITOR_INFO *info)
 {
-   if (adapter > android_get_num_video_adapters())
+   if (adapter >= android_get_num_video_adapters())
       return false;
 
    JNIEnv * env = (JNIEnv *)_al_android_get_jnienv();


### PR DESCRIPTION
Hey,

Porting a project to android I had a problem with my method that gets the screen size,

```
ALLEGRO_MONITOR_INFO monitor_info;
bool success = al_get_monitor_info(0, &monitor_info);
if (!success)
    ...

int width = monitor_info.x2 - monitor_info.x1; 
int height = monitor_info.y2 - monitor_info.x1;
```

Taking a look at it the al_get_monitor_info will always return false on android as the system interface get_monitor_info isn't implemented. I couldn't see a reason why it couldn't be so I added it. Fill me in  if there is a reason :)

Cheers