### PR TITLE
Unstable API experiment

### DIFF
--- a/addons/acodec/ogg.c
+++ b/addons/acodec/ogg.c
@@ -4,6 +4,7 @@
  * author: Ryan Dickie (c) 2008
  */
 
+
 #include "allegro5/allegro.h"
 #include "allegro5/allegro_acodec.h"
 #include "allegro5/allegro_audio.h"

--- a/addons/audio/allegro5/allegro_audio.h
+++ b/addons/audio/allegro5/allegro_audio.h
@@ -38,7 +38,6 @@ extern "C" {
    #define ALLEGRO_KCM_AUDIO_FUNC      AL_FUNC
 #endif
 
-
 /* Internal, used to communicate with acodec. */
 /* Must be in 512 <= n < 1024 */
 #define _KCM_STREAM_FEEDER_QUIT_EVENT_TYPE   (512)
@@ -53,6 +52,7 @@ extern "C" {
 
 #define ALLEGRO_EVENT_AUDIO_RECORDER_FRAGMENT       (515)
 
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_KCM_AUDIO_SRC)
 /* Type: ALLEGRO_AUDIO_RECORDER_EVENT
  */
 typedef struct ALLEGRO_AUDIO_RECORDER_EVENT ALLEGRO_AUDIO_RECORDER_EVENT;
@@ -63,6 +63,7 @@ struct ALLEGRO_AUDIO_RECORDER_EVENT
    void *buffer;
    unsigned int samples;
 };
+#endif
 
 
 /* Enum: ALLEGRO_AUDIO_DEPTH
@@ -173,9 +174,11 @@ typedef struct ALLEGRO_MIXER ALLEGRO_MIXER;
 typedef struct ALLEGRO_VOICE ALLEGRO_VOICE;
 
 
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_KCM_AUDIO_SRC)
 /* Type: ALLEGRO_AUDIO_RECORDER
  */
 typedef struct ALLEGRO_AUDIO_RECORDER ALLEGRO_AUDIO_RECORDER;
+#endif
 
 
 #ifndef __cplusplus
@@ -386,6 +389,9 @@ ALLEGRO_KCM_AUDIO_FUNC(bool, al_save_sample_f, (ALLEGRO_FILE* fp, const char *id
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_STREAM *, al_load_audio_stream_f, (ALLEGRO_FILE* fp, const char *ident,
 	size_t buffer_count, unsigned int samples));
 
+
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_KCM_AUDIO_SRC)
+
 /* Recording functions */
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_RECORDER *, al_create_audio_recorder, (size_t fragment_count,
    unsigned int samples, unsigned int freq, ALLEGRO_AUDIO_DEPTH depth, ALLEGRO_CHANNEL_CONF chan_conf));
@@ -396,6 +402,8 @@ ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_EVENT_SOURCE *, al_get_audio_recorder_event_sourc
    (ALLEGRO_AUDIO_RECORDER *r));
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_RECORDER_EVENT *, al_get_audio_recorder_event, (ALLEGRO_EVENT *event));
 ALLEGRO_KCM_AUDIO_FUNC(void, al_destroy_audio_recorder, (ALLEGRO_AUDIO_RECORDER *r));
+
+#endif
    
 #ifdef __cplusplus
 } /* End extern "C" */

--- a/addons/audio/allegro5/internal/aintern_audio.h
+++ b/addons/audio/allegro5/internal/aintern_audio.h
@@ -9,6 +9,42 @@
 #include "allegro5/internal/aintern_vector.h"
 #include "../allegro_audio.h"
 
+struct ALLEGRO_AUDIO_RECORDER {
+  ALLEGRO_EVENT_SOURCE source;
+  
+  ALLEGRO_THREAD           *thread;
+  ALLEGRO_MUTEX            *mutex;
+  ALLEGRO_COND             *cond;
+                           /* recording is done in its own thread as
+                              implemented by the driver */
+  
+  ALLEGRO_AUDIO_DEPTH      depth;
+  ALLEGRO_CHANNEL_CONF     chan_conf;
+  unsigned int             frequency;
+
+  void                     **fragments;
+                           /* the buffers to record into */
+
+  unsigned int             fragment_count;
+                           /* the number of fragments */
+
+  unsigned int             samples;
+                           /* the number of samples returned at every FRAGMENT event */
+                           
+  size_t                   fragment_size;
+                           /* size in bytes of each fragument */
+
+  unsigned int             sample_size;
+                           /* the size in bytes of each sample */
+  
+  volatile bool            is_recording; 
+                           /* true if the driver should actively be updating
+                              the buffer */
+                              
+  void                     *extra;
+                           /* custom data for the driver to use as needed */
+};
+
 typedef enum ALLEGRO_AUDIO_DRIVER_ENUM
 {
    /* Various driver modes. */
@@ -45,8 +81,8 @@ struct ALLEGRO_AUDIO_DRIVER {
    int            (*set_voice_position)(ALLEGRO_VOICE*, unsigned int);
    
    
-   int            (*allocate_recorder)(ALLEGRO_AUDIO_RECORDER *);
-   void           (*deallocate_recorder)(ALLEGRO_AUDIO_RECORDER *);
+   int            (*allocate_recorder)(struct ALLEGRO_AUDIO_RECORDER *);
+   void           (*deallocate_recorder)(struct ALLEGRO_AUDIO_RECORDER *);
 };
 
 extern ALLEGRO_AUDIO_DRIVER *_al_kcm_driver;
@@ -339,48 +375,6 @@ ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_CHANNEL_CONF, _al_count_to_channel_conf, (int num
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_DEPTH, _al_word_size_to_depth_conf, (int word_size));
 
 ALLEGRO_KCM_AUDIO_FUNC(void, _al_emit_audio_event, (int event_type));
-
-
-/*
- * Recording
- */
- 
-struct ALLEGRO_AUDIO_RECORDER {
-  ALLEGRO_EVENT_SOURCE source;
-  
-  ALLEGRO_THREAD           *thread;
-  ALLEGRO_MUTEX            *mutex;
-  ALLEGRO_COND             *cond;
-                           /* recording is done in its own thread as
-                              implemented by the driver */
-  
-  ALLEGRO_AUDIO_DEPTH      depth;
-  ALLEGRO_CHANNEL_CONF     chan_conf;
-  unsigned int             frequency;
-
-  void                     **fragments;
-                           /* the buffers to record into */
-
-  unsigned int             fragment_count;
-                           /* the number of fragments */
-
-  unsigned int             samples;
-                           /* the number of samples returned at every FRAGMENT event */
-                           
-  size_t                   fragment_size;
-                           /* size in bytes of each fragument */
-
-  unsigned int             sample_size;
-                           /* the size in bytes of each sample */
-  
-  volatile bool            is_recording; 
-                           /* true if the driver should actively be updating
-                              the buffer */
-                              
-  void                     *extra;
-                           /* custom data for the driver to use as needed */
-};
-
 
 #endif
 

--- a/addons/native_dialog/allegro5/allegro_native_dialog.h
+++ b/addons/native_dialog/allegro5/allegro_native_dialog.h
@@ -95,9 +95,12 @@ ALLEGRO_DIALOG_FUNC(const char *, al_get_menu_item_caption, (ALLEGRO_MENU *menu,
 ALLEGRO_DIALOG_FUNC(void, al_set_menu_item_caption, (ALLEGRO_MENU *menu, int pos, const char *caption));
 ALLEGRO_DIALOG_FUNC(int, al_get_menu_item_flags, (ALLEGRO_MENU *menu, int pos));
 ALLEGRO_DIALOG_FUNC(void, al_set_menu_item_flags, (ALLEGRO_MENU *menu, int pos, int flags));
-ALLEGRO_DIALOG_FUNC(int, al_toggle_menu_item_flags, (ALLEGRO_MENU *menu, int pos, int flags));
 ALLEGRO_DIALOG_FUNC(ALLEGRO_BITMAP *, al_get_menu_item_icon, (ALLEGRO_MENU *menu, int pos));
 ALLEGRO_DIALOG_FUNC(void, al_set_menu_item_icon, (ALLEGRO_MENU *menu, int pos, ALLEGRO_BITMAP *icon));
+
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_NATIVE_DIALOG_SRC)
+ALLEGRO_DIALOG_FUNC(int, al_toggle_menu_item_flags, (ALLEGRO_MENU *menu, int pos, int flags));
+#endif
  
 /* querying menus */
 ALLEGRO_DIALOG_FUNC(ALLEGRO_MENU *, al_find_menu, (ALLEGRO_MENU *haystack, uint16_t id));

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1432,6 +1432,8 @@ An opaque datatype that represents a recording device.
 
 Since: 5.1.1
 
+> *Unstable:* The API may need a slight redesign.
+
 ### API: ALLEGRO_AUDIO_RECORDER_EVENT
 
 Structure that holds the audio recorder event data. Every event type
@@ -1448,6 +1450,8 @@ Since 5.1.1
 
 See also: [al_get_audio_recorder_event]
 
+> *Unstable:* The API may need a slight redesign.
+
 ### ALLEGRO_EVENT_AUDIO_RECORDER_FRAGMENT
 
 Sent after a user-specified number of samples have been recorded. 
@@ -1456,6 +1460,8 @@ You must always check the values for the buffer and samples as they
 are not guaranteed to be exactly what was originally specified.
 
 Since: 5.1.1
+
+> *Unstable:* The API may need a slight redesign.
 
 ### API: al_create_audio_recorder
 
@@ -1491,6 +1497,8 @@ On failure, returns NULL.
 
 Since: 5.1.1
 
+> *Unstable:* The API may need a slight redesign.
+
 ### API: al_start_audio_recorder
 
 Begin recording into the fragment buffer. Once a complete fragment has been
@@ -1500,6 +1508,8 @@ captured (as specified in [al_create_audio_recorder]), an
 Returns true if it was able to begin recording.
 
 Since: 5.1.1
+
+> *Unstable:* The API may need a slight redesign.
 
 ### API: al_stop_audio_recorder
 
@@ -1515,6 +1525,8 @@ next fragment buffer.
 
 Since: 5.1.1
 
+> *Unstable:* The API may need a slight redesign.
+
 ### API: al_is_audio_recorder_recording
 
 Returns true if the audio recorder is currently capturing data and generating
@@ -1522,11 +1534,15 @@ events.
 
 Since: 5.1.1
 
+> *Unstable:* The API may need a slight redesign.
+
 ### API: al_get_audio_recorder_event
 
 Returns the event as an [ALLEGRO_AUDIO_RECORDER_EVENT].
 
 Since: 5.1.1
+
+> *Unstable:* The API may need a slight redesign.
 
 ### API: al_get_audio_recorder_event_source
 
@@ -1534,6 +1550,8 @@ Returns the event source for the recorder that generates the various recording
 events.
 
 Since: 5.1.1
+
+> *Unstable:* The API may need a slight redesign.
 
 ### API: al_destroy_audio_recorder
 
@@ -1544,3 +1562,5 @@ You may receive events after the recorder has been destroyed. They must be
 ignored, as the fragment buffer will no longer be valid.
 
 Since: 5.1.1
+
+> *Unstable:* The API may need a slight redesign.

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1432,7 +1432,7 @@ An opaque datatype that represents a recording device.
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### API: ALLEGRO_AUDIO_RECORDER_EVENT
 
@@ -1450,7 +1450,7 @@ Since 5.1.1
 
 See also: [al_get_audio_recorder_event]
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### ALLEGRO_EVENT_AUDIO_RECORDER_FRAGMENT
 
@@ -1461,7 +1461,7 @@ are not guaranteed to be exactly what was originally specified.
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### API: al_create_audio_recorder
 
@@ -1497,7 +1497,7 @@ On failure, returns NULL.
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### API: al_start_audio_recorder
 
@@ -1509,7 +1509,7 @@ Returns true if it was able to begin recording.
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### API: al_stop_audio_recorder
 
@@ -1525,7 +1525,7 @@ next fragment buffer.
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### API: al_is_audio_recorder_recording
 
@@ -1534,7 +1534,7 @@ events.
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### API: al_get_audio_recorder_event
 
@@ -1542,7 +1542,7 @@ Returns the event as an [ALLEGRO_AUDIO_RECORDER_EVENT].
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### API: al_get_audio_recorder_event_source
 
@@ -1551,7 +1551,7 @@ events.
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.
 
 ### API: al_destroy_audio_recorder
 
@@ -1563,4 +1563,4 @@ ignored, as the fragment buffer will no longer be valid.
 
 Since: 5.1.1
 
-> *Unstable:* The API may need a slight redesign.
+> *[Unstable API]:* The API may need a slight redesign.

--- a/docs/src/refman/getting_started.txt
+++ b/docs/src/refman/getting_started.txt
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Welcome to Allegro 5.0!
+Welcome to Allegro 5!
 
 This short guide should point you at the parts of the API that you'll
 want to know about first.  It's not a tutorial, as there isn't much
@@ -173,6 +173,13 @@ such a voice (or another mixer) and will mix together all sample data fed to it.
 You can then directly stream real-time sample data to a mixer or a voice using
 an [ALLEGRO_AUDIO_STREAM] or play complete sounds using an [ALLEGRO_SAMPLE_INSTANCE].
 The latter simply points to an [ALLEGRO_SAMPLE] and will stream it for you.
+
+## Unstable API
+
+Some of Allegro's API is marked as unstable, which means that future versions
+of Allegro may change or even remove this API entirely! If you want to
+experiment with unstable API, define `ALLEGRO_UNSTABLE` macro before including
+Allegro's headers.
 
 ## Not the end
 

--- a/docs/src/refman/getting_started.txt
+++ b/docs/src/refman/getting_started.txt
@@ -177,9 +177,13 @@ The latter simply points to an [ALLEGRO_SAMPLE] and will stream it for you.
 ## Unstable API
 
 Some of Allegro's API is marked as unstable, which means that future versions
-of Allegro may change or even remove this API entirely! If you want to
-experiment with unstable API, define `ALLEGRO_UNSTABLE` macro before including
-Allegro's headers.
+of Allegro it may change or even be removed entirely! If you want to experiment
+with unstable API, define `ALLEGRO_UNSTABLE` macro before including Allegro's
+headers.
+
+Note that when you define that macro, the version check performed by
+[al_install_system] and [al_init] becomes more scrict. See documentation of
+those functions for details.
 
 ## Not the end
 

--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -544,6 +544,9 @@ ALLEGRO_MEMORY_BITMAP.
 
 Since: 5.1.0
 
+> *Unstable:* Probably needs to be renamed, as it does something very different
+from [al_convert_bitmap].
+
 See also: [al_convert_bitmap], [al_create_bitmap]
 
 ### API: al_destroy_bitmap

--- a/docs/src/refman/haptic.txt
+++ b/docs/src/refman/haptic.txt
@@ -19,7 +19,7 @@ force feedback or vibration.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 See also: [al_get_haptic_from_joystick]
@@ -54,7 +54,7 @@ to determine what kind of haptic effect should be played.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 See also: [al_get_haptic_capabilities], [ALLEGRO_HAPTIC_EFFECT]
@@ -255,7 +255,7 @@ data
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: ALLEGRO_HAPTIC_EFFECT_ID
@@ -266,7 +266,7 @@ by the users of the Allegro library.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_install_haptic
@@ -287,7 +287,7 @@ call [al_uninstall_haptic] before closing the display, and
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_uninstall_haptic
@@ -301,7 +301,7 @@ call [al_uninstall_haptic] before closing the display, and
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_haptic_installed
@@ -310,7 +310,7 @@ Returns true if the haptic device subsystem is installed, false if not.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_mouse_haptic
@@ -319,7 +319,7 @@ Returns true if the mouse has haptic capabilities, false if not.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_keyboard_haptic
@@ -328,7 +328,7 @@ Returns true if the keyboard has haptic capabilities, false if not.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_display_haptic
@@ -339,7 +339,7 @@ a phone or a tablet.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_joystick_haptic
@@ -348,7 +348,7 @@ Returns true if the joystick has haptic capabilities, false if not.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_touch_input_haptic
@@ -357,7 +357,7 @@ Returns true if the touch input device has haptic capabilities, false if not.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_from_mouse
@@ -367,7 +367,7 @@ handle.  Otherwise returns NULL.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_from_keyboard
@@ -377,7 +377,7 @@ handle.  Otherwise returns NULL.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_from_display
@@ -387,7 +387,7 @@ handle.  Otherwise returns NULL.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_from_joystick
@@ -399,7 +399,7 @@ the old haptic device must be released using [al_release_haptic].
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_from_touch_input
@@ -409,7 +409,7 @@ haptic device handle. Otherwise returns NULL.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_release_haptic
@@ -426,7 +426,7 @@ failure in the driver.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_haptic_active
@@ -435,7 +435,7 @@ Returns true if the haptic device can currently be used, false if not.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_capabilities
@@ -445,7 +445,7 @@ if set, indicate that the haptic device supports the given feature.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_haptic_capable
@@ -456,7 +456,7 @@ The query parameter must be one of the values of [ALLEGRO_HAPTIC_CONSTANTS].
 
 Since: 5.1.9
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 See also: [al_get_haptic_capabilities]
@@ -473,7 +473,7 @@ effects will be played without any gain influence.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_gain
@@ -488,7 +488,7 @@ gain influence.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_set_haptic_autocenter
@@ -510,7 +510,7 @@ function returns false.
 
 Since: 5.1.9
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_autocenter
@@ -531,7 +531,7 @@ set. If not, this function returns 0.0.
 
 Since: 5.1.9
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_max_haptic_effects
@@ -542,7 +542,7 @@ device itself. This may return a value as low as 1.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_haptic_effect_ok
@@ -552,7 +552,7 @@ if not.  The haptic effect must have been filled in completely and correctly.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_upload_haptic_effect
@@ -571,7 +571,7 @@ taken to pass in a different [ALLEGRO_HAPTIC_EFFECT_ID].
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_play_haptic_effect
@@ -589,7 +589,7 @@ not.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_upload_and_play_haptic_effect
@@ -606,7 +606,7 @@ effects on the haptic devicefrom running out.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 See also: [al_upload_haptic_effect], [al_play_haptic_effect]
@@ -619,7 +619,7 @@ valid [ALLEGRO_HAPTIC_EFFECT_ID] obtained from [al_upload_haptic_effect],
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_haptic_effect_playing
@@ -632,7 +632,7 @@ from [al_upload_haptic_effect], [al_upload_and_play_haptic_effect] or
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_effect_duration
@@ -643,7 +643,7 @@ before using this function.
 
 Since: 5.1.9
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_release_haptic_effect
@@ -665,7 +665,7 @@ to release the effect by the driver.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_rumble_haptic
@@ -689,5 +689,5 @@ effects on the haptic device from running out.
 
 Since: 5.1.8
 
-> *Unstable:* Perhaps could be simplified due to limited support for all the
+> *[Unstable API]:* Perhaps could be simplified due to limited support for all the
 exposed features across all of the platforms. Awaiting feedback from users.

--- a/docs/src/refman/haptic.txt
+++ b/docs/src/refman/haptic.txt
@@ -19,6 +19,9 @@ force feedback or vibration.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 See also: [al_get_haptic_from_joystick]
 
 ## API: ALLEGRO_HAPTIC_CONSTANTS
@@ -50,6 +53,9 @@ to determine what kind of haptic effect should be played.
 * ALLEGRO_HAPTIC_AUTOCENTER
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 See also: [al_get_haptic_capabilities], [ALLEGRO_HAPTIC_EFFECT]
 
@@ -249,6 +255,9 @@ data
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: ALLEGRO_HAPTIC_EFFECT_ID
 
 This struct is used as a handle to control playback of a haptic effect and should
@@ -256,6 +265,9 @@ be considered opaque. Its implementation is visible merely to allow allocation
 by the users of the Allegro library.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_install_haptic
 
@@ -275,6 +287,9 @@ call [al_uninstall_haptic] before closing the display, and
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_uninstall_haptic
 
 Uninstalls the haptic device subsystem. This is useful since on some
@@ -286,11 +301,17 @@ call [al_uninstall_haptic] before closing the display, and
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_is_haptic_installed
 
 Returns true if the haptic device subsystem is installed, false if not.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_mouse_haptic
 
@@ -298,11 +319,17 @@ Returns true if the mouse has haptic capabilities, false if not.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_is_keyboard_haptic
 
 Returns true if the keyboard has haptic capabilities, false if not.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_display_haptic
 
@@ -312,17 +339,26 @@ a phone or a tablet.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_is_joystick_haptic
 
 Returns true if the joystick has haptic capabilities, false if not.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_is_touch_input_haptic
 
 Returns true if the touch input device has haptic capabilities, false if not.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_from_mouse
 
@@ -331,6 +367,9 @@ handle.  Otherwise returns NULL.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_get_haptic_from_keyboard
 
 If the keyboard has haptic capabilities, returns the associated haptic device
@@ -338,12 +377,18 @@ handle.  Otherwise returns NULL.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_get_haptic_from_display
 
 If the display has haptic capabilities, returns the associated haptic device
 handle.  Otherwise returns NULL.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_from_joystick
 
@@ -354,12 +399,18 @@ the old haptic device must be released using [al_release_haptic].
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_get_haptic_from_touch_input
 
 If the touch input device has haptic capabilities, returns the associated
 haptic device handle. Otherwise returns NULL.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_release_haptic
 
@@ -375,11 +426,17 @@ failure in the driver.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_is_haptic_active
 
 Returns true if the haptic device can currently be used, false if not.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_haptic_capabilities
 
@@ -388,6 +445,9 @@ if set, indicate that the haptic device supports the given feature.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_is_haptic_capable
 
 Returns true if the haptic device supports the feature indicated by
@@ -395,6 +455,9 @@ the query parameter, false if the feature is not supported.
 The query parameter must be one of the values of [ALLEGRO_HAPTIC_CONSTANTS]. 
 
 Since: 5.1.9
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 See also: [al_get_haptic_capabilities]
 
@@ -410,6 +473,9 @@ effects will be played without any gain influence.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_get_haptic_gain
 
 Returns the current gain of the device. Gain is much like volume for sound,
@@ -421,6 +487,9 @@ function will simply return 1.0 and all effects will be played without any
 gain influence.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_set_haptic_autocenter
 
@@ -441,6 +510,9 @@ function returns false.
 
 Since: 5.1.9
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_get_haptic_autocenter
 
 Returns the current automatic centering intensity of the device. 
@@ -459,6 +531,8 @@ set. If not, this function returns 0.0.
 
 Since: 5.1.9
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_get_max_haptic_effects
 
@@ -468,12 +542,18 @@ device itself. This may return a value as low as 1.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_is_haptic_effect_ok
 
 Returns true if the haptic device can play the haptic effect as given, false
 if not.  The haptic effect must have been filled in completely and correctly.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_upload_haptic_effect
 
@@ -489,8 +569,10 @@ be uploaded to the device at the same time.
 The same haptic effect can be uploaded several times, as long as care is
 taken to pass in a different [ALLEGRO_HAPTIC_EFFECT_ID].
 
-
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_play_haptic_effect
 
@@ -507,6 +589,9 @@ not.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_upload_and_play_haptic_effect
 
 Uploads the haptic effect to the device and starts playback immediately. Returns
@@ -521,6 +606,9 @@ effects on the haptic devicefrom running out.
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 See also: [al_upload_haptic_effect], [al_play_haptic_effect]
 
 ## API: al_stop_haptic_effect
@@ -530,6 +618,9 @@ valid [ALLEGRO_HAPTIC_EFFECT_ID] obtained from [al_upload_haptic_effect],
 [al_upload_and_play_haptic_effect] or [al_rumble_haptic].
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_is_haptic_effect_playing
 
@@ -541,6 +632,9 @@ from [al_upload_haptic_effect], [al_upload_and_play_haptic_effect] or
 
 Since: 5.1.8
 
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
+
 ## API: al_get_haptic_effect_duration
 
 Returns the estimated duration in seconds of a single loop of the given haptic 
@@ -548,6 +642,9 @@ effect. The effect's `effect.replay` must have been filled in correctly
 before using this function.
 
 Since: 5.1.9
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_release_haptic_effect
 
@@ -567,6 +664,9 @@ reason such as when NULL is passed, the effect is not active or failure
 to release the effect by the driver.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.
 
 ## API: al_rumble_haptic
 
@@ -588,3 +688,6 @@ when the effect isn't needed anymore, to prevent the amount of available
 effects on the haptic device from running out.
 
 Since: 5.1.8
+
+> *Unstable:* Perhaps could be simplified due to limited support for all the
+exposed features across all of the platforms. Awaiting feedback from users.

--- a/docs/src/refman/index.txt
+++ b/docs/src/refman/index.txt
@@ -1,15 +1,11 @@
-% Allegro 5.1 reference manual
+% Allegro 5 reference manual
 <!-- This file is only used for the HTML output. -->
 <!-- If you change this you should change inc.a as well. -->
 <!-- Don't use #-sectioning in this file. -->
 
->   *Note:* the Allegro 5.1 branch is *unstable*.
-    Any API additions since the 5.0 branch are subject to change, tinkering,
-    or outright removal at any time.
-
 * [Getting started guide](getting_started.html)
 
-API
+Core API
 ===
 
 * [Configuration files](config.html)

--- a/docs/src/refman/native_dialog.txt
+++ b/docs/src/refman/native_dialog.txt
@@ -524,7 +524,7 @@ Returns -1 if the id is invalid.
 
 Since: 5.1.0
 
-> *Unstable:* Redundant with `al_get/set_menu_item_flags`.
+> *[Unstable API]:* Redundant with `al_get/set_menu_item_flags`.
 
 See also: [al_get_menu_item_flags], [al_set_menu_item_flags]
 

--- a/docs/src/refman/native_dialog.txt
+++ b/docs/src/refman/native_dialog.txt
@@ -524,6 +524,8 @@ Returns -1 if the id is invalid.
 
 Since: 5.1.0
 
+> *Unstable:* Redundant with `al_get/set_menu_item_flags`.
+
 See also: [al_get_menu_item_flags], [al_set_menu_item_flags]
 
 ### API: al_get_menu_item_icon

--- a/docs/src/refman/system.txt
+++ b/docs/src/refman/system.txt
@@ -23,6 +23,14 @@ be used. A common reason for this function to fail is when the version of
 Allegro you compiled your game against is not compatible with the version of
 the shared libraries that were found on the system.
 
+The version compatibility check works as follows. Let A = xa.ya.za.* be the
+version of Allegro you  compiled with, and B = xb.yb.zb.* be the version of
+Allegro found in the system shared library.
+
+If you defined `ALLEGRO_UNSTABLE` before including Allegro headers, then
+version A is compatible with B only if xa.ya.za = xb.yb.zb. Otherwise, A is
+compatible with B only if xa.ya = xb.yb.
+
 See also: [al_init]
 
 ## API: al_init

--- a/docs/src/refman/touch.txt
+++ b/docs/src/refman/touch.txt
@@ -67,6 +67,9 @@ ALLEGRO_MOUSE_EMULATION_5_0_x
 
 Since: 5.1.0
 
+> *Unstable:* Seems of limited value, as touch input tends to have different
+semantics compared to mouse input.
+
 ## API: al_install_touch_input
 
 Install a touch input driver, returning true if successful.  If a
@@ -106,6 +109,9 @@ Sets the kind of mouse emulation for the touch input subsystem to perform.
 
 Since: 5.1.0
 
+> *Unstable:* Seems of limited value, as touch input tends to have different
+semantics compared to mouse input.
+
 See also: [ALLEGRO_MOUSE_EMULATION_MODE], [al_get_mouse_emulation_mode].
 
 ## API: al_get_mouse_emulation_mode
@@ -114,6 +120,9 @@ Returns the kind of mouse emulation which the touch input subsystem is
 set to perform.
 
 Since: 5.1.0
+
+> *Unstable:* Seems of limited value, as touch input tends to have different
+semantics compared to mouse input.
 
 See also: [ALLEGRO_MOUSE_EMULATION_MODE], [al_set_mouse_emulation_mode].
 
@@ -135,3 +144,6 @@ that are based on touch events.
 See also: [ALLEGRO_EVENT_SOURCE], [al_register_event_source]
 
 Since: 5.1.0
+
+> *Unstable:* Seems of limited value, as touch input tends to have different
+semantics compared to mouse input.

--- a/docs/src/refman/touch.txt
+++ b/docs/src/refman/touch.txt
@@ -67,7 +67,7 @@ ALLEGRO_MOUSE_EMULATION_5_0_x
 
 Since: 5.1.0
 
-> *Unstable:* Seems of limited value, as touch input tends to have different
+> *[Unstable API]:* Seems of limited value, as touch input tends to have different
 semantics compared to mouse input.
 
 ## API: al_install_touch_input
@@ -109,7 +109,7 @@ Sets the kind of mouse emulation for the touch input subsystem to perform.
 
 Since: 5.1.0
 
-> *Unstable:* Seems of limited value, as touch input tends to have different
+> *[Unstable API]:* Seems of limited value, as touch input tends to have different
 semantics compared to mouse input.
 
 See also: [ALLEGRO_MOUSE_EMULATION_MODE], [al_get_mouse_emulation_mode].
@@ -121,7 +121,7 @@ set to perform.
 
 Since: 5.1.0
 
-> *Unstable:* Seems of limited value, as touch input tends to have different
+> *[Unstable API]:* Seems of limited value, as touch input tends to have different
 semantics compared to mouse input.
 
 See also: [ALLEGRO_MOUSE_EMULATION_MODE], [al_set_mouse_emulation_mode].
@@ -145,5 +145,5 @@ See also: [ALLEGRO_EVENT_SOURCE], [al_register_event_source]
 
 Since: 5.1.0
 
-> *Unstable:* Seems of limited value, as touch input tends to have different
+> *[Unstable API]:* Seems of limited value, as touch input tends to have different
 semantics compared to mouse input.

--- a/examples/ex_blend.c
+++ b/examples/ex_blend.c
@@ -1,5 +1,7 @@
 /* An example demonstrating different blending modes.
  */
+
+#define ALLEGRO_UNSTABLE
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_font.h>
 #include <allegro5/allegro_image.h>

--- a/examples/ex_haiku.c
+++ b/examples/ex_haiku.c
@@ -10,6 +10,7 @@
  * the nice title sequence, text labels and mouse cursors.
  */
 
+#define ALLEGRO_UNSTABLE
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_audio.h>
 #include <allegro5/allegro_acodec.h>

--- a/examples/ex_haptic.c
+++ b/examples/ex_haptic.c
@@ -4,6 +4,7 @@
  *    This program tests haptic effects.
  */
 
+#define ALLEGRO_UNSTABLE
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_primitives.h>
 

--- a/examples/ex_haptic2.cpp
+++ b/examples/ex_haptic2.cpp
@@ -6,6 +6,7 @@
 
 #include <string>
 
+#define ALLEGRO_UNSTABLE
 #include "allegro5/allegro.h"
 #include "allegro5/allegro_font.h"
 #include "allegro5/allegro_primitives.h"

--- a/examples/ex_lockbitmap.c
+++ b/examples/ex_lockbitmap.c
@@ -4,6 +4,7 @@
  *       From left to right you should see Red, Green, Blue gradients.
  */
 
+#define ALLEGRO_UNSTABLE
 #include "allegro5/allegro.h"
 
 #include "common.c"

--- a/examples/ex_menu.c
+++ b/examples/ex_menu.c
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
                }
             }
             else if (event.user.data1 == DYNAMIC_CHECKBOX_ID) {
-               al_toggle_menu_item_flags(menu, DYNAMIC_DISABLED_ID, ALLEGRO_MENU_ITEM_DISABLED);               
+               al_set_menu_item_flags(menu, DYNAMIC_DISABLED_ID, al_get_menu_item_flags(menu, DYNAMIC_DISABLED_ID) ^ ALLEGRO_MENU_ITEM_DISABLED);
                al_set_menu_item_caption(menu, DYNAMIC_DISABLED_ID, 
                   (al_get_menu_item_flags(menu, DYNAMIC_DISABLED_ID) & ALLEGRO_MENU_ITEM_DISABLED) ?
                   "&Disabled" : "&Enabled");               

--- a/examples/ex_native_filechooser.c
+++ b/examples/ex_native_filechooser.c
@@ -6,6 +6,7 @@
  *    source to communicate back to the main program.
  */
 
+#define ALLEGRO_UNSTABLE
 #include <stdio.h>
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_native_dialog.h>

--- a/examples/ex_polygon.c
+++ b/examples/ex_polygon.c
@@ -4,6 +4,7 @@
  *    This program tests the polygon routines in the primitives addon.
  */
 
+#define ALLEGRO_UNSTABLE
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_font.h>
 #include <allegro5/allegro_primitives.h>

--- a/examples/ex_prim_shader.c
+++ b/examples/ex_prim_shader.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <math.h>
 
+#define ALLEGRO_UNSTABLE
 #include "allegro5/allegro.h"
 #include "allegro5/allegro_primitives.h"
 

--- a/examples/ex_record.c
+++ b/examples/ex_record.c
@@ -13,7 +13,8 @@
  * sample counts. However, when using things like memcpy() or fwrite(), you 
  * will be working with bytes.
  */
- 
+
+#define ALLEGRO_UNSTABLE
 #include "allegro5/allegro.h"
 #include "allegro5/allegro_audio.h"
 #include "allegro5/allegro_primitives.h"

--- a/examples/ex_record_name.c
+++ b/examples/ex_record_name.c
@@ -5,6 +5,7 @@
  * play it back.
  */
 
+#define ALLEGRO_UNSTABLE
 #include "allegro5/allegro.h"
 #include "allegro5/allegro_audio.h"
 #include "allegro5/allegro_acodec.h"

--- a/examples/nihgui.cpp
+++ b/examples/nihgui.cpp
@@ -7,8 +7,10 @@
 #include <iostream>
 #include <string>
 #include <algorithm>
-#include "allegro5/allegro.h"
-#include "allegro5/allegro_font.h"
+
+#define ALLEGRO_UNSTABLE
+#include <allegro5/allegro.h>
+#include <allegro5/allegro_font.h>
 #include <allegro5/allegro_primitives.h>
 
 #include "nihgui.hpp"

--- a/include/allegro5/base.h
+++ b/include/allegro5/base.h
@@ -57,6 +57,12 @@
 #define ALLEGRO_SUB_VERSION      1
 #define ALLEGRO_WIP_VERSION      14
 
+#ifdef ALLEGRO_UNSTABLE
+   #define ALLEGRO_UNSTABLE_BIT  1 << 31
+#else
+   #define ALLEGRO_UNSTABLE_BIT  0
+#endif
+
 /* Not sure we need it, but since ALLEGRO_VERSION_STR contains it:
  * 0 = GIT
  * 1 = first release
@@ -72,7 +78,8 @@
 #define ALLEGRO_DATE             20160124    /* yyyymmdd */
 #define ALLEGRO_VERSION_INT \
     ((ALLEGRO_VERSION << 24) | (ALLEGRO_SUB_VERSION << 16) | \
-    (ALLEGRO_WIP_VERSION << 8) | ALLEGRO_RELEASE_NUMBER)
+    (ALLEGRO_WIP_VERSION << 8) | ALLEGRO_RELEASE_NUMBER | \
+    ALLEGRO_UNSTABLE_BIT)
 
 AL_FUNC(uint32_t, al_get_allegro_version, (void));
 AL_FUNC(int, al_run_main, (int argc, char **argv, int (*)(int, char **)));

--- a/include/allegro5/bitmap.h
+++ b/include/allegro5/bitmap.h
@@ -69,7 +69,9 @@ AL_FUNC(void, al_reparent_bitmap, (ALLEGRO_BITMAP *bitmap,
 /* Miscellaneous */
 AL_FUNC(ALLEGRO_BITMAP *, al_clone_bitmap, (ALLEGRO_BITMAP *bitmap));
 AL_FUNC(void, al_convert_bitmap, (ALLEGRO_BITMAP *bitmap));
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 AL_FUNC(void, al_convert_bitmaps, (void));
+#endif
 
 #ifdef __cplusplus
    }

--- a/include/allegro5/haptic.h
+++ b/include/allegro5/haptic.h
@@ -30,6 +30,7 @@
    extern "C" {
 #endif
 
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 
 /* Enum: ALLEGRO_HAPTIC_CONSTANTS
  */
@@ -235,6 +236,7 @@ AL_FUNC(bool, al_release_haptic_effect, (ALLEGRO_HAPTIC_EFFECT_ID *));
 AL_FUNC(double, al_get_haptic_effect_duration, (ALLEGRO_HAPTIC_EFFECT *));
 AL_FUNC(bool, al_rumble_haptic, (ALLEGRO_HAPTIC *, double, double, ALLEGRO_HAPTIC_EFFECT_ID *));
 
+#endif
 
 #ifdef __cplusplus
    }

--- a/include/allegro5/internal/aintern_haptic.h
+++ b/include/allegro5/internal/aintern_haptic.h
@@ -11,6 +11,7 @@ extern "C"
 {
 #endif
 
+#if defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 
 typedef struct ALLEGRO_HAPTIC_DRIVER
 {
@@ -82,7 +83,12 @@ extern const _AL_DRIVER_INFO _al_haptic_driver_list[];
    { 0, NULL, false }                                                \
    };
 
+#else
 
+/* Forward declare it for ALLEGRO_SYSTEM_INTERFACE. */
+typedef struct ALLEGRO_HAPTIC_DRIVER ALLEGRO_HAPTIC_DRIVER;
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/allegro5/touch_input.h
+++ b/include/allegro5/touch_input.h
@@ -65,6 +65,7 @@ struct ALLEGRO_TOUCH_INPUT_STATE
 };
 
 
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 /* Enum: ALLEGRO_MOUSE_EMULATION_MODE
  */
 typedef enum ALLEGRO_MOUSE_EMULATION_MODE
@@ -75,19 +76,20 @@ typedef enum ALLEGRO_MOUSE_EMULATION_MODE
    ALLEGRO_MOUSE_EMULATION_EXCLUSIVE,
    ALLEGRO_MOUSE_EMULATION_5_0_x
 } ALLEGRO_MOUSE_EMULATION_MODE;
+#endif
 
 
 AL_FUNC(bool,           al_is_touch_input_installed,     (void));
 AL_FUNC(bool,           al_install_touch_input,          (void));
 AL_FUNC(void,           al_uninstall_touch_input,        (void));
 AL_FUNC(void,           al_get_touch_input_state,        (ALLEGRO_TOUCH_INPUT_STATE *ret_state));
+AL_FUNC(ALLEGRO_EVENT_SOURCE *, al_get_touch_input_event_source, (void));
 
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 AL_FUNC(void,           al_set_mouse_emulation_mode,     (int mode));
 AL_FUNC(int,            al_get_mouse_emulation_mode,     (void));
-
-AL_FUNC(ALLEGRO_EVENT_SOURCE *, al_get_touch_input_event_source, (void));
 AL_FUNC(ALLEGRO_EVENT_SOURCE *, al_get_touch_input_mouse_emulation_event_source, (void));
-
+#endif
 
 #ifdef __cplusplus
    }

--- a/src/system.c
+++ b/src/system.c
@@ -166,21 +166,31 @@ static void read_allegro_cfg(void)
  * Let a = xa.ya.za.*
  * Let b = xb.yb.zb.*
  *
- * When ya is odd, a is compatible with b if xa.ya.za = xb.yb.zb.
- * When ya is even, a is compatible with b if xa.ya = xb.yb.
+ * When a has the unstable bit, a is compatible with b if xa.ya.za = xb.yb.zb.
+ * Otherwise, a is compatible with b if xa.ya = xb.yb.
  *
  * Otherwise a and b are incompatible.
  */
 static bool compatible_versions(int a, int b)
 {
-   if ((a & 0xffff0000) != (b & 0xffff0000)) {
+   int a_unstable = a & (1 << 31);
+
+   int a_major = (a & 0x7f000000) >> 24;
+   int a_sub   = (a & 0x00ff0000) >> 16;
+   int a_wip   = (a & 0x0000ff00) >> 8;
+
+   int b_major = (b & 0x7f000000) >> 24;
+   int b_sub   = (b & 0x00ff0000) >> 16;
+   int b_wip   = (b & 0x0000ff00) >> 8;
+
+   if (a_major != b_major) {
       return false;
    }
-   if (((a & 0x00ff0000) >> 16) & 1) {
-      
-      if ((a & 0x0000ff00) != (b & 0x0000ff00)) {
-         return false;
-      }
+   if (a_unstable && a_wip != b_wip) {
+      return false;
+   }
+   if (a_sub != b_sub) {
+      return false;
    }
    return true;
 }


### PR DESCRIPTION
This illustrates the ideas I had for combining unstable and stable API in a stable release. For illustration purposes I made the audio recording API unstable (since it's the only thing that came to mind as being obviously half-baked), but this doesn't necessarily mean that it truly has to be marked as such for the 5.2 release. The general idea is as follows:

From the user's point of view, the unstable API will not be declared by Allegro headers unless they define `ALLEGRO_UNSTABLE` macro. When that happens, in addition to revealing the unstable API, the version compatibility check by `al_install_system` will get more stringent in that the wip versions will have to match (i.e. 5.2.0 is only compatible with 5.2.0 if you're using the unstable API).

From our point of view, we will wrap the unstable API with this:

```c
#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_*_SRC)
```

The first term is obvious. `ALLEGRO_INTERNAL_UNSTABLE` is for the case when you need to use unstable API between addons. It's there to not accidentally set the unstable bit (see below). The third term is so that when Allegro is compiled, all API is exported for shared libraries.

On the documentation side of things, I propose adding a little note explaining that an API is unstable and a short explanation as to why.

<s>The aforementioned more stringent version check is implemented as follows. When `ALLEGRO_UNSTABLE` is defined, Allegro's minor version goes from even to the next odd version (i.e. very similar to how things are right now). I.e. if you get a 5.2.0 shared library, but declare `ALLEGRO_UNSTABLE`, your library version will actually be 5.3.0.</s>

<s>I did it this way for a few reasons. First, `al_install_system` only accepts a single integer, and it documents it to be `ALLEGRO_VERSION_INT`. We also document the construction of `ALLEGRO_VERSION_INT`, so we can't really change it (e.g. by adding an unstable bit or something). Bumping the sub version by 1 seemed like an easy way to do it. I admit, it's a bit of a hack.</s>

<s>Since that the above behaviour is a change from what is done now I also bumped the version to 5.2.0.</s>

The aforementioned more stringent version check is implemented as follows. When `ALLEGRO_UNSTABLE` is defined, the MSB of ALLEGRO_VERSION_INT is set. When passed to `al_install_system`, it checks for that bit, and then performs the more stringent check accordingly.

What do you think about all this?