### PR TITLE
Rework TTF locking a bit.

### DIFF
--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -166,3 +166,9 @@ functions=1
 # glyphs.
 min_page_size = 0
 max_page_size = 0
+
+# This entry contains characters that will be pre-catched during font loading.
+# cache_text = a bcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+
+# Uncomment if you want only the characters in the cache_text entry to ever be drawn
+# skip_cache_misses = true


### PR DESCRIPTION
- Change lock_more logic to be slightly simpler.
- Add a configuration option to pre-cache a set of user specified glyphs. Off by default (should we turn it on by default?)
- Add a configuration option to not cache glyphs on the fly (this is to work around some locking bugs)
- Fix one spot where the fallback font wasn't used.

This is an alternative to #562 which should actually work.