### PR TITLE
Turn off allegro_acodec dynamic loading by default

### DIFF
--- a/addons/acodec/CMakeLists.txt
+++ b/addons/acodec/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 option(WANT_VORBIS "Enable Ogg Vorbis support using libvorbis" on)
 option(WANT_TREMOR "Enable Ogg Vorbis support using Tremor" off)
 option(WANT_MODAUDIO "Enable MOD Audio support" on)
-option(WANT_ACODEC_DYNAMIC_LOAD "Enable DLL loading in acodec (Windows)" on)
+option(WANT_ACODEC_DYNAMIC_LOAD "Enable DLL loading in acodec (Windows)" off)
 
 #-----------------------------------------------------------------------------#
 


### PR DESCRIPTION
Dynamic loading is a useful feature in some situations, but has limited utility.  It almost never makes sense when building Allegro in-house since you can just compile out the codecs you don't need; the only time it really makes sense is if you're installing the library system-wide and want to leave it up to individual games to provide the audio codecs they need.

Therefore the most logical default setting for this option is off, leaving the user to turn it back on in the limited circumstance where it's necessary.