### PR TITLE
Fix al_get_text_dimensions to get exact bounding box

### DIFF
--- a/addons/ttf/ttf.c
+++ b/addons/ttf/ttf.c
@@ -677,7 +677,7 @@ static void ttf_get_text_dimensions(ALLEGRO_FONT const *f,
       }
 
       if (nch < 0) {
-         x += gx + gw + 2;
+         x += gx + gw;
       }
       else {
          x += al_get_glyph_advance(f, ch, nch);
@@ -1005,10 +1005,10 @@ static bool ttf_get_glyph_dimensions(ALLEGRO_FONT const *f,
       }
    }
    cache_glyph(data, face, ft_index, glyph, false);
-   *bbx = glyph->offset_x;
+   *bbx = glyph->offset_x + 1;
    *bbw = glyph->region.w - 2;
-   *bbh = glyph->region.h;
-   *bby = glyph->offset_y;
+   *bbh = glyph->region.h - 2;
+   *bby = glyph->offset_y + 1;
       
    return true;
 }

--- a/addons/ttf/ttf.c
+++ b/addons/ttf/ttf.c
@@ -663,7 +663,8 @@ static void ttf_get_text_dimensions(ALLEGRO_FONT const *f,
    bool first = true;
    int x = 0;
    int32_t ch, nch;
-
+   int ymin = f->height;
+   int ymax = 0;
    *bbx = 0;
 
    nch = al_ustr_get_next(text, &pos);
@@ -682,15 +683,23 @@ static void ttf_get_text_dimensions(ALLEGRO_FONT const *f,
          x += al_get_glyph_advance(f, ch, nch);
       }
 
+      if (gy < ymin) {
+         ymin = gy;
+      }
+
+      if (gh+gy > ymax) {
+         ymax = gh + gy;
+      }
+
       if (first) {
          *bbx = gx;
          first = false;
       }
    }
 
-   *bby = 0; // FIXME
+   *bby = ymin;
    *bbw = x - *bbx;
-   *bbh = f->height; // FIXME, we want the bounding box!
+   *bbh = ymax - ymin; 
 }
 
 


### PR DESCRIPTION
al_get_text_dimensions is supposed to return the text bounding box, but currently only the width is correct (for the height it returns the font line height instead of a tight bounding box).
This fixes it so that bbh is the exact height of the bounding box and bby is the offset from the top.
