### PR TITLE
Add an example of using Enet with Allegro.

### DIFF
--- a/cmake/FindENet.cmake
+++ b/cmake/FindENet.cmake
@@ -1,0 +1,29 @@
+# - Find ENet
+# Find the native ENet includes and libraries
+#
+#  ENET_INCLUDE_DIR - where to find ENet headers.
+#  ENET_LIBRARIES   - List of libraries when using libenet.
+#  ENET_FOUND       - True if libenet found.
+
+if(ENET_INCLUDE_DIR)
+    # Already in cache, be silent
+    set(ENET_FIND_QUIETLY TRUE)
+endif(ENET_INCLUDE_DIR)
+
+find_path(ENET_INCLUDE_DIR enet/enet.h)
+
+find_library(ENET_LIBRARY NAMES enet enet_static libenet libenet_static)
+
+# Handle the QUIETLY and REQUIRED arguments and set ENET_FOUND to TRUE if
+# all listed variables are TRUE.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ENET DEFAULT_MSG
+    ENET_INCLUDE_DIR ENET_LIBRARY)
+
+if(ENET_FOUND)
+  set(ENET_LIBRARIES ${ENET_LIBRARY})
+else(ENET_FOUND)
+  set(ENET_LIBRARIES)
+endif(ENET_FOUND)
+
+mark_as_advanced(ENET_INCLUDE_DIR ENET_LIBRARY)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -243,6 +243,14 @@ if(WANT_CURL_EXAMPLE)
     endif(CURL_FOUND)
 endif(WANT_CURL_EXAMPLE)
 
+# The enet example won't compile if the enet library isn't available.
+# This example isn't important so it's disabled by default to prevent problems.
+option(WANT_ENET_EXAMPLE "Build ex_enet example" off)
+if(WANT_ENET_EXAMPLE)
+    example(ex_enet_client -lenet ${PRIM})
+    example(ex_enet_server -lenet)
+endif(WANT_ENET_EXAMPLE)
+
 # example(ex_ogre3d ex_ogre3d.cpp)
 # include_directories(/usr/include/OGRE)
 # target_link_libraries(ex_ogre3d OgreMain)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -243,13 +243,12 @@ if(WANT_CURL_EXAMPLE)
     endif(CURL_FOUND)
 endif(WANT_CURL_EXAMPLE)
 
-# The enet example won't compile if the enet library isn't available.
-# This example isn't important so it's disabled by default to prevent problems.
-option(WANT_ENET_EXAMPLE "Build ex_enet example" off)
-if(WANT_ENET_EXAMPLE)
-    example(ex_enet_client -lenet ${PRIM})
-    example(ex_enet_server -lenet)
-endif(WANT_ENET_EXAMPLE)
+# Only build the enet examples if libenet is installed
+find_package(ENet)
+if(ENET_FOUND)
+    example(ex_enet_client ${ENET_LIBRARIES} ${PRIM})
+    example(ex_enet_server ${ENET_LIBRARIES})
+endif(ENET_FOUND)
 
 # example(ex_ogre3d ex_ogre3d.cpp)
 # include_directories(/usr/include/OGRE)

--- a/examples/enet_common.h
+++ b/examples/enet_common.h
@@ -1,0 +1,48 @@
+#ifndef ENET_COMMON_H
+#define ENET_COMMON_H
+
+#include <allegro5/allegro.h>
+
+#define SCREEN_W 640
+#define SCREEN_H 480
+
+#define FPS 30           // framerate
+#define PLAYER_SIZE 16   // radius of player circle
+#define PLAYER_SPEED 200 // movement rate of player in pixels/sec
+#define MAX_PLAYER_COUNT 32
+#define DEFAULT_PORT 9234
+
+typedef enum
+{
+    PLAYER_JOIN,
+    PLAYER_LEAVE,
+    POSITION_UPDATE,
+} MESSAGE_TYPE;
+
+// message sent from client to server
+typedef struct
+{
+    int x; // requested x movement (-1, 0, or 1)
+    int y; // requested y movement (-1, 0, or 1)
+} ClientMessage;
+
+// message sent from server to client
+typedef struct
+{
+    int player_id;
+    MESSAGE_TYPE type;
+    int x;               // current position (x)
+    int y;               // current position (y)
+    ALLEGRO_COLOR color; // valid when type == PLAYER_JOIN
+} ServerMessage;
+
+// storage for all players
+struct
+{
+   bool active;
+   int x, y;   // current position
+   int dx, dy; // direction of movemnt
+   ALLEGRO_COLOR color;
+} players[MAX_PLAYER_COUNT];
+
+#endif

--- a/examples/ex_enet_client.c
+++ b/examples/ex_enet_client.c
@@ -1,0 +1,249 @@
+/* Simple networked game example using ENet (http://enet.bespin.org/).
+ *
+ * You will need enet installed to run this demo.
+ *
+ * This example is based on http://enet.bespin.org/Tutorial.html
+ *
+ * To try this example, first run ex_enet_server.
+ * Then start multiple instances of ex_enet_client.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <enet/enet.h>
+#include "allegro5/allegro.h"
+#include "allegro5/allegro_primitives.h"
+
+#include "common.c"
+#include "enet_common.h"
+
+static ENetHost* create_client(void)
+{
+   ENetHost * client;
+   client = enet_host_create(NULL /* create a client host */,
+      1 /* only allow 1 outgoing connection */,
+      2 /* allow up 2 channels to be used, 0 and 1 */,
+      57600 / 8 /* 56K modem with 56 Kbps downstream bandwidth */,
+      14400 / 8 /* 56K modem with 14 Kbps upstream bandwidth */);
+
+   if (client == NULL)
+      abort_example("Client: Failed to create the client.\n");
+
+   return client;
+}
+
+static void disconnect_client(ENetHost *client, ENetPeer *server)
+{
+   enet_peer_disconnect(server, 0);
+
+   /* Allow up to 3 seconds for the disconnect to succeed
+    * and drop any packets received packets.
+    */
+   ENetEvent event;
+   while (enet_host_service (client, &event, 3000) > 0) {
+      switch (event.type) {
+         case ENET_EVENT_TYPE_RECEIVE:
+            enet_packet_destroy(event.packet);
+            break;
+         case ENET_EVENT_TYPE_DISCONNECT:
+            puts("Client: Disconnect succeeded.");
+            return;
+         case ENET_EVENT_TYPE_NONE:
+         case ENET_EVENT_TYPE_CONNECT:
+            break;
+      }
+   }
+
+   // failed to disconnect gracefully, force the connection closed
+   enet_peer_reset(server);
+}
+
+static ENetPeer* connect_client(ENetHost *client, int port)
+{
+   ENetAddress address;
+   ENetEvent event;
+   ENetPeer *server;
+   enet_address_set_host(&address, "localhost");
+   address.port = port;
+   /* Initiate the connection, allocating the two channels 0 and 1. */
+   server = enet_host_connect(client, & address, 2, 0);
+   if (server == NULL)
+      abort_example("Client: No available peers for initiating an ENet connection.\n");
+
+   /* Wait up to 5 seconds for the connection attempt to succeed. */
+   if (enet_host_service(client, & event, 5000) > 0 &&
+      event.type == ENET_EVENT_TYPE_CONNECT)
+   {
+      printf("Client: Connected to %x:%u.\n",
+         event.peer->address.host,
+         event.peer->address.port);
+   }
+   else
+   {
+      /* Either the 5 seconds are up or a disconnect event was */
+      /* received. Reset the peer in the event the 5 seconds   */
+      /* had run out without any significant event.            */
+      enet_peer_reset(server);
+      abort_example("Client: Connection to server failed.");
+   }
+
+   return server;
+}
+
+static void send_receive(ENetHost *client)
+{
+   ENetEvent event;
+   ServerMessage *msg;
+
+   // Check if we have any queued incoming messages, but do not wait otherwise.
+   // This also sends outgoing messages queued with enet_peer_send.
+   while (enet_host_service(client, &event, 0) > 0) {
+      // clients only care about incoming packets, they will not receive
+      // connect/disconnect events.
+      if (event.type == ENET_EVENT_TYPE_RECEIVE) {
+         msg = (ServerMessage*)event.packet->data;
+
+         switch (msg->type) {
+            case POSITION_UPDATE:
+               players[msg->player_id].x = msg->x;
+               players[msg->player_id].y = msg->y;
+               break;
+            case PLAYER_JOIN:
+               printf("Client: player #%d joined\n", msg->player_id);
+               players[msg->player_id].active = true;
+               players[msg->player_id].x = msg->x;
+               players[msg->player_id].y = msg->y;
+               players[msg->player_id].color = msg->color;
+               break;
+            case PLAYER_LEAVE:
+               printf("Client: player #%d left\n", msg->player_id);
+               players[msg->player_id].active = false;
+               break;
+         }
+
+         /* Clean up the packet now that we're done using it. */
+         enet_packet_destroy(event.packet);
+      }
+   }
+}
+
+int main(int argc, char **argv)
+{
+   ALLEGRO_DISPLAY *display;
+   ALLEGRO_TIMER *timer;
+   ALLEGRO_EVENT_QUEUE *queue;
+   ALLEGRO_EVENT event;
+   ENetHost *client;
+   ENetPeer *server;
+   bool update = true; // when true, update positions and render
+   bool done = false;  // when true, client exits
+   int dx = 0, dy = 0; // movement direction
+   int port = DEFAULT_PORT;
+
+   if (argc == 2) {
+      port = atoi(argv[1]);
+   }
+   else if (argc > 2)
+      abort_example("Usage: %s [portnum]", argv[0]);
+
+
+   // --- allegro setup ---
+   if (!al_init())
+      abort_example("Could not init Allegro.\n");
+
+   init_platform_specific();
+
+   al_install_keyboard();
+   al_init_primitives_addon();
+
+   // Create a new display that we can render the image to.
+   display = al_create_display(SCREEN_W, SCREEN_H);
+   if (!display)
+      abort_example("Error creating display\n");
+
+   timer = al_create_timer(1.0 / FPS); // Run at 30FPS
+   queue = al_create_event_queue();
+
+   al_register_event_source(queue, al_get_keyboard_event_source());
+   al_register_event_source(queue, al_get_display_event_source(display));
+   al_register_event_source(queue, al_get_timer_event_source(timer));
+   al_start_timer(timer);
+
+   // --- enet setup ---
+   if (enet_initialize() != 0)
+      abort_example("An error occurred while initializing ENet.\n");
+
+   client = create_client();
+   server = connect_client(client, port);
+
+   // --- game loop ---
+   bool direction_changed = false;
+   while (!done) {
+      al_wait_for_event(queue, &event); // Wait for and get an event.
+
+      switch (event.type) {
+         case ALLEGRO_EVENT_DISPLAY_CLOSE:
+            done = true;
+            break;
+         case ALLEGRO_EVENT_KEY_DOWN:
+            switch (event.keyboard.keycode) {
+               case ALLEGRO_KEY_W: dy -= 1; direction_changed = true; break;
+               case ALLEGRO_KEY_S: dy += 1; direction_changed = true; break;
+               case ALLEGRO_KEY_A: dx -= 1; direction_changed = true; break;
+               case ALLEGRO_KEY_D: dx += 1; direction_changed = true; break;
+            }
+            break;
+         case ALLEGRO_EVENT_KEY_UP:
+            switch (event.keyboard.keycode) {
+               case ALLEGRO_KEY_W: dy += 1; direction_changed = true; break;
+               case ALLEGRO_KEY_S: dy -= 1; direction_changed = true; break;
+               case ALLEGRO_KEY_A: dx += 1; direction_changed = true; break;
+               case ALLEGRO_KEY_D: dx -= 1; direction_changed = true; break;
+            }
+            break;
+         case (ALLEGRO_EVENT_TIMER):
+            update = true;
+            break;
+      }
+
+      // update, but only if the event queue is empty
+      if (update && al_is_event_queue_empty(queue)) {
+         update = false;
+
+         // if player changed direction this frame, notify the server.
+         // only check once per frame to stop clients from flooding the server
+         if (direction_changed) {
+            direction_changed = false;
+
+            ClientMessage msg = { dx, dy };
+
+            ENetPacket *packet = enet_packet_create(&msg,
+               sizeof(msg),
+               ENET_PACKET_FLAG_RELIABLE);
+
+            enet_peer_send(server, 0, packet);
+         }
+
+         // this will send our queued direction message if we have one, and get
+         // position updates for other clients
+         send_receive(client);
+
+         // draw each player
+         al_clear_to_color(al_map_rgb_f(0, 0, 0));
+         for (int i = 0; i < MAX_PLAYER_COUNT; i++) {
+            if (!players[i].active) continue;
+
+            int x = players[i].x;
+            int y = players[i].y;
+            ALLEGRO_COLOR color = players[i].color;
+            al_draw_filled_circle(x, y, PLAYER_SIZE, color);
+         }
+         al_flip_display();
+      }
+   }
+
+   disconnect_client(client, server);
+   enet_host_destroy(client);
+   enet_deinitialize();
+}
+
+/* vim: set sts=3 sw=3 et: */

--- a/examples/ex_enet_server.c
+++ b/examples/ex_enet_server.c
@@ -1,0 +1,236 @@
+/* Simple networked game example using ENet (http://enet.bespin.org/).
+ *
+ * You will need enet installed to run this demo.
+ *
+ * This example is based on http://enet.bespin.org/Tutorial.html
+ *
+ * This is the server, which you will want to start first. Once the server is
+ * running, run ex_enet_client to connect each client.
+ */
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+#include <enet/enet.h>
+#include <allegro5/allegro.h>
+
+#include "common.c"
+#include "enet_common.h"
+
+#define PLAYER_SPEED 200 // pixels / second
+
+const int port = 9234;
+
+static float rand01(void) { return rand() / (float)RAND_MAX; }
+
+static int init_player(void)
+{
+   // find the first open player slot
+   for (int i = 0 ; i < MAX_PLAYER_COUNT ; ++i) {
+      if (!players[i].active) {
+         // assign a random color and position to this new player
+         players[i].active = true;
+         players[i].color = al_map_rgb_f(rand01(), rand01(), rand01());
+         players[i].x = rand01() * SCREEN_W;
+         players[i].y = rand01() * SCREEN_H;
+
+         return i;
+      }
+   }
+
+   abort_example("Cannot create more than %d clients", MAX_PLAYER_COUNT);
+   return -1;
+}
+
+static ServerMessage create_join_message(int player_id)
+{
+   ServerMessage msg_out;
+   msg_out.type = PLAYER_JOIN;
+   msg_out.player_id = player_id;
+   msg_out.color = players[player_id].color;
+   msg_out.x = players[player_id].x;
+   msg_out.y = players[player_id].y;
+   return msg_out;
+}
+
+static void send_receive(ENetHost *server)
+{
+   ClientMessage *msg_in;
+   ServerMessage msg_out;
+   ENetPacket *packet;
+   ENetEvent event;
+
+   // Process all messages in queue, exit as soon as it is empty
+   while (enet_host_service(server, &event, 0) > 0) {
+      switch (event.type) {
+         case ENET_EVENT_TYPE_NONE:
+            break;
+         case ENET_EVENT_TYPE_CONNECT:
+            printf("Server: A new client connected from %x:%u.\n",
+               event.peer->address.host,
+               event.peer->address.port);
+
+            int player_id = init_player();
+
+            // store the id with the peer we can correlate messages from this
+            // client with this ID
+            event.peer->data = malloc(sizeof(int));
+            *(int*)event.peer->data = player_id;
+
+            // notify all clients of the new player
+            msg_out = create_join_message(player_id);
+
+            printf("Server: created player #%d at %d,%d\n",
+               player_id,
+               players[player_id].x,
+               players[player_id].y);
+
+            packet = enet_packet_create(&msg_out,
+               sizeof(msg_out),
+               ENET_PACKET_FLAG_RELIABLE);
+
+            enet_host_broadcast(server, 0, packet);
+
+            // notify new client of all other existing players
+            for (int i = 0 ; i < MAX_PLAYER_COUNT ; ++i) {
+               if (!players[i].active || i == player_id) continue;
+
+               msg_out = create_join_message(i);
+
+               packet = enet_packet_create(&msg_out,
+                  sizeof(msg_out),
+                  ENET_PACKET_FLAG_RELIABLE);
+               enet_peer_send(event.peer, 0, packet);
+            }
+
+            break;
+         case ENET_EVENT_TYPE_RECEIVE:
+            msg_in = (ClientMessage*)event.packet->data;
+
+            // update the player's movement
+            player_id = *(int*)event.peer->data;
+            players[player_id].dx = msg_in->x;
+            players[player_id].dy = msg_in->y;
+
+            /* Clean up the incoming packet now that we're done using it. */
+            enet_packet_destroy(event.packet);
+            break;
+         case ENET_EVENT_TYPE_DISCONNECT:
+            printf("Server: client #%d disconnected.\n", *((int*)event.peer->data));
+
+            // notify all other players that a player left
+            msg_out.type = PLAYER_LEAVE;
+            msg_out.player_id = *(int*)event.peer->data;
+
+            packet = enet_packet_create(&msg_out,
+               sizeof(msg_out),
+               ENET_PACKET_FLAG_RELIABLE);
+
+            enet_host_broadcast(server, 0, packet);
+
+            /* Reset the peer's server information. */
+            free(event.peer->data);
+            event.peer->data = NULL;
+      }
+   }
+}
+
+static void update_players(ENetHost *server, float time)
+{
+   for (int i = 0 ; i < MAX_PLAYER_COUNT ; ++i) {
+      if (!players[i].active) continue;
+
+      players[i].x += players[i].dx * PLAYER_SPEED * time;
+      players[i].y += players[i].dy * PLAYER_SPEED * time;
+
+      // notify all clients of this player's new position
+      ServerMessage msg;
+      msg.type = POSITION_UPDATE;
+      msg.player_id = i;
+      msg.x = players[i].x;
+      msg.y = players[i].y;
+
+      ENetPacket *packet = enet_packet_create(&msg,
+         sizeof(ServerMessage),
+         ENET_PACKET_FLAG_RELIABLE);
+
+      enet_host_broadcast(server, 0, packet);
+   }
+}
+
+static ENetHost* create_server(int port)
+{
+   ENetAddress address;
+   ENetHost *server;
+   /* Bind the server to the default localhost.     */
+   /* A specific host address can be specified by   */
+   /* enet_address_set_host (& address, "x.x.x.x"); */
+   address.host = ENET_HOST_ANY;
+   /* Bind the server to port 1234. */
+   address.port = port;
+   server = enet_host_create(& address /* the address to bind the server host to */,
+      32      /* allow up to 32 clients and/or outgoing connections */,
+      2      /* allow up to 2 channels to be used, 0 and 1 */,
+      0      /* assume any amount of incoming bandwidth */,
+      0      /* assume any amount of outgoing bandwidth */);
+   if (server == NULL) {
+      fprintf(stderr, "Failed to create the server.\n");
+      exit(EXIT_FAILURE);
+   }
+
+   return server;
+}
+
+int main(int argc, char **argv)
+{
+   ALLEGRO_TIMER *timer;
+   ALLEGRO_EVENT_QUEUE *queue;
+   ALLEGRO_EVENT event;
+   double last_time; // time of last update
+   double cur_time;  // time of this update
+   srand(time(NULL));
+   ENetHost * server;
+   int port;
+
+   if (argc == 1)
+      port = DEFAULT_PORT;
+   else if (argc == 2)
+      port = atoi(argv[1]);
+   else
+      abort_example("Usage: %s [portnum]", argv[0]);
+
+   if (!al_init())
+      abort_example("Could not init Allegro.\n");
+
+   if (enet_initialize() != 0) {
+      fprintf(stderr, "An error occurred while initializing ENet.\n");
+      return EXIT_FAILURE;
+   }
+
+   timer = al_create_timer(1.0 / FPS); // Run at 30FPS
+   queue = al_create_event_queue();
+
+   al_register_event_source(queue, al_get_timer_event_source(timer));
+   al_start_timer(timer);
+
+   server = create_server(port);
+
+   last_time = al_get_time();
+
+   while(1)
+   {
+      al_wait_for_event(queue, &event); // Wait for and get an event.
+
+      if (event.type == ALLEGRO_EVENT_TIMER) {
+         cur_time = al_get_time();
+         update_players(server, cur_time - last_time);
+         last_time = cur_time;
+
+         send_receive(server);
+      }
+   }
+
+   enet_host_destroy(server);
+   enet_deinitialize();
+}
+
+/* vim: set sts=3 sw=3 et: */


### PR DESCRIPTION
This should help address questions about why Allegro does not include
its own networking code. The example comes in two parts: ex_enet_client
and ex_enet_server.

The example coordinates movement between circles each controlled by a
separate client. The clients send changes in movement direction to the
server and rely on the server as an authoritative source of their
positions.

Resolves #554 
Resolves #496