### PR TITLE
Add necessary includes for top level headers to be used in isolation.

### DIFF
--- a/addons/image/allegro5/allegro_image.h
+++ b/addons/image/allegro5/allegro_image.h
@@ -1,6 +1,8 @@
 #ifndef __al_included_allegro5_allegro_image_h
 #define __al_included_allegro5_allegro_image_h
 
+#include "allegro5/base.h"
+
 #if (defined ALLEGRO_MINGW32) || (defined ALLEGRO_MSVC) || (defined ALLEGRO_BCC32)
    #ifndef ALLEGRO_STATICLINK
       #ifdef ALLEGRO_IIO_SRC

--- a/include/allegro5/allegro_opengl.h
+++ b/include/allegro5/allegro_opengl.h
@@ -22,6 +22,8 @@
    extern "C" {
 #endif
 
+#include <stdint.h>
+
 #if defined(ALLEGRO_WINDOWS)
 #include <windows.h>
 #endif
@@ -110,6 +112,9 @@
 #include <EGL/eglext.h>
 #endif
 
+#include "allegro5/bitmap.h"
+#include "allegro5/display.h"
+#include "allegro5/shader.h"
 #include "allegro5/opengl/gl_ext.h"
 
 #ifdef ALLEGRO_WINDOWS

--- a/include/allegro5/allegro_opengl.h
+++ b/include/allegro5/allegro_opengl.h
@@ -22,8 +22,6 @@
    extern "C" {
 #endif
 
-#include <stdint.h>
-
 #if defined(ALLEGRO_WINDOWS)
 #include <windows.h>
 #endif

--- a/include/allegro5/allegro_x.h
+++ b/include/allegro5/allegro_x.h
@@ -19,6 +19,9 @@
 
 #include <X11/Xlib.h>
 
+#include "allegro5/base.h"
+#include "allegro5/display.h"
+
 #ifdef __cplusplus
    extern "C" {
 #endif

--- a/include/allegro5/blender.h
+++ b/include/allegro5/blender.h
@@ -1,6 +1,9 @@
 #ifndef __al_included_allegro5_blender_h
 #define __al_included_allegro5_blender_h
 
+#include "allegro5/base.h"
+#include "allegro5/color.h"
+
 #ifdef __cplusplus
    extern "C" {
 #endif

--- a/include/allegro5/fullscreen_mode.h
+++ b/include/allegro5/fullscreen_mode.h
@@ -1,6 +1,8 @@
 #ifndef __al_included_allegro5_fullscreen_mode_h
 #define __al_included_allegro5_fullscreen_mode_h
 
+#include "allegro5/base.h"
+
 #ifdef __cplusplus
    extern "C" {
 #endif

--- a/include/allegro5/memory.h
+++ b/include/allegro5/memory.h
@@ -16,6 +16,8 @@
 #ifndef __al_included_allegro5_memory_h
 #define __al_included_allegro5_memory_h
 
+#include "allegro5/base.h"
+
 #ifdef __cplusplus
    extern "C" {
 #endif

--- a/include/allegro5/monitor.h
+++ b/include/allegro5/monitor.h
@@ -1,6 +1,8 @@
 #ifndef __al_included_allegro5_monitor_h
 #define __al_included_allegro5_monitor_h
 
+#include "allegro5/base.h"
+
 #ifdef __cplusplus
    extern "C" {
 #endif

--- a/include/allegro5/render_state.h
+++ b/include/allegro5/render_state.h
@@ -1,6 +1,8 @@
 #ifndef __al_included_allegro5_render_state_h
 #define __al_included_allegro5_render_state_h
 
+#include "allegro5/base.h"
+
 #ifdef __cplusplus
    extern "C" {
 #endif

--- a/include/allegro5/timer.h
+++ b/include/allegro5/timer.h
@@ -17,6 +17,7 @@
 #define __al_included_allegro5_timer_h
 
 #include "allegro5/base.h"
+#include "allegro5/events.h"
 
 #ifdef __cplusplus
    extern "C" {


### PR DESCRIPTION
I've been playing around with a tool to automatically create bindings for allegro. The tool runs the C preprocessor on each of the top-level headers. However, in some headers this fails because they don't include the necessary dependencies. This pull request makes those dependencies explicit for the headers that I found had problems.