### PR TITLE
Add .gitignore and ignore build/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+# ignore the build/ directory
+build/

--- a/README_make.txt
+++ b/README_make.txt
@@ -10,8 +10,8 @@ Linux, and also Mac OS X and MinGW.
 2. Create a build directory under the Allegro directory and go there.
 
         cd /path/to/allegro
-        mkdir Build
-        cd Build
+        mkdir build
+        cd build
 
 3. Run `cmake` with whatever options you want.  See README_cmake.txt
 for details about options you can set.


### PR DESCRIPTION
Welcome our Git overlords with a nice `.gitignore` file.

In the file, we'll ignore the `build/` directory and all its contents that are created during the recommended build process. (Incidentally, the uppercase `Build/` is written in `README_make.txt` though I can't seem to find it anywhere else, docs, wiki or otherwise. So I fixed that here too.)