### PR TITLE
Optimize bitmap hold blend mode

### DIFF
--- a/src/opengl/ogl_bitmap.c
+++ b/src/opengl/ogl_bitmap.c
@@ -364,7 +364,7 @@ static void ogl_draw_bitmap_region(ALLEGRO_BITMAP *bitmap,
       }
    }
    if (disp->ogl_extras->opengl_target == target) {
-      if (_al_opengl_set_blender(disp)) {
+      if (disp->cache_enabled || _al_opengl_set_blender(disp)) {
          draw_quad(bitmap, tint, sx, sy, sw, sh, flags);
          return;
       }

--- a/src/opengl/ogl_draw.c
+++ b/src/opengl/ogl_draw.c
@@ -363,6 +363,9 @@ static void ogl_flush_vertex_cache(ALLEGRO_DISPLAY *disp)
    if (disp->num_cache_vertices == 0)
       return;
 
+   if (!_al_opengl_set_blender(disp))
+      return;
+
    if (disp->flags & ALLEGRO_PROGRAMMABLE_PIPELINE) {
 #ifdef ALLEGRO_CFG_OPENGL_PROGRAMMABLE_PIPELINE
       if (disp->ogl_extras->varlocs.use_tex_loc >= 0) {


### PR DESCRIPTION
During a bitmap hold, this changes Allegro to defer the blend mode change until a vertex flush.  On some graphics chipsets (Intel, e.g.), `glBlend*()` calls are very expensive.  This defers them during `al_hold_bitmap_drawing` until the hold is released.  The change should be safe since it's already undefined behavior to change blend modes during `al_hold_bitmap_drawing`.