### PR TITLE
Fix Android app woken up during sleep

### DIFF
--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -312,6 +312,9 @@ JNI_FUNC(void, AllegroActivity, nativeOnPause, (JNIEnv *env, jobject obj))
          _al_event_source_emit_event(&display->es, &event);
       }
       _al_event_source_unlock(&display->es);
+
+      ALLEGRO_DISPLAY_ANDROID *d = (ALLEGRO_DISPLAY_ANDROID*)display;
+      _al_android_destroy_surface(env, d, false);
    }
 }
 

--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -314,7 +314,8 @@ JNI_FUNC(void, AllegroActivity, nativeOnPause, (JNIEnv *env, jobject obj))
       _al_event_source_unlock(&display->es);
 
       ALLEGRO_DISPLAY_ANDROID *d = (ALLEGRO_DISPLAY_ANDROID*)display;
-      _al_android_destroy_surface(env, d, false);
+      if (d->created)
+         _al_android_destroy_surface(env, d, false);
    }
 }
 


### PR DESCRIPTION
I spent 40 hours trying to figure out how to fix my music from starting when my Android TV system goes to sleep and I have backgrounded my game. Here's what I learned:

- Allegro generates a DISPLAY_RESUME event in surfaceChanged. It seems like it would be better placed in onResume, however threading issues make it (near?) impossible... I couldn't get it to work anyway, not without rewriting everything.
- surfaceChanged can be called at any time, it doesn't depend on the Android lifecycle... so onResume isn't always called afterwards. This leads to screenblank activating which for some stupid reason generates a surfaceChanged that wakes up the game, but the system doesn't wake up.
- surfaceCreated always gets called during a resume, so with this patch, the surface is always recreated and in my testing on phone and TV systems, this doesn't lead to a zombie state like https://github.com/liballeg/allegro5/commit/c3493b46eaf47f34b7393a70f9be1451c1e8d11e.
- Unlike the linked patch, this destroys the surface on the way into a pause, so there's no double free. And it gets recreated when the app resumes.

So all this effectively changes is one erroneous RESUME_DRAWING is avoided... but I welcome further testing. I guess where there is no surface, that surfaceChanged event is avoided...

The issue with putting the DISPLAY_RESUME in onResume is that onResume would have to wait for al_acknowledge_drawing_resume. However al_acknowledge_drawing_resume depends on surfaceChanged being finished... but they can happen in any order so the only potential way to work it out is a bunch of while (!flag); stuff (conditions don't work three way branches.)