### PR TITLE
DPI awareness on Windows

### DIFF
--- a/README_windows.txt
+++ b/README_windows.txt
@@ -1,0 +1,22 @@
+Windows-specific notes
+======================
+
+DPI Awareness
+-------------
+
+By default, apps created with Allegro are marked as DPI aware, and are not
+scaled by the OS. This is mostly transparent on your end, the only complication
+comes when the DPI changes on the fly (e.g. your app's window gets moved
+between displays with different DPIs):
+
+- If the ALLEGRO_DISPLAY was created with the ALLEGRO_RESIZABLE flag it will
+  send an ALLEGRO_DISPLAY_RESIZE event. This will have the effect of your app's
+  window remaining visually the same, while the display size in pixels will
+  increase or decrease. This is the recommended situation.
+
+- If the ALLEGRO_DISPLAY was not created with the ALLEGRO_RESIZABLE flag, then
+  the display size in pixels will remain the same, but the app's window will
+  appear to grow or shrink.
+
+If you for some reason want to opt out of DPI-awareness, utilize the
+application manifests to specify that your app is not DPI-aware.

--- a/src/win/wsystem.c
+++ b/src/win/wsystem.c
@@ -168,11 +168,11 @@ static void set_dpi_awareness(void)
    }
 
    /* SetProcessDPIAware is an older API that corresponds to system dpi
-    * awareness above. This is the only option pre-8.1 systems. */
+    * awareness above. This is the only option on pre-8.1 systems. */
    if (!dpi_awareness_set && user32_dll) {
       typedef BOOL (WINAPI *SetProcessDPIAwarePROC)(void);
       SetProcessDPIAwarePROC imp_SetProcessDPIAware =
-         (SetProcessDPIAwarePROC)GetProcAddress(shcore_dll, "SetProcessDPIAware");
+         (SetProcessDPIAwarePROC)GetProcAddress(user32_dll, "SetProcessDPIAware");
       if (imp_SetProcessDPIAware) {
          imp_SetProcessDPIAware();
       }

--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -54,6 +54,10 @@ UINT _al_win_msg_call_proc = 0;
 UINT _al_win_msg_suicide = 0;
 
 
+#ifndef WM_DPICHANGED
+#define WM_DPICHANGED 0x02E0
+#endif
+
 
 static void display_flags_to_window_styles(int flags,
    DWORD *style, DWORD *ex_style)
@@ -910,6 +914,21 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
             win_display->can_acknowledge = true;
          }
          break;
+      case WM_DPICHANGED:
+        if ((d->flags & ALLEGRO_RESIZABLE) && !(d->flags & ALLEGRO_FULLSCREEN)) {
+            RECT* rect = (RECT*)lParam;
+            // XXX: This doesn't seem to actually move the window... why?
+            SetWindowPos(
+               hWnd,
+               0,
+               rect->left,
+               rect->top,
+               rect->right - rect->left,
+               rect->bottom - rect->top,
+               SWP_NOZORDER | SWP_NOACTIVATE);
+            win_generate_resize_event(win_display);
+        }
+        break;
    }
 
    return DefWindowProc(hWnd,message,wParam,lParam);


### PR DESCRIPTION
This marks Allegro apps DPI aware by default (implementing a workabout for issue #574) and adds handling for the DPI change events.

Fixes Issue #576 