### PR TITLE
Fix al_set_new_window_title() off-by-1

### DIFF
--- a/include/allegro5/display.h
+++ b/include/allegro5/display.h
@@ -117,7 +117,7 @@ AL_FUNC(void, al_set_new_display_flags, (int flags));
 AL_FUNC(int,  al_get_new_display_refresh_rate, (void));
 AL_FUNC(int,  al_get_new_display_flags, (void));
 
-AL_FUNC(void, al_set_new_window_title, (char *title));
+AL_FUNC(void, al_set_new_window_title, (const char *title));
 AL_FUNC(const char *, al_get_new_window_title, (void));
 
 AL_FUNC(int, al_get_display_width,  (ALLEGRO_DISPLAY *display));

--- a/src/tls.c
+++ b/src/tls.c
@@ -189,7 +189,7 @@ ALLEGRO_EXTRA_DISPLAY_SETTINGS *_al_get_new_display_settings(void)
 
 /* Function: al_set_new_window_title
  */
-void al_set_new_window_title(char *title)
+void al_set_new_window_title(const char *title)
 {
    thread_local_state *tls;
    size_t size;
@@ -203,7 +203,7 @@ void al_set_new_window_title(char *title)
       size = ALLEGRO_NEW_WINDOW_TITLE_MAX_SIZE;
    }
 
-   _al_sane_strncpy(tls->new_window_title, title, size);
+   _al_sane_strncpy(tls->new_window_title, title, size + 1);
 }
 
 


### PR DESCRIPTION
The last character was cut off of whatever title was set due to an off-by-1 error in the `strncpy`. I also made it const-correct.