### PR TITLE
Switch destructors to using a linked list with backreferences.

### DIFF
--- a/addons/audio/allegro5/internal/aintern_audio.h
+++ b/addons/audio/allegro5/internal/aintern_audio.h
@@ -6,6 +6,7 @@
 #define AINTERN_AUDIO_H
 
 #include "allegro5/allegro.h"
+#include "allegro5/internal/aintern_list.h"
 #include "allegro5/internal/aintern_vector.h"
 #include "../allegro_audio.h"
 
@@ -116,6 +117,8 @@ struct ALLEGRO_VOICE {
    ALLEGRO_MUTEX        *mutex;
    ALLEGRO_COND         *cond;
 
+   _AL_LIST_ITEM        *dtor_item;
+
    ALLEGRO_AUDIO_DRIVER *driver;
                         /* XXX shouldn't there only be one audio driver active
                          * at a time?
@@ -147,6 +150,7 @@ struct ALLEGRO_SAMPLE {
                         /* Whether `buffer' needs to be freed when the sample
                          * is destroyed, or when `buffer' changes.
                          */
+   _AL_LIST_ITEM        *dtor_item;
 };
 
 /* Read some samples into a mixer buffer.
@@ -232,6 +236,7 @@ struct ALLEGRO_SAMPLE_INSTANCE {
    sample_parent_t      parent;
                         /* The object that this sample is attached to, if any.
                          */
+   _AL_LIST_ITEM        *dtor_item;
 };
 
 void _al_kcm_destroy_sample(ALLEGRO_SAMPLE_INSTANCE *sample, bool unregister);
@@ -308,6 +313,8 @@ struct ALLEGRO_AUDIO_STREAM {
                           * streams don't need to be fed by the user.
                           */
 
+   _AL_LIST_ITEM        *dtor_item;
+
    void                  *extra;
                          /* Extra data for use by the flac/vorbis addons. */
 };
@@ -337,6 +344,7 @@ struct ALLEGRO_MIXER {
                            /* Vector of ALLEGRO_SAMPLE_INSTANCE*.  Holds the list of
                             * streams being mixed together.
                             */
+   _AL_LIST_ITEM           *dtor_item;
 };
 
 extern void _al_kcm_mixer_rejig_sample_matrix(ALLEGRO_MIXER *mixer,
@@ -362,9 +370,9 @@ void _al_kcm_emit_stream_events(ALLEGRO_AUDIO_STREAM *stream);
 
 void _al_kcm_init_destructors(void);
 void _al_kcm_shutdown_destructors(void);
-void _al_kcm_register_destructor(char const *name, void *object,
+_AL_LIST_ITEM *_al_kcm_register_destructor(char const *name, void *object,
    void (*func)(void*));
-void _al_kcm_unregister_destructor(void *object);
+void _al_kcm_unregister_destructor(_AL_LIST_ITEM *dtor_item);
 void _al_kcm_foreach_destructor(
       void (*callback)(void *object, void (*func)(void *), void *udata),
       void *userdata);

--- a/addons/audio/kcm_dtor.c
+++ b/addons/audio/kcm_dtor.c
@@ -53,19 +53,19 @@ void _al_kcm_shutdown_destructors(void)
 /* _al_kcm_register_destructor:
  *  Register an object to be destroyed.
  */
-void _al_kcm_register_destructor(char const *name, void *object,
+_AL_LIST_ITEM *_al_kcm_register_destructor(char const *name, void *object,
    void (*func)(void*))
 {
-   _al_register_destructor(kcm_dtors, name, object, func);
+   return _al_register_destructor(kcm_dtors, name, object, func);
 }
 
 
 /* _al_kcm_unregister_destructor:
  *  Unregister an object to be destroyed.
  */
-void _al_kcm_unregister_destructor(void *object)
+void _al_kcm_unregister_destructor(_AL_LIST_ITEM *dtor_item)
 {
-   _al_unregister_destructor(kcm_dtors, object);
+   _al_unregister_destructor(kcm_dtors, dtor_item);
 }
 
 

--- a/addons/audio/kcm_instance.c
+++ b/addons/audio/kcm_instance.c
@@ -178,7 +178,7 @@ ALLEGRO_SAMPLE_INSTANCE *al_create_sample_instance(ALLEGRO_SAMPLE *sample_data)
    spl->mutex = NULL;
    spl->parent.u.ptr = NULL;
 
-   _al_kcm_register_destructor("sample_instance", spl,
+   spl->dtor_item = _al_kcm_register_destructor("sample_instance", spl,
       (void (*)(void *))al_destroy_sample_instance);
 
    return spl;
@@ -200,7 +200,7 @@ void _al_kcm_destroy_sample(ALLEGRO_SAMPLE_INSTANCE *spl, bool unregister)
 {
    if (spl) {
       if (unregister) {
-         _al_kcm_unregister_destructor(spl);
+         _al_kcm_unregister_destructor(spl->dtor_item);
       }
 
       _al_kcm_detach_from_parent(spl);

--- a/addons/audio/kcm_mixer.c
+++ b/addons/audio/kcm_mixer.c
@@ -667,7 +667,7 @@ ALLEGRO_MIXER *al_create_mixer(unsigned int freq,
 
    _al_vector_init(&mixer->streams, sizeof(ALLEGRO_SAMPLE_INSTANCE *));
 
-   _al_kcm_register_destructor("mixer", mixer, (void (*)(void *)) al_destroy_mixer);
+   mixer->dtor_item = _al_kcm_register_destructor("mixer", mixer, (void (*)(void *)) al_destroy_mixer);
 
    return mixer;
 }
@@ -678,7 +678,7 @@ ALLEGRO_MIXER *al_create_mixer(unsigned int freq,
 void al_destroy_mixer(ALLEGRO_MIXER *mixer)
 {
    if (mixer) {
-      _al_kcm_unregister_destructor(mixer);
+      _al_kcm_unregister_destructor(mixer->dtor_item);
       _al_kcm_destroy_sample(&mixer->ss, false);
    }
 }

--- a/addons/audio/kcm_sample.c
+++ b/addons/audio/kcm_sample.c
@@ -153,7 +153,7 @@ ALLEGRO_SAMPLE *al_create_sample(void *buf, unsigned int samples,
    spl->buffer.ptr = buf;
    spl->free_buf = free_buf;
 
-   _al_kcm_register_destructor("sample", spl, (void (*)(void *)) al_destroy_sample);
+   spl->dtor_item = _al_kcm_register_destructor("sample", spl, (void (*)(void *)) al_destroy_sample);
 
    return spl;
 }
@@ -184,7 +184,7 @@ void al_destroy_sample(ALLEGRO_SAMPLE *spl)
    if (spl) {
       _al_kcm_foreach_destructor(stop_sample_instances_helper,
          al_get_sample_data(spl));
-      _al_kcm_unregister_destructor(spl);
+      _al_kcm_unregister_destructor(spl->dtor_item);
 
       if (spl->free_buf && spl->buffer.ptr) {
          al_free(spl->buffer.ptr);

--- a/addons/audio/kcm_stream.c
+++ b/addons/audio/kcm_stream.c
@@ -135,7 +135,7 @@ ALLEGRO_AUDIO_STREAM *al_create_audio_stream(size_t fragment_count,
    al_init_user_event_source(&stream->spl.es);
 
    /* This can lead to deadlocks on shutdown, hence we don't do it. */
-   /* _al_kcm_register_destructor(stream, (void (*)(void *)) al_destroy_audio_stream); */
+   /* stream->dtor_item = _al_kcm_register_destructor(stream, (void (*)(void *)) al_destroy_audio_stream); */
 
    return stream;
 }
@@ -150,7 +150,7 @@ void al_destroy_audio_stream(ALLEGRO_AUDIO_STREAM *stream)
          stream->unload_feeder(stream);
       }
       /* See commented out call to _al_kcm_register_destructor. */
-      /* _al_kcm_unregister_destructor(stream); */
+      /* _al_kcm_unregister_destructor(stream->dtor_item); */
       _al_kcm_detach_from_parent(&stream->spl);
 
       al_destroy_user_event_source(&stream->spl.es);

--- a/addons/audio/kcm_voice.c
+++ b/addons/audio/kcm_voice.c
@@ -94,7 +94,7 @@ ALLEGRO_VOICE *al_create_voice(unsigned int freq,
       return NULL;
    }
 
-   _al_kcm_register_destructor("voice", voice,
+   voice->dtor_item = _al_kcm_register_destructor("voice", voice,
       (void (*)(void *)) al_destroy_voice);
 
    return voice;
@@ -106,7 +106,7 @@ ALLEGRO_VOICE *al_create_voice(unsigned int freq,
 void al_destroy_voice(ALLEGRO_VOICE *voice)
 {
    if (voice) {
-      _al_kcm_unregister_destructor(voice);
+      _al_kcm_unregister_destructor(voice->dtor_item);
 
       al_detach_voice(voice);
       ASSERT(al_get_voice_playing(voice) == false);

--- a/addons/font/allegro5/allegro_font.h
+++ b/addons/font/allegro5/allegro_font.h
@@ -2,6 +2,7 @@
 #define __al_included_allegro5_allegro_font_h
 
 #include "allegro5/allegro.h"
+#include "allegro5/internal/aintern_list.h"
 
 #if (defined ALLEGRO_MINGW32) || (defined ALLEGRO_MSVC) || (defined ALLEGRO_BCC32)
    #ifndef ALLEGRO_STATICLINK
@@ -54,6 +55,7 @@ struct ALLEGRO_FONT
    int height;
    ALLEGRO_FONT *fallback;
    ALLEGRO_FONT_VTABLE *vtable;
+   _AL_LIST_ITEM *dtor_item;
 };
 
 /* text- and font-related stuff */

--- a/addons/font/fontbmp.c
+++ b/addons/font/fontbmp.c
@@ -284,7 +284,7 @@ ALLEGRO_FONT *al_grab_font_from_bitmap(ALLEGRO_BITMAP *bmp,
    if (unmasked)
        al_destroy_bitmap(unmasked);
 
-   _al_register_destructor(_al_dtor_list, "font", f,
+   f->dtor_item = _al_register_destructor(_al_dtor_list, "font", f,
       (void (*)(void  *))al_destroy_font);
 
    return f;

--- a/addons/font/text.c
+++ b/addons/font/text.c
@@ -359,7 +359,7 @@ void al_destroy_font(ALLEGRO_FONT *f)
    if (!f)
       return;
 
-   _al_unregister_destructor(_al_dtor_list, f);
+   _al_unregister_destructor(_al_dtor_list, f->dtor_item);
 
    f->vtable->destroy(f);
 }

--- a/addons/native_dialog/allegro5/internal/aintern_native_dialog.h
+++ b/addons/native_dialog/allegro5/internal/aintern_native_dialog.h
@@ -1,6 +1,7 @@
 #ifndef __al_included_allegro_aintern_native_dialog_h
 #define __al_included_allegro_aintern_native_dialog_h
 
+#include "allegro5/internal/aintern_list.h"
 #include "allegro5/internal/aintern_vector.h"
 #include "allegro5/internal/aintern_native_dialog_cfg.h"
 
@@ -41,6 +42,8 @@ struct ALLEGRO_NATIVE_DIALOG
    bool is_active;
    void *window;
    void *async_queue;
+   
+   _AL_LIST_ITEM *dtor_item;
 };
 
 extern bool _al_init_native_dialog_addon(void);

--- a/addons/native_dialog/dialog.c
+++ b/addons/native_dialog/dialog.c
@@ -56,7 +56,7 @@ ALLEGRO_FILECHOOSER *al_create_native_file_dialog(
    fc->fc_patterns = al_ustr_new(patterns);
    fc->flags = mode;
 
-   _al_register_destructor(_al_dtor_list, "native_dialog", fc,
+   fc->dtor_item = _al_register_destructor(_al_dtor_list, "native_dialog", fc,
       (void (*)(void *))al_destroy_native_file_dialog);
 
    return (ALLEGRO_FILECHOOSER *)fc;
@@ -100,7 +100,7 @@ void al_destroy_native_file_dialog(ALLEGRO_FILECHOOSER *dialog)
    if (!fd)
       return;
 
-   _al_unregister_destructor(_al_dtor_list, fd);
+   _al_unregister_destructor(_al_dtor_list, fd->dtor_item);
 
    al_ustr_free(fd->title);
    al_destroy_path(fd->fc_initial_path);

--- a/addons/native_dialog/textlog.c
+++ b/addons/native_dialog/textlog.c
@@ -80,7 +80,7 @@ ALLEGRO_TEXTLOG *al_open_native_text_log(char const *title, int flags)
       return NULL;
    }
 
-   _al_register_destructor(_al_dtor_list, "textlog", textlog,
+   textlog->dtor_item = _al_register_destructor(_al_dtor_list, "textlog", textlog,
       (void (*)(void *))al_close_native_text_log);
 
    return (ALLEGRO_TEXTLOG *)textlog;
@@ -111,7 +111,7 @@ void al_close_native_text_log(ALLEGRO_TEXTLOG *textlog)
          al_lock_mutex(dialog->tl_text_mutex);
       }
 
-      _al_unregister_destructor(_al_dtor_list, dialog);
+      _al_unregister_destructor(_al_dtor_list, dialog->dtor_item);
    }
 
    al_ustr_free(dialog->title);

--- a/addons/ttf/ttf.c
+++ b/addons/ttf/ttf.c
@@ -918,7 +918,7 @@ ALLEGRO_FONT *al_load_ttf_font_stretch_f(ALLEGRO_FILE *file,
     f->vtable = &vt;
     f->data = data;
 
-    _al_register_destructor(_al_dtor_list, "ttf_font", f,
+    f->dtor_item = _al_register_destructor(_al_dtor_list, "ttf_font", f,
        (void (*)(void *))al_destroy_font);
 
     return f;

--- a/include/allegro5/internal/aintern_bitmap.h
+++ b/include/allegro5/internal/aintern_bitmap.h
@@ -6,6 +6,7 @@
 #include "allegro5/display.h"
 #include "allegro5/render_state.h"
 #include "allegro5/transformations.h"
+#include "allegro5/internal/aintern_list.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -96,6 +97,8 @@ struct ALLEGRO_BITMAP
 
    /* Extra data for display bitmaps, like texture id and so on. */
    void *extra;
+
+   _AL_LIST_ITEM *dtor_item;
 
    /* set_target_bitmap and lock_bitmap mark bitmaps as dirty for preservation */
    bool dirty;

--- a/include/allegro5/internal/aintern_dtor.h
+++ b/include/allegro5/internal/aintern_dtor.h
@@ -1,6 +1,8 @@
 #ifndef __al_included_allegro5_aintern_dtor_h
 #define __al_included_allegro5_aintern_dtor_h
 
+#include "allegro5/internal/aintern_list.h"
+
 #ifdef __cplusplus
    extern "C" {
 #endif
@@ -14,9 +16,9 @@ AL_FUNC(void, _al_push_destructor_owner, (void));
 AL_FUNC(void, _al_pop_destructor_owner, (void));
 AL_FUNC(void, _al_run_destructors, (_AL_DTOR_LIST *dtors));
 AL_FUNC(void, _al_shutdown_destructors, (_AL_DTOR_LIST *dtors));
-AL_FUNC(void, _al_register_destructor, (_AL_DTOR_LIST *dtors, char const *name,
+AL_FUNC(_AL_LIST_ITEM*, _al_register_destructor, (_AL_DTOR_LIST *dtors, char const *name,
    void *object, void (*func)(void*)));
-AL_FUNC(void, _al_unregister_destructor, (_AL_DTOR_LIST *dtors, void *object));
+AL_FUNC(void, _al_unregister_destructor, (_AL_DTOR_LIST *dtors, _AL_LIST_ITEM* dtor_item));
 AL_FUNC(void, _al_foreach_destructor, (_AL_DTOR_LIST *dtors,
                                           void (*callback)(void *object, void (*func)(void *), void *udata),
                                           void *userdata));

--- a/include/allegro5/internal/aintern_shader.h
+++ b/include/allegro5/internal/aintern_shader.h
@@ -1,6 +1,7 @@
 #ifndef __al_included_allegro5_internal_aintern_shader_h
 #define __al_included_allegro5_internal_aintern_shader_h
 
+#include "allegro5/internal/aintern_list.h"
 #include "allegro5/internal/aintern_vector.h"
 
 #ifdef __cplusplus
@@ -42,6 +43,7 @@ struct ALLEGRO_SHADER
    ALLEGRO_SHADER_PLATFORM platform;
    ALLEGRO_SHADER_INTERFACE *vt;
    _AL_VECTOR bitmaps; /* of ALLEGRO_BITMAP pointers */
+   _AL_LIST_ITEM *dtor_item;
 };
 
 /* In most cases you should use _al_set_bitmap_shader_field. */

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -188,7 +188,7 @@ ALLEGRO_BITMAP *al_create_bitmap(int w, int h)
       al_get_new_bitmap_format(), al_get_new_bitmap_flags(),
       al_get_new_bitmap_depth(), al_get_new_bitmap_samples());
    if (bitmap) {
-      _al_register_destructor(_al_dtor_list, "bitmap", bitmap,
+      bitmap->dtor_item = _al_register_destructor(_al_dtor_list, "bitmap", bitmap,
          (void (*)(void *))al_destroy_bitmap);
    }
 
@@ -217,7 +217,7 @@ void al_destroy_bitmap(ALLEGRO_BITMAP *bitmap)
 
    _al_set_bitmap_shader_field(bitmap, NULL);
 
-   _al_unregister_destructor(_al_dtor_list, bitmap);
+   _al_unregister_destructor(_al_dtor_list, bitmap->dtor_item);
 
    if (!al_is_sub_bitmap(bitmap)) {
       ALLEGRO_DISPLAY* disp = _al_get_bitmap_display(bitmap);
@@ -468,7 +468,7 @@ ALLEGRO_BITMAP *al_create_sub_bitmap(ALLEGRO_BITMAP *parent,
    bitmap->yofs = y;
    bitmap->memory = NULL;
 
-   _al_register_destructor(_al_dtor_list, "sub_bitmap", bitmap,
+   bitmap->dtor_item = _al_register_destructor(_al_dtor_list, "sub_bitmap", bitmap,
       (void (*)(void *))al_destroy_bitmap);
 
    return bitmap;

--- a/src/bitmap_type.c
+++ b/src/bitmap_type.c
@@ -85,6 +85,8 @@ void _al_unregister_convert_bitmap(ALLEGRO_BITMAP *bitmap)
 static void swap_bitmaps(ALLEGRO_BITMAP *bitmap, ALLEGRO_BITMAP *other)
 {
    ALLEGRO_BITMAP temp;
+   _AL_LIST_ITEM *bitmap_dtor_item = bitmap->dtor_item;
+   _AL_LIST_ITEM *other_dtor_item = other->dtor_item;
    ALLEGRO_DISPLAY *bitmap_display, *other_display;
 
    _al_unregister_convert_bitmap(bitmap);
@@ -98,6 +100,12 @@ static void swap_bitmaps(ALLEGRO_BITMAP *bitmap, ALLEGRO_BITMAP *other)
    temp = *bitmap;
    *bitmap = *other;
    *other = temp;
+
+   /* Re-associate the destructors back, as they are tied to the object
+    * pointers.
+    */
+   bitmap->dtor_item = bitmap_dtor_item;
+   other->dtor_item = other_dtor_item;
 
    bitmap_display = _al_get_bitmap_display(bitmap);
    other_display = _al_get_bitmap_display(other);

--- a/src/dtor.c
+++ b/src/dtor.c
@@ -29,7 +29,7 @@
 #include "allegro5/internal/aintern_dtor.h"
 #include "allegro5/internal/aintern_thread.h"
 #include "allegro5/internal/aintern_tls.h"
-#include "allegro5/internal/aintern_vector.h"
+#include "allegro5/internal/aintern_list.h"
 
 /* XXX The dependency on tls.c is not nice but the DllMain stuff for Windows
  * does not it easy to make abstract away TLS API differences.
@@ -40,7 +40,7 @@ ALLEGRO_DEBUG_CHANNEL("dtor")
 
 struct _AL_DTOR_LIST {
    _AL_MUTEX mutex;
-   _AL_VECTOR dtors;
+   _AL_LIST* dtors;
 };
 
 
@@ -60,7 +60,7 @@ _AL_DTOR_LIST *_al_init_destructors(void)
 
    _AL_MARK_MUTEX_UNINITED(dtors->mutex);
    _al_mutex_init(&dtors->mutex);
-   _al_vector_init(&dtors->dtors, sizeof(DTOR));
+   dtors->dtors = _al_list_create();
 
    return dtors;
 }
@@ -107,8 +107,9 @@ void _al_run_destructors(_AL_DTOR_LIST *dtors)
    /* call the destructors in reverse order */
    _al_mutex_lock(&dtors->mutex);
    {
-      while (!_al_vector_is_empty(&dtors->dtors)) {
-         DTOR *dtor = _al_vector_ref_back(&dtors->dtors);
+      _AL_LIST_ITEM *iter = _al_list_back(dtors->dtors);
+      while (iter) {
+         DTOR *dtor = _al_list_item_data(iter);
          void *object = dtor->object;
          void (*func)(void *) = dtor->func;
 
@@ -119,6 +120,9 @@ void _al_run_destructors(_AL_DTOR_LIST *dtors)
             (*func)(object);
          }
          _al_mutex_lock(&dtors->mutex);
+         /* Don't do normal iteration as the destructors will possibly run
+          * multiple destructors at once. */
+         iter = _al_list_back(dtors->dtors);
       }
    }
    _al_mutex_unlock(&dtors->mutex);
@@ -136,8 +140,8 @@ void _al_shutdown_destructors(_AL_DTOR_LIST *dtors)
    }
 
    /* free resources used by the destructor subsystem */
-   ASSERT(_al_vector_size(&dtors->dtors) == 0);
-   _al_vector_free(&dtors->dtors);
+   ASSERT(_al_list_is_empty(dtors->dtors));
+   _al_list_destroy(dtors->dtors);
 
    _al_mutex_destroy(&dtors->mutex);
 
@@ -150,42 +154,48 @@ void _al_shutdown_destructors(_AL_DTOR_LIST *dtors)
  *  Register OBJECT to be destroyed by FUNC during Allegro shutdown.
  *  This would be done in the object's constructor function.
  *
+ *  Returns a list item representing the destructor's position in the list
+ *  (possibly null).
+ *
  *  [thread-safe]
  */
-void _al_register_destructor(_AL_DTOR_LIST *dtors, char const *name,
+_AL_LIST_ITEM *_al_register_destructor(_AL_DTOR_LIST *dtors, char const *name,
    void *object, void (*func)(void*))
 {
    int *dtor_owner_count;
+   _AL_LIST_ITEM *ret = NULL;
    ASSERT(object);
    ASSERT(func);
 
    dtor_owner_count = _al_tls_get_dtor_owner_count();
    if (*dtor_owner_count > 0)
-      return;
+      return NULL;
 
    _al_mutex_lock(&dtors->mutex);
    {
 #ifdef DEBUGMODE
       /* make sure the object is not registered twice */
       {
-         unsigned int i;
+         _AL_LIST_ITEM *iter = _al_list_front(dtors->dtors);
 
-         for (i = 0; i < _al_vector_size(&dtors->dtors); i++) {
-            DTOR *dtor = _al_vector_ref(&dtors->dtors, i);
+         while (iter) {
+            DTOR *dtor = _al_list_item_data(iter);
             ASSERT(dtor->object != object);
+            iter = _al_list_next(dtors->dtors, iter);
          }
       }
 #endif /* DEBUGMODE */
 
       /* add the destructor to the list */
       {
-         DTOR *new_dtor = _al_vector_alloc_back(&dtors->dtors);
+         DTOR *new_dtor = al_malloc(sizeof(DTOR));
          if (new_dtor) {
             new_dtor->object = object;
             new_dtor->func = func;
             new_dtor->name = name;
             ALLEGRO_DEBUG("added dtor for %s %p, func %p\n", name,
                object, func);
+            ret = _al_list_push_back(dtors->dtors, new_dtor);
          }
          else {
             ALLEGRO_WARN("failed to add dtor for %s %p\n", name,
@@ -194,6 +204,7 @@ void _al_register_destructor(_AL_DTOR_LIST *dtors, char const *name,
       }
    }
    _al_mutex_unlock(&dtors->mutex);
+   return ret;
 }
 
 
@@ -204,27 +215,18 @@ void _al_register_destructor(_AL_DTOR_LIST *dtors, char const *name,
  *
  *  [thread-safe]
  */
-void _al_unregister_destructor(_AL_DTOR_LIST *dtors, void *object)
+void _al_unregister_destructor(_AL_DTOR_LIST *dtors, _AL_LIST_ITEM *dtor_item)
 {
-   ASSERT(object);
+   if (!dtor_item) {
+      return;
+   }
 
    _al_mutex_lock(&dtors->mutex);
    {
-      unsigned int i;
-
-      for (i = 0; i < _al_vector_size(&dtors->dtors); i++) {
-         DTOR *dtor = _al_vector_ref(&dtors->dtors, i);
-         if (dtor->object == object) {
-            char const *name = dtor->name;
-            _al_vector_delete_at(&dtors->dtors, i);
-            ALLEGRO_DEBUG("removed dtor for %s %p\n", name, object);
-            break;
-         }
-      }
-
-      /* We cannot assert that the destructor was found because it might not
-       * have been registered if the owner count was non-zero at the time.
-       */
+      DTOR *dtor = _al_list_item_data(dtor_item);
+      ALLEGRO_DEBUG("removed dtor for %s %p\n", dtor->name, dtor->object);
+      al_free(dtor);
+      _al_list_erase(dtors->dtors, dtor_item);
    }
    _al_mutex_unlock(&dtors->mutex);
 }
@@ -241,11 +243,12 @@ void _al_foreach_destructor(_AL_DTOR_LIST *dtors,
 {
    _al_mutex_lock(&dtors->mutex);
    {
-      unsigned int i;
+      _AL_LIST_ITEM *iter = _al_list_front(dtors->dtors);
 
-      for (i = 0; i < _al_vector_size(&dtors->dtors); i++) {
-         DTOR *dtor = _al_vector_ref(&dtors->dtors, i);
+      while (iter) {
+         DTOR *dtor = _al_list_item_data(iter);
          callback(dtor->object, dtor->func, userdata);
+         iter = _al_list_next(dtors->dtors, iter);
       }
    }
    _al_mutex_unlock(&dtors->mutex);

--- a/src/events.c
+++ b/src/events.c
@@ -42,6 +42,7 @@ struct ALLEGRO_EVENT_QUEUE
    bool paused;
    _AL_MUTEX mutex;
    _AL_COND cond;
+   _AL_LIST_ITEM *dtor_item;
 };
 
 
@@ -105,7 +106,7 @@ ALLEGRO_EVENT_QUEUE *al_create_event_queue(void)
       _al_mutex_init(&queue->mutex);
       _al_cond_init(&queue->cond);
 
-      _al_register_destructor(_al_dtor_list, "queue", queue,
+      queue->dtor_item = _al_register_destructor(_al_dtor_list, "queue", queue,
          (void (*)(void *)) al_destroy_event_queue);
    }
 
@@ -120,7 +121,7 @@ void al_destroy_event_queue(ALLEGRO_EVENT_QUEUE *queue)
 {
    ASSERT(queue);
 
-   _al_unregister_destructor(_al_dtor_list, queue);
+   _al_unregister_destructor(_al_dtor_list, queue->dtor_item);
 
    /* Unregister any event sources registered with this queue.  */
    while (_al_vector_is_nonempty(&queue->sources)) {

--- a/src/shader.c
+++ b/src/shader.c
@@ -69,7 +69,7 @@ ALLEGRO_SHADER *al_create_shader(ALLEGRO_SHADER_PLATFORM platform)
    if (shader) {
       ASSERT(shader->platform);
       ASSERT(shader->vt);
-      _al_register_destructor(_al_dtor_list, "shader", shader,
+      shader->dtor_item = _al_register_destructor(_al_dtor_list, "shader", shader,
          (void (*)(void *))al_destroy_shader);
    }
    else {
@@ -211,7 +211,7 @@ void al_destroy_shader(ALLEGRO_SHADER *shader)
       al_use_shader(NULL);
    }
 
-   _al_unregister_destructor(_al_dtor_list, shader);
+   _al_unregister_destructor(_al_dtor_list, shader->dtor_item);
 
    al_ustr_free(shader->vertex_copy);
    shader->vertex_copy = NULL;

--- a/src/timernu.c
+++ b/src/timernu.c
@@ -45,6 +45,7 @@ struct ALLEGRO_TIMER
    double speed_secs;
    int64_t count;
    double counter;		/* counts down to zero=blastoff */
+   _AL_LIST_ITEM *dtor_item;
 };
 
 
@@ -232,7 +233,7 @@ ALLEGRO_TIMER *al_create_timer(double speed_secs)
          timer->speed_secs = speed_secs;
          timer->counter = 0;
 
-         _al_register_destructor(_al_dtor_list, "timer", timer,
+         timer->dtor_item = _al_register_destructor(_al_dtor_list, "timer", timer,
             (void (*)(void *)) al_destroy_timer);
       }
 
@@ -249,7 +250,7 @@ void al_destroy_timer(ALLEGRO_TIMER *timer)
    if (timer) {
       al_stop_timer(timer);
 
-      _al_unregister_destructor(_al_dtor_list, timer);
+      _al_unregister_destructor(_al_dtor_list, timer->dtor_item);
 
       _al_event_source_free(&timer->es);
       al_free(timer);


### PR DESCRIPTION
This changes the complexity of _al_unregister_destructor from O(N) to O(1).

The backreferences will increase the memory used, but hopefully not
significantly so.

Fixes #640