### PR TITLE
Make set_shader_uniform const-correct

### DIFF
--- a/include/allegro5/internal/aintern_shader.h
+++ b/include/allegro5/internal/aintern_shader.h
@@ -24,13 +24,13 @@ struct ALLEGRO_SHADER_INTERFACE
    bool (*set_shader_sampler)(ALLEGRO_SHADER *shader, const char *name,
          ALLEGRO_BITMAP *bitmap, int unit);
    bool (*set_shader_matrix)(ALLEGRO_SHADER *shader, const char *name,
-         ALLEGRO_TRANSFORM *matrix);
+         const ALLEGRO_TRANSFORM *matrix);
    bool (*set_shader_int)(ALLEGRO_SHADER *shader, const char *name, int i);
    bool (*set_shader_float)(ALLEGRO_SHADER *shader, const char *name, float f);
    bool (*set_shader_int_vector)(ALLEGRO_SHADER *shader, const char *name,
-         int elem_size, int *i, int num_elems);
+         int elem_size, const int *i, int num_elems);
    bool (*set_shader_float_vector)(ALLEGRO_SHADER *shader, const char *name,
-         int elem_size, float *f, int num_elems);
+         int elem_size, const float *f, int num_elems);
    bool (*set_shader_bool)(ALLEGRO_SHADER *shader, const char *name, bool b);
 };
 

--- a/include/allegro5/shader.h
+++ b/include/allegro5/shader.h
@@ -57,13 +57,13 @@ AL_FUNC(void, al_destroy_shader, (ALLEGRO_SHADER *shader));
 AL_FUNC(bool, al_set_shader_sampler, (const char *name, ALLEGRO_BITMAP *bitmap,
    int unit));
 AL_FUNC(bool, al_set_shader_matrix, (const char *name,
-   ALLEGRO_TRANSFORM *matrix));
+   const ALLEGRO_TRANSFORM *matrix));
 AL_FUNC(bool, al_set_shader_int, (const char *name, int i));
 AL_FUNC(bool, al_set_shader_float, (const char *name, float f));
 AL_FUNC(bool, al_set_shader_int_vector, (const char *name, int num_components,
-   int *i, int num_elems));
+   const int *i, int num_elems));
 AL_FUNC(bool, al_set_shader_float_vector, (const char *name, int num_components,
-   float *f, int num_elems));
+   const float *f, int num_elems));
 AL_FUNC(bool, al_set_shader_bool, (const char *name, bool b));
 
 AL_FUNC(char const *, al_get_default_shader_source, (ALLEGRO_SHADER_PLATFORM platform,

--- a/src/opengl/ogl_shader.c
+++ b/src/opengl/ogl_shader.c
@@ -284,7 +284,7 @@ static bool glsl_set_shader_sampler(ALLEGRO_SHADER *shader,
 }
 
 static bool glsl_set_shader_matrix(ALLEGRO_SHADER *shader,
-   const char *name, ALLEGRO_TRANSFORM *matrix)
+   const char *name, const ALLEGRO_TRANSFORM *matrix)
 {
    ALLEGRO_SHADER_GLSL_S *gl_shader = (ALLEGRO_SHADER_GLSL_S *)shader;
    GLint handle;
@@ -296,7 +296,7 @@ static bool glsl_set_shader_matrix(ALLEGRO_SHADER *shader,
       return false;
    }
 
-   glUniformMatrix4fv(handle, 1, false, (float *)matrix->m);
+   glUniformMatrix4fv(handle, 1, false, (const float *)matrix->m);
 
    return check_gl_error(name);
 }
@@ -338,7 +338,7 @@ static bool glsl_set_shader_float(ALLEGRO_SHADER *shader,
 }
 
 static bool glsl_set_shader_int_vector(ALLEGRO_SHADER *shader,
-   const char *name, int num_components, int *i, int num_elems)
+   const char *name, int num_components, const int *i, int num_elems)
 {
    ALLEGRO_SHADER_GLSL_S *gl_shader = (ALLEGRO_SHADER_GLSL_S *)shader;
    GLint handle;
@@ -372,7 +372,7 @@ static bool glsl_set_shader_int_vector(ALLEGRO_SHADER *shader,
 }
 
 static bool glsl_set_shader_float_vector(ALLEGRO_SHADER *shader,
-   const char *name, int num_components, float *f, int num_elems)
+   const char *name, int num_components, const float *f, int num_elems)
 {
    ALLEGRO_SHADER_GLSL_S *gl_shader = (ALLEGRO_SHADER_GLSL_S *)shader;
    GLint handle;

--- a/src/shader.c
+++ b/src/shader.c
@@ -256,7 +256,7 @@ bool al_set_shader_sampler(const char *name,
 /* Function: al_set_shader_matrix
  */
 bool al_set_shader_matrix(const char *name,
-   ALLEGRO_TRANSFORM *matrix)
+   const ALLEGRO_TRANSFORM *matrix)
 {
    ALLEGRO_BITMAP *bmp;
    ALLEGRO_SHADER *shader;
@@ -317,7 +317,7 @@ bool al_set_shader_float(const char *name, float f)
 /* Function: al_set_shader_int_vector
  */
 bool al_set_shader_int_vector(const char *name,
-   int num_components, int *i, int num_elems)
+   int num_components, const int *i, int num_elems)
 {
    ALLEGRO_BITMAP *bmp;
    ALLEGRO_SHADER *shader;
@@ -338,7 +338,7 @@ bool al_set_shader_int_vector(const char *name,
 /* Function: al_set_shader_float_vector
  */
 bool al_set_shader_float_vector(const char *name,
-   int num_components, float *f, int num_elems)
+   int num_components, const float *f, int num_elems)
 {
    ALLEGRO_BITMAP *bmp;
    ALLEGRO_SHADER *shader;

--- a/src/win/d3d_shader.cpp
+++ b/src/win/d3d_shader.cpp
@@ -85,15 +85,15 @@ static void hlsl_on_reset_device(ALLEGRO_SHADER *shader);
 static bool hlsl_set_shader_sampler(ALLEGRO_SHADER *shader,
                const char *name, ALLEGRO_BITMAP *bitmap, int unit);
 static bool hlsl_set_shader_matrix(ALLEGRO_SHADER *shader,
-               const char *name, ALLEGRO_TRANSFORM *matrix);
+               const char *name, const ALLEGRO_TRANSFORM *matrix);
 static bool hlsl_set_shader_int(ALLEGRO_SHADER *shader,
                const char *name, int i);
 static bool hlsl_set_shader_float(ALLEGRO_SHADER *shader,
                const char *name, float f);
 static bool hlsl_set_shader_int_vector(ALLEGRO_SHADER *shader,
-               const char *name, int num_components, int *i, int num_elems);
+               const char *name, int num_components, const int *i, int num_elems);
 static bool hlsl_set_shader_float_vector(ALLEGRO_SHADER *shader,
-               const char *name, int num_components, float *f, int num_elems);
+               const char *name, int num_components, const float *f, int num_elems);
 static bool hlsl_set_shader_bool(ALLEGRO_SHADER *shader,
                const char *name, bool b);
 
@@ -355,7 +355,7 @@ static bool hlsl_set_shader_sampler(ALLEGRO_SHADER *shader,
 }
 
 static bool hlsl_set_shader_matrix(ALLEGRO_SHADER *shader,
-   const char *name, ALLEGRO_TRANSFORM *matrix)
+   const char *name, const ALLEGRO_TRANSFORM *matrix)
 {
    ALLEGRO_SHADER_HLSL_S *hlsl_shader = (ALLEGRO_SHADER_HLSL_S *)shader;
    HRESULT result;
@@ -392,7 +392,7 @@ static bool hlsl_set_shader_float(ALLEGRO_SHADER *shader,
 }
 
 static bool hlsl_set_shader_int_vector(ALLEGRO_SHADER *shader,
-   const char *name, int num_components, int *i, int num_elems)
+   const char *name, int num_components, const int *i, int num_elems)
 {
    ALLEGRO_SHADER_HLSL_S *hlsl_shader = (ALLEGRO_SHADER_HLSL_S *)shader;
    HRESULT result;
@@ -404,7 +404,7 @@ static bool hlsl_set_shader_int_vector(ALLEGRO_SHADER *shader,
 }
 
 static bool hlsl_set_shader_float_vector(ALLEGRO_SHADER *shader,
-   const char *name, int num_components, float *f, int num_elems)
+   const char *name, int num_components, const float *f, int num_elems)
 {
    ALLEGRO_SHADER_HLSL_S *hlsl_shader = (ALLEGRO_SHADER_HLSL_S *)shader;
    HRESULT result;


### PR DESCRIPTION
`al_set_shader_matrix()` and `al_set_shader_*_vector()` don't modify the arrays passed to them, so they should be `const`.