### PR TITLE
Add backspace input to ex_logo

### DIFF
--- a/examples/ex_logo.c
+++ b/examples/ex_logo.c
@@ -475,7 +475,17 @@ int main(int argc, char **argv)
          else {
             int c = event.keyboard.unichar;
             if (editing) {
-               if (c >= 32) {
+               if (event.keyboard.keycode == ALLEGRO_KEY_BACKSPACE) {
+                  if (cursor > 0) {
+                     ALLEGRO_USTR *u = al_ustr_new(param_values[selection]);
+                     cursor--;
+                     al_ustr_remove_chr(u, cursor);
+                     strncpy(param_values[selection], al_cstr(u),
+                        sizeof param_values[selection]);
+                     al_ustr_free(u);
+                  }
+               }
+               else if (c >= 32) {
                   ALLEGRO_USTR *u = al_ustr_new(param_values[selection]);
                   al_ustr_set_chr(u, cursor, c);
                   cursor++;


### PR DESCRIPTION
### Problem

When editing the text fields in `examples/ex_logo` program, you can't use the backspace to delete characters.

![beforepr](https://cloud.githubusercontent.com/assets/772949/13903256/bf429224-ee49-11e5-89ca-662b2a9e6591.gif)

### Solution

Handle backspace when in the text fields.

![afterpr](https://cloud.githubusercontent.com/assets/772949/13903257/c2f11ddc-ee49-11e5-8db1-0e75e4e3a94a.gif)
