### PR TITLE
is_event_source_registered()

### DIFF
--- a/docs/src/refman/events.txt
+++ b/docs/src/refman/events.txt
@@ -676,6 +676,8 @@ Return true if the event source is registered.
 
 See also: [al_register_event_source]
 
+Since: 5.1.14
+
 ## API: al_pause_event_queue
 
 Pause or resume accepting new events into the event queue (to resume, pass false

--- a/docs/src/refman/events.txt
+++ b/docs/src/refman/events.txt
@@ -670,6 +670,12 @@ source, they will no longer be in the queue after this call.
 
 See also: [al_register_event_source]
 
+## API: al_is_event_source_registered
+
+Return true if the event source is registered.
+
+See also: [al_register_event_source]
+
 ## API: al_pause_event_queue
 
 Pause or resume accepting new events into the event queue (to resume, pass false

--- a/include/allegro5/events.h
+++ b/include/allegro5/events.h
@@ -244,6 +244,8 @@ typedef struct ALLEGRO_EVENT_QUEUE ALLEGRO_EVENT_QUEUE;
 
 AL_FUNC(ALLEGRO_EVENT_QUEUE*, al_create_event_queue, (void));
 AL_FUNC(void, al_destroy_event_queue, (ALLEGRO_EVENT_QUEUE*));
+AL_FUNC(bool, al_is_event_source_registered, (ALLEGRO_EVENT_QUEUE *, 
+         ALLEGRO_EVENT_SOURCE *));
 AL_FUNC(void, al_register_event_source, (ALLEGRO_EVENT_QUEUE*, ALLEGRO_EVENT_SOURCE*));
 AL_FUNC(void, al_unregister_event_source, (ALLEGRO_EVENT_QUEUE*, ALLEGRO_EVENT_SOURCE*));
 AL_FUNC(void, al_pause_event_queue, (ALLEGRO_EVENT_QUEUE*, bool));

--- a/src/events.c
+++ b/src/events.c
@@ -141,6 +141,19 @@ void al_destroy_event_queue(ALLEGRO_EVENT_QUEUE *queue)
 }
 
 
+/* Function: al_is_event_source_registered
+ */
+bool al_is_event_source_registered(ALLEGRO_EVENT_QUEUE *queue, 
+      ALLEGRO_EVENT_SOURCE *source)
+{
+   ASSERT(queue);
+   ASSERT(source);
+
+   if(_al_vector_contains(&queue->sources, &source))
+      return true;
+   else
+      return false;
+}
 
 /* Function: al_register_event_source
  */


### PR DESCRIPTION
Currently there is no way of knowing which event sources are registered to an event queue. 
Is this acceptable?