### PR TITLE
BMP loading speed improvements

### DIFF
--- a/addons/image/bmp.c
+++ b/addons/image/bmp.c
@@ -538,9 +538,9 @@ static void read_32_argb_8888_line(ALLEGRO_FILE *f, char *buf, char *data,
 
       if (premul && a != 0xFF000000U)
       {
-         data32[i*4+1] = data32[i*4+1] * a / 255;
-         data32[i*4+2] = data32[i*4+2] * a / 255;
-         data32[i*4+3] = data32[i*4+3] * a / 255;
+         data[i*4+1] = data[i*4+1] * a / 255;
+         data[i*4+2] = data[i*4+2] * a / 255;
+         data[i*4+3] = data[i*4+3] * a / 255;
       }
    }
 }
@@ -567,9 +567,9 @@ static void read_32_rgba_8888_line(ALLEGRO_FILE *f, char *buf, char *data,
 
       if (premul && a != 0x00000000FFU)
       {
-         data32[i*4] = data32[i*4] * a / 255;
-         data32[i*4+1] = data32[i*4+1] * a / 255;
-         data32[i*4+2] = data32[i*4+2] * a / 255;
+         data[i*4] = data[i*4] * a / 255;
+         data[i*4+1] = data[i*4+1] * a / 255;
+         data[i*4+2] = data[i*4+2] * a / 255;
       }
    }
 }

--- a/addons/image/bmp.c
+++ b/addons/image/bmp.c
@@ -66,11 +66,11 @@ typedef struct BMPINFOHEADER
    unsigned short biBitCount;
    unsigned long biCompression;
    unsigned long biClrUsed;
-   uint_fast32_t biRedMask;
-   uint_fast32_t biGreenMask;
-   uint_fast32_t biBlueMask;
+   uint32_t biRedMask;
+   uint32_t biGreenMask;
+   uint32_t biBlueMask;
    bool biHaveAlphaMask;
-   uint_fast32_t biAlphaMask;
+   uint32_t biAlphaMask;
 } BMPINFOHEADER;
 
 
@@ -194,7 +194,7 @@ static int read_os2_bminfoheader(ALLEGRO_FILE *f, BMPINFOHEADER *infoheader)
 /* decode_bitfield:
  *  Converts a bitfield in to a shift+mask pair
  */
-static void decode_bitfield(uint_fast32_t m, int *shift_out, uint_fast32_t *mask_out)
+static void decode_bitfield(uint32_t m, int *shift_out, uint32_t *mask_out)
 {
    int shift = 0;
 
@@ -229,11 +229,11 @@ static void read_palette(int ncolors, PalEntry *pal, ALLEGRO_FILE *f,
 {
    int i;
    unsigned char c[3];
-   uint_fast32_t r, g, b, a;
+   uint32_t r, g, b, a;
    bool premul = !(flags & ALLEGRO_NO_PREMULTIPLIED_ALPHA);
 
    int as;
-   uint_fast32_t am;
+   uint32_t am;
 
    decode_bitfield(infoheader->biAlphaMask, &as, &am);
 
@@ -243,7 +243,7 @@ static void read_palette(int ncolors, PalEntry *pal, ALLEGRO_FILE *f,
       g = c[1];
       b = c[0];
 
-      uint_fast32_t pixel = (r << 16) | (g << 8) | b;
+      uint32_t pixel = (r << 16) | (g << 8) | b;
 
       switch (am)
       {
@@ -746,7 +746,7 @@ static bool read_bitfields_image(ALLEGRO_FILE *f, int flags,
    bool premul = !(flags & ALLEGRO_NO_PREMULTIPLIED_ALPHA);
 
    int rs, gs, bs, as;
-   uint_fast32_t rm, gm, bm, am;
+   uint32_t rm, gm, bm, am;
 
    // Temporary colour conversion tables for 1..10 bit channels
    // Worst case: ~7KB is temporarily allocated
@@ -775,7 +775,7 @@ static bool read_bitfields_image(ALLEGRO_FILE *f, int flags,
    decode_bitfield(infoheader->biAlphaMask, &as, &am);
 
    for (i = 0; i < (int)(sizeof(tempconvert) / sizeof(int *)); ++i) {
-      uint_fast32_t mask = ~(0xFFFFFFFFU << (i+1)) & 0xFFFFFFFFU;
+      uint32_t mask = ~(0xFFFFFFFFU << (i+1)) & 0xFFFFFFFFU;
 
       switch (i) {
          case 0: tempconvert[i] = _al_rgb_scale_1; break;
@@ -815,12 +815,12 @@ static bool read_bitfields_image(ALLEGRO_FILE *f, int flags,
       memset(linebuf + bytes_read, 0, linesize - bytes_read);
 
       for (k = 0; k < width; k++) {
-         unsigned int pixel = ((unsigned int)(linebuf[k*bytes_per_pixel+3]) << 24)
-                            | ((unsigned int)(linebuf[k*bytes_per_pixel+2]) << 16)
-                            | ((unsigned int)(linebuf[k*bytes_per_pixel+1]) << 8)
-                            |  (unsigned int)(linebuf[k*bytes_per_pixel]);
+         uint32_t pixel = ((uint32_t)(linebuf[k*bytes_per_pixel+3]) << 24)
+                        | ((uint32_t)(linebuf[k*bytes_per_pixel+2]) << 16)
+                        | ((uint32_t)(linebuf[k*bytes_per_pixel+1]) << 8)
+                        |  (uint32_t)(linebuf[k*bytes_per_pixel]);
 
-         uint_fast32_t r, g, b, a = 0xFF;
+         uint32_t r, g, b, a = 0xFF;
 
          r = ((pixel >> rs) & rm);
          g = ((pixel >> gs) & gm);
@@ -1246,7 +1246,7 @@ ALLEGRO_BITMAP *_al_load_bmp_f(ALLEGRO_FILE *f, int flags)
       infoheader.biHaveAlphaMask = true;
       infoheader.biAlphaMask = (uint32_t)al_fread32le(f);
 
-      uint_fast32_t pixel_mask = 0xFFFFFFFFU;
+      uint32_t pixel_mask = 0xFFFFFFFFU;
 
       if (infoheader.biBitCount < 32)
          pixel_mask = ~(pixel_mask << infoheader.biBitCount) & 0xFFFFFFFFU;

--- a/addons/image/bmp.c
+++ b/addons/image/bmp.c
@@ -248,7 +248,7 @@ static void read_palette(int ncolors, PalEntry *pal, ALLEGRO_FILE *f,
       switch (am)
       {
          case 0x00:
-            a = 0xFF;
+            a = 255;
             break;
 
          case 0x01:
@@ -815,12 +815,8 @@ static bool read_bitfields_image(ALLEGRO_FILE *f, int flags,
       memset(linebuf + bytes_read, 0, linesize - bytes_read);
 
       for (k = 0; k < width; k++) {
-         uint32_t pixel = ((uint32_t)(linebuf[k*bytes_per_pixel+3]) << 24)
-                        | ((uint32_t)(linebuf[k*bytes_per_pixel+2]) << 16)
-                        | ((uint32_t)(linebuf[k*bytes_per_pixel+1]) << 8)
-                        |  (uint32_t)(linebuf[k*bytes_per_pixel]);
-
-         uint32_t r, g, b, a = 0xFF;
+         uint32_t pixel = read_32le(linebuf + k*bytes_per_pixel);
+         uint32_t r, g, b, a = 255;
 
          r = ((pixel >> rs) & rm);
          g = ((pixel >> gs) & gm);
@@ -933,7 +929,7 @@ static bool read_RGB_image_32bit_alpha_hack(ALLEGRO_FILE *f, int flags,
          unsigned char *data = (unsigned char *)lr->data + lr->pitch * line;
 
          for (j = 0; j < width; j++) {
-            data[j*4+3] |= 0xFF;
+            data[j*4+3] = 255;
          }
       }
    }

--- a/addons/image/bmp.c
+++ b/addons/image/bmp.c
@@ -98,7 +98,8 @@ typedef struct OS2BMPINFOHEADER
 } OS2BMPINFOHEADER;
 
 
-typedef void(*bmp_line_fn)(ALLEGRO_FILE *f, char *buf, char *data, int width);
+typedef void(*bmp_line_fn)(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul);
 
 
 
@@ -284,7 +285,8 @@ static void read_palette(int ncolors, PalEntry *pal, ALLEGRO_FILE *f,
 /* read_1bit_line:
  *  Support function for reading the 1 bit bitmap file format.
  */
-static void read_1bit_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_1bit_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i, j;
    unsigned char *ucbuf = (unsigned char *)buf;
@@ -306,7 +308,8 @@ static void read_1bit_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
 /* read_2bit_line:
  *  Support function for reading the 2 bit bitmap file format.
  */
-static void read_2bit_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_2bit_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    unsigned char *ucbuf = (unsigned char *)buf;
@@ -329,7 +332,8 @@ static void read_2bit_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
 /* read_4bit_line:
  *  Support function for reading the 4 bit bitmap file format.
  */
-static void read_4bit_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_4bit_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    unsigned char *ucbuf = (unsigned char *)buf;
@@ -350,7 +354,8 @@ static void read_4bit_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
 /* read_8bit_line:
  *  Support function for reading the 8 bit bitmap file format.
  */
-static void read_8bit_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_8bit_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    size_t bytes_wanted = (length + 3) & ~3;
 
@@ -363,7 +368,8 @@ static void read_8bit_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
 /* read_16_rgb_555_line:
  *  Support function for reading the 16 bit / RGB555 bitmap file format.
  */
-static void read_16_rgb_555_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_16_rgb_555_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    uint16_t *buf16 = (uint16_t *)buf;
@@ -383,7 +389,8 @@ static void read_16_rgb_555_line(ALLEGRO_FILE *f, char *buf, char *data, int len
 /* read_16_argb_1555_line:
  *  Support function for reading the 16 bit / ARGB1555 bitmap file format.
  */
-static void read_16_argb_1555_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_16_argb_1555_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    uint16_t *buf16 = (uint16_t *)buf;
@@ -395,6 +402,9 @@ static void read_16_argb_1555_line(ALLEGRO_FILE *f, char *buf, char *data, int l
 
    for (i = 0; i < length; ++i) {
       data32[i] = ALLEGRO_CONVERT_ARGB_1555_TO_ABGR_8888_LE(buf16[i]);
+
+      if (premul && (buf16[i] & 0x8000))
+         data32[i] = 0x00;
    }
 }
 
@@ -403,7 +413,8 @@ static void read_16_argb_1555_line(ALLEGRO_FILE *f, char *buf, char *data, int l
 /* read_16_rgb_565_line:
  *  Support function for reading the 16 bit / RGB565 bitmap file format.
  */
-static void read_16_rgb_565_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_16_rgb_565_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    uint16_t *buf16 = (uint16_t *)buf;
@@ -423,7 +434,8 @@ static void read_16_rgb_565_line(ALLEGRO_FILE *f, char *buf, char *data, int len
 /* read_24_rgb_888_line:
  *  Support function for reading the 24 bit / RGB888 bitmap file format.
  */
-static void read_24_rgb_888_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_24_rgb_888_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int bi, i;
    unsigned char *ucbuf = (unsigned char *)buf;
@@ -467,7 +479,8 @@ static void read_24_rgb_888_line(ALLEGRO_FILE *f, char *buf, char *data, int len
 /* read_32_xrgb_8888_line:
  *  Support function for reading the 32 bit / XRGB8888 bitmap file format.
  */
-static void read_32_xrgb_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_32_xrgb_8888_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    uint32_t *buf32 = (uint32_t *)buf;
@@ -487,7 +500,8 @@ static void read_32_xrgb_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int l
 /* read_32_rgbx_8888_line:
  *  Support function for reading the 32 bit / RGBX8888 bitmap file format.
  */
-static void read_32_rgbx_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_32_rgbx_8888_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    uint32_t *buf32 = (uint32_t *)buf;
@@ -507,7 +521,8 @@ static void read_32_rgbx_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int l
 /* read_32_argb_8888_line:
  *  Support function for reading the 32 bit / ARGB8888 bitmap file format.
  */
-static void read_32_argb_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_32_argb_8888_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    uint32_t *buf32 = (uint32_t *)buf;
@@ -518,7 +533,15 @@ static void read_32_argb_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int l
    memset(buf + bytes_read, 0, bytes_wanted - bytes_read);
 
    for (i = 0; i < length; i++) {
+      uint32_t a = (buf32[i] & 0xFF000000U);
       data32[i] = ALLEGRO_CONVERT_ARGB_8888_TO_ABGR_8888_LE(buf32[i]);
+
+      if (premul && a != 0xFF000000U)
+      {
+         data32[i*4+1] = data32[i*4+1] * a / 255;
+         data32[i*4+2] = data32[i*4+2] * a / 255;
+         data32[i*4+3] = data32[i*4+3] * a / 255;
+      }
    }
 }
 
@@ -527,7 +550,8 @@ static void read_32_argb_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int l
 /* read_32_rgba_8888_line:
  *  Support function for reading the 32 bit / RGBA8888 bitmap file format.
  */
-static void read_32_rgba_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int length)
+static void read_32_rgba_8888_line(ALLEGRO_FILE *f, char *buf, char *data,
+   int length, bool premul)
 {
    int i;
    uint32_t *buf32 = (uint32_t *)buf;
@@ -538,7 +562,15 @@ static void read_32_rgba_8888_line(ALLEGRO_FILE *f, char *buf, char *data, int l
    memset(buf + bytes_read, 0, bytes_wanted - bytes_read);
 
    for (i = 0; i < length; i++) {
+      uint32_t a = (buf32[i] & 0x00000000FFU);
       data32[i] = ALLEGRO_CONVERT_RGBA_8888_TO_ABGR_8888_LE(buf32[i]);
+
+      if (premul && a != 0x00000000FFU)
+      {
+         data32[i*4] = data32[i*4] * a / 255;
+         data32[i*4+1] = data32[i*4+1] * a / 255;
+         data32[i*4+2] = data32[i*4+2] * a / 255;
+      }
    }
 }
 
@@ -554,6 +586,7 @@ static bool read_RGB_image(ALLEGRO_FILE *f, int flags,
    int i, line, height, width, dir;
    size_t linesize;
    char *linebuf;
+   bool premul = !(flags & ALLEGRO_NO_PREMULTIPLIED_ALPHA);
 
    height = infoheader->biHeight;
    width = infoheader->biWidth;
@@ -568,8 +601,7 @@ static bool read_RGB_image(ALLEGRO_FILE *f, int flags,
 
    linebuf = al_malloc(linesize);
 
-   if (!linebuf)
-   {
+   if (!linebuf) {
       ALLEGRO_WARN("Failed to allocate pixel row buffer\n");
       return false;
    }
@@ -580,7 +612,7 @@ static bool read_RGB_image(ALLEGRO_FILE *f, int flags,
 
    for (i = 0; i < height; i++, line += dir) {
       char *data = (char *)lr->data + lr->pitch * line;
-      fn(f, linebuf, data, width);
+      fn(f, linebuf, data, width, premul);
    }
 
    al_free(linebuf);
@@ -625,7 +657,7 @@ static bool read_RGB_paletted_image(ALLEGRO_FILE *f, int flags,
 
    for (i = 0; i < height; i++, line += dir) {
       char *data = (char *)lr->data + lr->pitch * line;
-      fn(f, linebuf, data, width);
+      fn(f, linebuf, data, width, false);
 
       for (j = 0; j < width; ++j) {
          unsigned char idx = linebuf[j];
@@ -808,72 +840,76 @@ static bool read_bitfields_image(ALLEGRO_FILE *f, int flags,
 static bool read_RGB_image_32bit_alpha_hack(ALLEGRO_FILE *f, int flags,
    const BMPINFOHEADER *infoheader, ALLEGRO_LOCKED_REGION *lr)
 {
-   int i, j, line, height, dir;
-   unsigned char *data;
-   unsigned char r, g, b, a;
-   unsigned char have_alpha = 0;
+   int i, j, line, height, width, dir;
+   int have_alpha = 0;
+   size_t linesize;
+   char *linebuf;
    const bool premul = !(flags & ALLEGRO_NO_PREMULTIPLIED_ALPHA);
 
    height = infoheader->biHeight;
+   width = infoheader->biWidth;
+
+   // Includes enough space to read the padding for a line
+   linesize = infoheader->biWidth | 3;
+
+   if (infoheader->biBitCount < 8)
+      linesize *= (8 / infoheader->biBitCount);
+   else
+      linesize *= (infoheader->biBitCount / 8);
+
+   linebuf = al_malloc(linesize);
+
+   if (!linebuf) {
+      ALLEGRO_WARN("Failed to allocate pixel row buffer\n");
+      return false;
+   }
+
    line = height < 0 ? 0 : height - 1;
    dir = height < 0 ? 1 : -1;
    height = abs(height);
 
-   /* Read data. */
    for (i = 0; i < height; i++, line += dir) {
-      data = (unsigned char *)lr->data + lr->pitch * line;
+      unsigned char *data = (unsigned char *)lr->data + lr->pitch * line;
 
-      for (j = 0; j < (int)infoheader->biWidth; j++) {
-         b = al_fgetc(f);
-         g = al_fgetc(f);
-         r = al_fgetc(f);
-         a = al_fgetc(f);
-         have_alpha |= a;
+      /* Don't premultiply alpha here or the image will come out all black */
+      read_32_argb_8888_line(f, linebuf, data, width, false);
 
-         data[0] = r;
-         data[1] = g;
-         data[2] = b;
-         data[3] = a;
-         data += 4;
+      /* Check the alpha values of every pixel in the row */
+      for (j = 0; j < width; j++) {
+         have_alpha |= ((data[j*4+3] & 0xFF) != 0);
       }
    }
 
-   /* Fixup pass. */
+   /* Fixup pass - make imague opaque or premultiply alpha */
    if (!have_alpha) {
-      for (i = 0; i < height; i++) {
-         data = (unsigned char *)lr->data + lr->pitch * i;
-         for (j = 0; j < (int)infoheader->biWidth; j++) {
-            data[3] = 255; /* a */
-            data += 4;
+      line = height < 0 ? 0 : height - 1;
+
+      for (i = 0; i < height; i++, line += dir) {
+         unsigned char *data = (unsigned char *)lr->data + lr->pitch * line;
+
+         for (j = 0; j < width; j++) {
+            data[j*4+3] |= 0xFF;
          }
       }
    }
    else if (premul) {
-      for (i = 0; i < height; i++) {
-         data = (unsigned char *)lr->data + lr->pitch * i;
-         for (j = 0; j < (int)infoheader->biWidth; j++) {
-            r = data[0];
-            g = data[1];
-            b = data[2];
-            a = data[3];
+      line = height < 0 ? 0 : height - 1;
 
-            r = r * a / 255;
-            g = g * a / 255;
-            b = b * a / 255;
+      for (i = 0; i < height; i++, line += dir) {
+         unsigned char *data = (unsigned char *)lr->data + lr->pitch * line;
 
-            data[0] = r;
-            data[1] = g;
-            data[2] = b;
-            data[3] = a;
-            data += 4;
+         for (j = 0; j < width; j++) {
+            data[j*4+0] = data[j*4+0] * data[j*4+3] / 255;
+            data[j*4+1] = data[j*4+1] * data[j*4+3] / 255;
+            data[j*4+2] = data[j*4+2] * data[j*4+3] / 255;
          }
       }
    }
 
+   al_free(linebuf);
+
    return true;
 }
-
-
 
 /* read_RLE8_compressed_image:
  *  For reading the 8 bit RLE compressed BMP image format.

--- a/addons/image/bmp.c
+++ b/addons/image/bmp.c
@@ -840,7 +840,7 @@ static bool read_bitfields_image(ALLEGRO_FILE *f, int flags,
 static bool read_RGB_image_32bit_alpha_hack(ALLEGRO_FILE *f, int flags,
    const BMPINFOHEADER *infoheader, ALLEGRO_LOCKED_REGION *lr)
 {
-   int i, j, line, height, width, dir;
+   int i, j, line, startline, height, width, dir;
    int have_alpha = 0;
    size_t linesize;
    char *linebuf;
@@ -864,7 +864,7 @@ static bool read_RGB_image_32bit_alpha_hack(ALLEGRO_FILE *f, int flags,
       return false;
    }
 
-   line = height < 0 ? 0 : height - 1;
+   line = startline = height < 0 ? 0 : height - 1;
    dir = height < 0 ? 1 : -1;
    height = abs(height);
 
@@ -882,7 +882,7 @@ static bool read_RGB_image_32bit_alpha_hack(ALLEGRO_FILE *f, int flags,
 
    /* Fixup pass - make imague opaque or premultiply alpha */
    if (!have_alpha) {
-      line = height < 0 ? 0 : height - 1;
+      line = startline;
 
       for (i = 0; i < height; i++, line += dir) {
          unsigned char *data = (unsigned char *)lr->data + lr->pitch * line;
@@ -893,7 +893,7 @@ static bool read_RGB_image_32bit_alpha_hack(ALLEGRO_FILE *f, int flags,
       }
    }
    else if (premul) {
-      line = height < 0 ? 0 : height - 1;
+      line = startline;
 
       for (i = 0; i < height; i++, line += dir) {
          unsigned char *data = (unsigned char *)lr->data + lr->pitch * line;

--- a/addons/image/bmp.c
+++ b/addons/image/bmp.c
@@ -1006,6 +1006,33 @@ ALLEGRO_BITMAP *_al_load_bmp_f(ALLEGRO_FILE *f, int flags)
       return NULL;
    }
 
+   if (infoheader.biBitCount != 1 && infoheader.biBitCount != 2 && infoheader.biBitCount != 4 &&
+       infoheader.biBitCount != 8 && infoheader.biBitCount != 16 && infoheader.biBitCount != 24 &&
+       infoheader.biBitCount != 32)
+   {
+      ALLEGRO_WARN("unsupported bit depth: %d\n", infoheader.biBitCount);
+      return NULL;
+   }
+
+   if (infoheader.biCompression == BIT_RLE4 && infoheader.biBitCount != 4)
+   {
+      ALLEGRO_WARN("unsupported bit depth for RLE4 compression: %d\n", infoheader.biBitCount);
+      return NULL;
+   }
+
+   if (infoheader.biCompression == BIT_RLE8 && infoheader.biBitCount != 8)
+   {
+      ALLEGRO_WARN("unsupported bit depth for RLE8 compression: %d\n", infoheader.biBitCount);
+      return NULL;
+   }
+
+   if (infoheader.biCompression == BIT_BITFIELDS && 
+      infoheader.biBitCount != 16 && infoheader.biBitCount != 24 && infoheader.biBitCount != 32)
+   {
+      ALLEGRO_WARN("unsupported bit depth for bitfields compression: %d\n", infoheader.biBitCount);
+      return NULL;
+   }
+
    /* In BITMAPINFOHEADER (V1) the RGB bit masks are not part of the header.
     * In BITMAPV2INFOHEADER they form part of the header, but only valid when
     * for BITFIELDS images.

--- a/tests/manual_bmpsuite4.ini
+++ b/tests/manual_bmpsuite4.ini
@@ -94,6 +94,10 @@ brletopdown = bmpsuite2/b/rletopdown.bmp
 [template]
 op0=al_draw_bitmap(bmp, 0, 0, 0)
 
+[template_premul]
+op0=bmp = al_load_bitmap(filename)
+op1=al_draw_bitmap(bmp, 0, 0, 0)
+
 [test bmpsuite2 gpal1bg]
 extend=template
 bmp=gpal1bg
@@ -358,3 +362,33 @@ hash=db0c5b9c
 extend=template
 bmp=brletopdown
 hash=3f98d122
+
+[test bmpsuite2 qrgba16-1924_premul]
+extend=template_premul
+filename=bmpsuite2/q/rgba16-1924.bmp
+hash=e2f9488d
+
+[test bmpsuite2 qrgba16-4444_premul]
+extend=template_premul
+filename=bmpsuite2/q/rgba16-4444.bmp
+hash=463e4ca9
+
+[test bmpsuite2 qrgba32-61754_premul]
+extend=template_premul
+filename=bmpsuite2/q/rgba32-61754.bmp
+hash=d7e0e0e2
+
+[test bmpsuite2 qrgba32-81284_premul]
+extend=template_premul
+filename=bmpsuite2/q/rgba32-81284.bmp
+hash=cd6f937e
+
+[test bmpsuite2 qrgba32_premul]
+extend=template_premul
+filename=bmpsuite2/q/rgba32.bmp
+hash=b4aca763
+
+[test bmpsuite2 qrgb32fakealpha_premul]
+extend=template_premul
+filename=bmpsuite2/q/rgb32fakealpha.bmp
+hash=5cf7f0d4

--- a/tests/manual_bmpsuite4.ini
+++ b/tests/manual_bmpsuite4.ini
@@ -347,7 +347,7 @@ hash=eb1512c3
 [test bmpsuite2 bshortfile]
 extend=template
 bmp=bshortfile
-hash=c421e6d5
+hash=76ba6cd6
 
 [test bmpsuite2 brgb16-880]
 extend=template


### PR DESCRIPTION
Hi, bet you're happy to see me again. :)

I felt bad after I benchmarked the loading speed of BMP files after my last request, so I optimized the loader for some of the more common formats.

Optimizations consist of reading files line by line, adding optimized conversion loops for common image formats, and creating temporary conversion tables on demand for use during weird bitfield format images.

Speed comparisons between this code (NEW), the current code (CURRENT), and the code before I submitted any changes (ORIGINAL):

| File                 | NEW (d3c5b81) | CURRENT (13e5c37) | ORIGINAL (01a0e84c) | Comments                                                                      |
|----------------------|---------------|-------------------|---------------------|-------------------------------------------------------------------------------|
| g/rgb16.bmp          | 87us          | 669us             | 472us               |                                                                               |
| g/rgb16-565.bmp      | 89us          | 1147us            | 473us               |                                                                               |
| g/rgb24.bmp          | 70us          | 634us             | 447us               |                                                                               |
| g/pal1.bmp           | 90us          | 168us             | 156us               |                                                                               |
| q/pal2.bmp           | 91us          | 193us             | N/A                 | Original loader gives a blank image.                                          |
| g/pal4.bmp           | 93us          | 236us             | 203us               |                                                                               |
| g/pal8.bmp           | 114us         | 346us             | 277us               |                                                                               |
| g/pal4rle.bmp        | 391us         | 284us             | 259us               | Not optimized for (obscure compression format)                                |
| g/pal8rle.bmp        | 502us         | 416us             | 410us               | Not optimized for (obscure compression format)                                |
| g/rgb32.bmp          | 95us          | 1189us            | 1121us              |                                                                               |
| g/rgba32.bmp         | 95us          | 1346us            | N/A                 | Original loader didn't support                                                |
| g/rgb32bf.bmp        | 151us         | 1140us            | N/A                 | Original loader didn't support                                                |
| g/rgb16-231.bmp      | 139us         | 1144us            | N/A                 | Original loader didn't support.                                               |
| q/rgb32-111110.bmp   | 705us         | 1137us            | N/A                 | Original loader didn't support. Not optimized for (uses 11-bit color channel) |
| q/rgb32fakealpha.bmp | 179us         | 1231us            | 1164us              | Uses alpha channel detection hack                                             |

Benchmark used: https://gist.github.com/tehsausage/7704d013a263c3a4c8cc (Linux x86-64, Athlon64 3500+, without display)

Edit: I seem to be terrible at Git. I'm not sure why all the previous commits are listed below...
Edit2: Fixed it >:D