### PR TITLE
Specify the Android toolchain file on the command line now.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@
 #
 #-----------------------------------------------------------------------------#
 
+# Set the project name.
+# We use C++ in a few cases.
+project(ALLEGRO C CXX)
+
 cmake_minimum_required(VERSION 2.8.5 FATAL_ERROR)
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
@@ -29,19 +33,13 @@ endif()
 # Note: This needs to be done before the project command
 set(CMAKE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}" CACHE INTERNAL "internal")
 
-option(WANT_ANDROID "Build for Android" OFF)
-option(WANT_ANDROID_LEGACY "Build for Android 4 (1.6)" OFF)
-option(WANT_GLES2 "Compile with GLES2 support" ON)
-if(WANT_ANDROID)
-    include(${PROJECT_SOURCE_DIR}/cmake/Toolchain-android.cmake)
+if(ANDROID)
+    option(WANT_ANDROID_LEGACY "Build for Android 4 (1.6)" OFF)
     set(ANDROID_TARGET "android-12" CACHE STRING "What Android target to compile for.")
-endif(WANT_ANDROID)
+endif(ANDROID)
+option(WANT_GLES2 "Compile with GLES2 support" ON)
 option(ALLEGRO_SDL "Build using the SDL backend (experimental)" OFF)
 option(WANT_STATIC_RUNTIME "Whether or not to link the C and C++ runtimes statically (currently only implemented for MSVC)" OFF)
-
-# Set the project name.
-# We use C++ in a few cases.
-project(ALLEGRO C CXX)
 
 set(ALLEGRO_VERSION 5.2.1)
 string(REGEX MATCH "^[0-9]+[.][0-9]+" ALLEGRO_SOVERSION ${ALLEGRO_VERSION})
@@ -931,10 +929,10 @@ configure_file(
 #
 #-----------------------------------------------------------------------------#
 
-if(WANT_ANDROID)
+if(ANDROID)
     include(AndroidApp)
     add_subdirectory(android)
-endif(WANT_ANDROID)
+endif(ANDROID)
 
 #-----------------------------------------------------------------------------#
 #

--- a/README_android.txt
+++ b/README_android.txt
@@ -45,18 +45,18 @@ Make NDK standalone toolchain
 Next you need to setup a standalone NDK toolchain. Set an environment
 variable to point to the desired location of the Android toolchain:
 
-    export TC=$HOME/android-toolchain
+    export ANDROID_NDK_TOOLCHAIN_ROOT=$HOME/android-toolchain
 
 Assuming the NDK was extracted into $HOME/android-ndk run the following
 command:
 
     $HOME/android-ndk/build/tools/make-standalone-toolchain.sh \
-        --platform=android-9 --install-dir=$TC --stl=stlport
+        --platform=android-9 --install-dir=$ANDROID_NDK_TOOLCHAIN_ROOT
 
 You can use any platform 9 or higher. This command was last tested on ndk10d.
 You may need to add --arch=arm if the auto-configuration fails.
 
-Add $TC/bin to your PATH.
+Add $ANDROID_NDK_TOOLCHAIN_ROOT/bin to your PATH.
 
 
 Build dependencies for Allegro
@@ -108,11 +108,12 @@ or modify the paths in CMake variables manually.
 Building Allegro
 ================
 
-The following steps will build Allegro for Android:
+The following steps will build Allegro for Android. Note that you still
+need ANDROID_NDK_TOOLCHAIN_ROOT (see above) in your environment.
 
     mkdir build
     cd build
-    cmake .. -DANDROID_NDK_TOOLCHAIN_ROOT=$TC -DWANT_ANDROID=on \
+    cmake .. -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchain-android.cmake
         -DCMAKE_BUILD_TYPE=Debug -DANDROID_TARGET=android-12 \
         # -G"MSYS Makefiles"
     make

--- a/cmake/Toolchain-android.cmake
+++ b/cmake/Toolchain-android.cmake
@@ -4,7 +4,7 @@ SET(CMAKE_SYSTEM_VERSION 1)
 
 #set path for android toolchain -- look
 
-set(ANDROID_NDK_TOOLCHAIN_ROOT "$ENV{HOME}/android-toolchain" CACHE PATH "Path to the Android NDK Standalone Toolchain" )
+set(ANDROID_NDK_TOOLCHAIN_ROOT "$ENV{ANDROID_NDK_TOOLCHAIN_ROOT}" CACHE PATH "Path to the Android NDK Standalone Toolchain" )
 
 message( STATUS "Selected Android toolchain: ${ANDROID_NDK_TOOLCHAIN_ROOT}" )
 if(NOT EXISTS ${ANDROID_NDK_TOOLCHAIN_ROOT})
@@ -106,14 +106,10 @@ endif()
 # where is the target environment 
 SET(CMAKE_FIND_ROOT_PATH  ${ANDROID_NDK_TOOLCHAIN_ROOT}/bin ${ANDROID_NDK_TOOLCHAIN_ROOT}/arm-linux-androideabi ${ANDROID_NDK_TOOLCHAIN_ROOT}/sysroot ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/share)
 
-#for some reason this is needed? TODO figure out why...
-include_directories(${ANDROID_NDK_TOOLCHAIN_ROOT}/arm-linux-androideabi/include/c++/4.4.3/arm-linux-androideabi)
-
 SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
 # only search for libraries and includes in the ndk toolchain
 SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-
 
 if(ARM_TARGETS STREQUAL "x86")
   SET(CMAKE_CXX_FLAGS "-DGL_GLEXT_PROTOTYPES -fPIC -DANDROID -Wno-psabi")


### PR DESCRIPTION
ANDROID_NDK_TOOLCHAIN_ROOT now has to be specified in an
environment variable. README_ANDROID.txt has been updated.

(same pull request as before on a new branch)