### PR TITLE
Fix debug lib crashing on start

### DIFF
--- a/src/file_stdio.c
+++ b/src/file_stdio.c
@@ -38,7 +38,6 @@
 #include <sys/stat.h>
 #endif
 
-ALLEGRO_DEBUG_CHANNEL("stdio")
 
 /* forward declaration */
 const struct ALLEGRO_FILE_INTERFACE _al_file_interface_stdio;
@@ -101,8 +100,6 @@ static void *file_stdio_fopen(const char *path, const char *mode)
 {
    FILE *fp;
    USERDATA *userdata;
-
-   ALLEGRO_DEBUG("opening %s %s\n", path, mode);
 
 #ifdef ALLEGRO_WINDOWS
    {


### PR DESCRIPTION
A logging function was called before getting a system driver,
then al_get_time() pointed to nothing (at least on Windows).