### PR TITLE
General Updates for OS X

### DIFF
--- a/addons/image/macosx.m
+++ b/addons/image/macosx.m
@@ -191,7 +191,7 @@ bool _al_osx_save_image_f(ALLEGRO_FILE *f, const char *ident, ALLEGRO_BITMAP *bm
    
    NSImage *image = NSImageFromAllegroBitmap(bmp);
    NSArray *reps = [image representations];
-   NSData *nsdata = [NSBitmapImageRep representationOfImageRepsInArray: reps usingType: type properties: nil];
+   NSData *nsdata = [NSBitmapImageRep representationOfImageRepsInArray: reps usingType: type properties: [NSDictionary dictionary]];
    
    size_t size = (size_t)[nsdata length];
    bool ret = al_fwrite(f, [nsdata bytes], size) == size;

--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -371,7 +371,7 @@ void _al_append_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
     BOOL _hasAppMenu;
     NSMenu* _menu;
 }
-@property (readonly) NSMenu* menu;
+-(NSMenu*) menu;
 -(instancetype) initWithMenu:(ALLEGRO_MENU*) amenu; // Designated initializer
 -(NSMenu*) menu;
 -(void) show;
@@ -550,7 +550,6 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amenu)
 {
     /* This isn't a valid initializer */
     return nil;
-//    return [self initWithMenu:nil];
 }
 // Manage the enabled and checked state (done dynamically by the framework)
 -(BOOL) validateMenuItem:(NSMenuItem *)menuItem {
@@ -567,6 +566,11 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amenu)
     [self->lock release];
     [self->_menu release];
     [super dealloc];
+}
+// Get the menu
+-(NSMenu*) menu
+{
+    return self->_menu;
 }
 // Action event when the menu is selected
 -(void) activated:(id)sender {

--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -504,7 +504,7 @@ typedef struct DISPLAY_INFO {
    else {
       *key = al_ustr_get(aitem->caption, amp_pos+1);
    }
-   NSMenuItem *menu_item = [[[NSMenuItem allocWithZone: [NSMenu menuZone]]
+   NSMenuItem *menu_item = [[[NSMenuItem alloc]
       initWithTitle:[[NSString alloc] initWithUTF8String:buf]
       action:@selector(activated)
       keyEquivalent:[[NSString alloc] initWithUTF8String:key]]
@@ -524,7 +524,7 @@ static ALLEGRO_MUTEX *mutex;
 
 
 #define add_menu(name, sel, eq)                                          \
-        [menu addItem: [[[NSMenuItem allocWithZone: [NSMenu menuZone]]   \
+        [menu addItem: [[[NSMenuItem alloc]   \
                                     initWithTitle: name                  \
                                            action: @selector(sel)        \
                                     keyEquivalent: eq] autorelease]]
@@ -543,11 +543,11 @@ static NSMenu *init_apple_menu(void)
           title = [[NSProcessInfo processInfo] processName];
       }
 
-      NSMenu *main_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: @""];
+      NSMenu *main_menu = [[NSMenu alloc] initWithTitle: @""];
 
       /* Add application ("Apple") menu */
-      menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: @"Apple menu"];
-      temp_item = [[NSMenuItem allocWithZone: [NSMenu menuZone]]
+      menu = [[NSMenu alloc] initWithTitle: @"Apple menu"];
+      temp_item = [[NSMenuItem alloc]
               initWithTitle: @""
               action: NULL
               keyEquivalent: @""];
@@ -725,7 +725,7 @@ static void add_items(NSMenu *menu, ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amen
          }
          else {
             if (aitem->popup) {
-               temp_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: [NSString stringWithUTF8String:buf]];
+               temp_menu = [[NSMenu alloc] initWithTitle: [NSString stringWithUTF8String:buf]];
                [temp_menu setAutoenablesItems:NO];
                MenuDelegate *menu_delegate = [[MenuDelegate alloc] init];
                NSMenuItem *nsmenuitem = [menu_delegate build_menu_item:aitem];
@@ -737,7 +737,7 @@ static void add_items(NSMenu *menu, ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amen
                [temp_menu release];
             }
             else {
-               temp_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: [NSString stringWithUTF8String:buf]];
+               temp_menu = [[NSMenu alloc] initWithTitle: [NSString stringWithUTF8String:buf]];
                [temp_menu setAutoenablesItems:NO];
                MenuDelegate *menu_delegate = [[MenuDelegate alloc] init];
                NSMenuItem *nsmenuitem = [menu_delegate build_menu_item:aitem];
@@ -833,7 +833,7 @@ static NSMenu *show_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amenu, bool pop
    }
 
    if(popup) {
-      main_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: @""];
+      main_menu = [[NSMenu alloc] initWithTitle: @""];
       [main_menu setAutoenablesItems:NO];
       [NSApp activateIgnoringOtherApps:YES];
    }

--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -499,7 +499,7 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amenu)
     }
 }
 // Get the NSMenuItem corresponding to this ALLEGRO_MENU_ITEM
-- (nullable NSMenuItem*) itemForAllegroItem:(ALLEGRO_MENU_ITEM*) aitem
+- (NSMenuItem*) itemForAllegroItem:(ALLEGRO_MENU_ITEM*) aitem
 {
     int index = _al_vector_find(&self->amenu->items, &aitem);
     if (index >= 0) {
@@ -513,7 +513,7 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amenu)
     }
 }
 // Get the ALLEGRO_MENU_ITEM corresponding to this NSMenuItem
-- (nullable ALLEGRO_MENU_ITEM*) allegroItemforItem: (NSMenuItem*) mi
+- (ALLEGRO_MENU_ITEM*) allegroItemforItem: (NSMenuItem*) mi
 {
     unsigned int index = (int) [self.menu indexOfItem:mi];
     if (self->_hasAppMenu) {

--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -369,6 +369,7 @@ void _al_append_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
     NSLock* lock;
     ALLEGRO_MENU* amenu;
     BOOL _hasAppMenu;
+    NSMenu* _menu;
 }
 @property (readonly) NSMenu* menu;
 -(instancetype) initWithMenu:(ALLEGRO_MENU*) amenu; // Designated initializer

--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -562,7 +562,7 @@ static NSMenu *init_apple_menu(void)
       [NSApp setAppleMenu:menu];
       [menu release];
 
-      return main_menu;
+      return [main_menu autorelease];
 }
 
 static void *event_thread(void *unused)
@@ -681,7 +681,7 @@ bool _al_update_menu_item_at(ALLEGRO_MENU_ITEM *item, int i)
 
    char buf[200];
    get_accelerator(item->caption, buf);
-   [menu_item setTitle:[[NSString alloc] initWithUTF8String:buf]];
+   [menu_item setTitle:[NSString stringWithUTF8String:buf]];
 
    if (item->flags & ALLEGRO_MENU_ITEM_CHECKBOX) {
       update_checked_state(mit->menu_item, item->flags & ALLEGRO_MENU_ITEM_CHECKED);
@@ -725,7 +725,7 @@ static void add_items(NSMenu *menu, ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amen
          }
          else {
             if (aitem->popup) {
-               temp_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: [[NSString alloc] initWithUTF8String:buf]];
+               temp_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: [NSString stringWithUTF8String:buf]];
                [temp_menu setAutoenablesItems:NO];
                MenuDelegate *menu_delegate = [[MenuDelegate alloc] init];
                NSMenuItem *nsmenuitem = [menu_delegate build_menu_item:aitem];
@@ -733,9 +733,11 @@ static void add_items(NSMenu *menu, ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amen
                [menu setSubmenu:temp_menu forItem:nsmenuitem];
                the_menu = aitem->popup;
                add_items(temp_menu, display, amenu, the_menu, popup);
+               [menu_delegate release];
+               [temp_menu release];
             }
             else {
-               temp_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: [[NSString alloc] initWithUTF8String:buf]];
+               temp_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: [NSString stringWithUTF8String:buf]];
                [temp_menu setAutoenablesItems:NO];
                MenuDelegate *menu_delegate = [[MenuDelegate alloc] init];
                NSMenuItem *nsmenuitem = [menu_delegate build_menu_item:aitem];
@@ -754,6 +756,7 @@ static void add_items(NSMenu *menu, ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amen
                }
                [nsmenuitem setEnabled:((aitem->flags & ALLEGRO_MENU_ITEM_DISABLED) ? FALSE : TRUE)];
                _al_update_menu_item_at(aitem, -1);
+               [temp_menu release];
             }
          }
       }

--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -350,7 +350,7 @@ void _al_append_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
  * a window becomes main and swaps in the corresponding menu.
  */
 @interface ALLEGTargetManager : NSObject {
-    NSMutableArray<NSDictionary *>* _items;
+    NSMutableArray * _items;
 }
 +(ALLEGTargetManager*) sharedManager;
 -(instancetype) init;

--- a/addons/native_dialog/textlog.c
+++ b/addons/native_dialog/textlog.c
@@ -8,10 +8,10 @@
 #include "allegro5/internal/aintern_system.h"
 
 
-/* The GTK implementation does not require an extra thread.
- * The Windows and OSX implementations do.
+/* The GTK and OSX implementations do not require an extra thread.
+ * The Windows implementation does.
  */
-#if defined(ALLEGRO_CFG_NATIVE_DIALOG_WINDOWS) || defined(ALLEGRO_CFG_NATIVE_DIALOG_OSX)
+#if defined(ALLEGRO_CFG_NATIVE_DIALOG_WINDOWS) 
    #define TEXT_LOG_EXTRA_THREAD true
 #else
    #define TEXT_LOG_EXTRA_THREAD false

--- a/include/allegro5/platform/aintosx.h
+++ b/include/allegro5/platform/aintosx.h
@@ -75,8 +75,11 @@
 #define HID_ELEMENT_HAT                 5
 
 
+/* If we've included IOKit, generate the full definition
+ * otherwise just a forward definition
+ */
+#ifdef _IOKIT_HID_IOHIDLIB_H_
 
-	
 typedef struct HID_ELEMENT
 {
    int type;
@@ -107,6 +110,11 @@ typedef struct
    int capacity;
    HID_DEVICE* devices;
 } HID_DEVICE_COLLECTION;
+#else
+typedef struct HID_ELEMENT HID_ELEMENT;
+typedef struct HID_DEVICE HID_DEVICE;
+typedef struct HID_DEVICE_COLLECTION HID_DEVICE_COLLECTION;
+#endif
 
 int _al_osx_bootstrap_ok(void);
 

--- a/src/macosx/osx_app_delegate.m
+++ b/src/macosx/osx_app_delegate.m
@@ -56,7 +56,7 @@ static BOOL in_bundle(void)
 }
 
 
-@interface AllegroAppDelegate : NSObject
+@interface AllegroAppDelegate : NSObject <NSApplicationDelegate>
 {
     NSTimer* activity;
 }

--- a/src/macosx/osx_app_delegate.m
+++ b/src/macosx/osx_app_delegate.m
@@ -252,7 +252,7 @@ static void call_user_main(void)
 
 /* Helper macro to add entries to the menu */
 #define add_menu(name, sel, eq)                                         \
-        [menu addItem: [[[NSMenuItem allocWithZone: [NSMenu menuZone]]   \
+        [menu addItem: [[[NSMenuItem alloc]   \
                                     initWithTitle: name                 \
                                            action: @selector(sel)       \
                                     keyEquivalent: eq] autorelease]]                 \
@@ -291,12 +291,12 @@ int _al_osx_run_main(int argc, char **argv,
         {
             title = [[NSProcessInfo processInfo] processName];
         }
-        NSMenu* main_menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: @""];
+        NSMenu* main_menu = [[NSMenu alloc] initWithTitle: @""];
         [NSApp setMainMenu: main_menu];
 
         /* Add application ("Apple") menu */
-        menu = [[NSMenu allocWithZone: [NSMenu menuZone]] initWithTitle: @"Apple menu"];
-        temp_item = [[NSMenuItem allocWithZone: [NSMenu menuZone]]
+        menu = [[NSMenu alloc] initWithTitle: @"Apple menu"];
+        temp_item = [[NSMenuItem alloc]
                      initWithTitle: @""
                      action: NULL
                      keyEquivalent: @""];
@@ -312,9 +312,9 @@ int _al_osx_run_main(int argc, char **argv,
         [menu release];
 
         /* Add "Window" menu */
-        menu = [[NSMenu allocWithZone: [NSMenu menuZone]]
+        menu = [[NSMenu alloc]
                         initWithTitle: @"Window"];
-        temp_item = [[NSMenuItem allocWithZone: [NSMenu menuZone]]
+        temp_item = [[NSMenuItem alloc]
                                  initWithTitle: @""
                                         action: NULL
                                  keyEquivalent: @""];

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -2128,10 +2128,10 @@ static bool get_window_constraints(ALLEGRO_DISPLAY* display,
  */
 static void set_window_title(ALLEGRO_DISPLAY *display, const char *title)
 {
-   NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
    ALLEGRO_DISPLAY_OSX_WIN* dpy = (ALLEGRO_DISPLAY_OSX_WIN*) display;
-   [dpy->win setTitle: [NSString stringWithUTF8String:title]];
-   [pool drain];
+   NSString* string = [[NSString alloc] initWithUTF8String:title];
+   [dpy->win performSelectorOnMainThread:@selector(setTitle:) withObject:string waitUntilDone:YES];
+   [string release];
 }
 
 /* set_icons:

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -1287,7 +1287,7 @@ static ALLEGRO_DISPLAY* create_display_fs(int w, int h)
 
    NSRect rect = NSMakeRect(0, 0, w, h);
 
-   dpy->win = [[NSWindow alloc] initWithContentRect:rect styleMask:(IS_LION ? NSBorderlessWindowMask : 0) backing:NSBackingStoreBuffered defer:NO];
+   dpy->win = [[ALWindow alloc] initWithContentRect:rect styleMask:(IS_LION ? NSBorderlessWindowMask : 0) backing:NSBackingStoreBuffered defer:NO];
    [dpy->win setAcceptsMouseMovedEvents:YES];
    [dpy->win setViewsNeedDisplay:NO];
 

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -936,7 +936,6 @@ static void osx_get_opengl_pixelformat_attributes(ALLEGRO_DISPLAY_OSX_WIN *dpy)
    ALLEGRO_DISPLAY_OSX_WIN* dpy = [display_object pointerValue];
    NSRect rc = NSMakeRect(0, 0, dpy->parent.w,  dpy->parent.h);
    ALWindow *alwin = dpy->win = [ALWindow alloc];
-   alwin.display = (ALLEGRO_DISPLAY *)dpy;
    NSWindow* win = alwin;
    NSScreen *screen;
    unsigned int mask = (dpy->parent.flags & ALLEGRO_FRAMELESS) ? NSBorderlessWindowMask :
@@ -965,6 +964,7 @@ static void osx_get_opengl_pixelformat_attributes(ALLEGRO_DISPLAY_OSX_WIN *dpy)
                   defer: NO
                  screen: screen
     ];
+   alwin.display = (ALLEGRO_DISPLAY *)dpy;
    if (dpy->parent.flags & ALLEGRO_RESIZABLE) {
       if ([win respondsToSelector:NSSelectorFromString(@"setCollectionBehavior:")]) {
          [win setCollectionBehavior:NSWindowCollectionBehaviorFullScreenPrimary];

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -1883,8 +1883,9 @@ static bool acknowledge_resize_display_win(ALLEGRO_DISPLAY *d)
        */
       d->flags &= ~ALLEGRO_MAXIMIZED;
    }
-
-   _al_ogl_resize_backbuffer(d->ogl_extras->backbuffer, d->w, d->h);
+   if (d->ogl_extras->backbuffer) {
+      _al_ogl_resize_backbuffer(d->ogl_extras->backbuffer, d->w, d->h);
+   }
    setup_gl(d);
 
    [pool drain];


### PR DESCRIPTION
Since the release of OS X 10.11 (El Capitan) I had a look at the platform specific code. I found some issues particularly with the 'native dialog' addon. I fixed most of the problems and deprecation warnings that  Xcode reported, using a deployment setting of OS X 10.6 (Snow Leopard, released in 2009.) This is the earliest version that current tools will build for. I didn't fix two deprecation warnings:
* one relating to full screen - this will require a big change as the recommended way to do full screen graphics has changed. 
* one relating to mouse events when moving the pointer programmatically - I don't know how to do this in non-deprecated code.

Thanks to Todd Cope for pointing out a problem with `al_set_window_title` (https://www.allegro.cc/forums/thread/615836) which is fixed in 3fff98d3093492ec5cfdbb9ecd9abbbd8661e995
