### PR TITLE
Rename LONG_LONG to AL_LONG_LONG

### DIFF
--- a/cmake/FileList.cmake
+++ b/cmake/FileList.cmake
@@ -263,6 +263,7 @@ set(ALLEGRO_INCLUDE_ALLEGRO_INLINE_FILES
 set(ALLEGRO_INCLUDE_ALLEGRO_INTERNAL_FILES
     # Only files which need to be installed.
     include/allegro5/internal/alconfig.h
+    include/allegro5/internal/aintern_list.h
     )
 
 set(ALLEGRO_INCLUDE_ALLEGRO_OPENGL_FILES

--- a/include/allegro5/inline/fmaths.inl
+++ b/include/allegro5/inline/fmaths.inl
@@ -110,7 +110,7 @@ AL_INLINE(al_fixed, al_fixsub, (al_fixed x, al_fixed y),
  *
  * PS. Don't move the #ifs inside the AL_INLINE; BCC doesn't like it.
  */
-#if (defined ALLEGRO_I386) || (!defined LONG_LONG)
+#if (defined ALLEGRO_I386) || (!defined AL_LONG_LONG)
    AL_INLINE(al_fixed, al_fixmul, (al_fixed x, al_fixed y),
    {
       return al_ftofix(al_fixtof(x) * al_fixtof(y));
@@ -118,12 +118,12 @@ AL_INLINE(al_fixed, al_fixsub, (al_fixed x, al_fixed y),
 #else
    AL_INLINE(al_fixed, al_fixmul, (al_fixed x, al_fixed y),
    {
-      LONG_LONG lx = x;
-      LONG_LONG ly = y;
-      LONG_LONG lres = (lx*ly);
+      AL_LONG_LONG lx = x;
+      AL_LONG_LONG ly = y;
+      AL_LONG_LONG lres = (lx*ly);
 
       if (lres > 0x7FFFFFFF0000LL) {
-	 al_set_errno(ERANGE);
+     al_set_errno(ERANGE);
 	 return 0x7FFFFFFF;
       }
       else if (lres < -0x7FFFFFFF0000LL) {
@@ -138,10 +138,10 @@ AL_INLINE(al_fixed, al_fixsub, (al_fixed x, al_fixed y),
 #endif	    /* al_fixmul() C implementations */
 
 
-#if (defined ALLEGRO_CFG_NO_FPU) && (defined LONG_LONG)
+#if (defined ALLEGRO_CFG_NO_FPU) && (defined AL_LONG_LONG)
 AL_INLINE(al_fixed, al_fixdiv, (al_fixed x, al_fixed y),
 {
-   LONG_LONG lres = x;
+   AL_LONG_LONG lres = x;
    if (y == 0) {
       al_set_errno(ERANGE);
       return (x < 0) ? -0x7FFFFFFF : 0x7FFFFFFF;

--- a/include/allegro5/inline/fmaths.inl
+++ b/include/allegro5/inline/fmaths.inl
@@ -123,16 +123,16 @@ AL_INLINE(al_fixed, al_fixsub, (al_fixed x, al_fixed y),
       AL_LONG_LONG lres = (lx*ly);
 
       if (lres > 0x7FFFFFFF0000LL) {
-     al_set_errno(ERANGE);
-	 return 0x7FFFFFFF;
+         al_set_errno(ERANGE);
+         return 0x7FFFFFFF;
       }
       else if (lres < -0x7FFFFFFF0000LL) {
-	 al_set_errno(ERANGE);
-	 return 0x80000000;
+         al_set_errno(ERANGE);
+         return 0x80000000;
       }
       else {
-	 int res = lres >> 16;
-	 return res;
+         int res = lres >> 16;
+         return res;
       }
    })
 #endif	    /* al_fixmul() C implementations */

--- a/include/allegro5/internal/alconfig.h
+++ b/include/allegro5/internal/alconfig.h
@@ -107,8 +107,8 @@
       #endif
    #endif
    
-   #ifndef LONG_LONG
-      #define LONG_LONG       long long
+   #ifndef AL_LONG_LONG
+      #define AL_LONG_LONG    long long
       #ifdef ALLEGRO_GUESS_INTTYPES_OK
          #define int64_t      signed long long
          #define uint64_t     unsigned long long

--- a/include/allegro5/platform/albcc32.h
+++ b/include/allegro5/platform/albcc32.h
@@ -75,7 +75,7 @@
 #define AL_INLINE(type, name, args, code)        extern __inline type __cdecl name args code END_OF_INLINE(name)
 #define AL_INLINE_STATIC(type, name, args, code) static __inline type name args code END_OF_INLINE(name)
 
-#define LONG_LONG    __int64
+#define AL_LONG_LONG __int64
 #define int64_t      signed __int64
 #define uint64_t     unsigned __int64
 

--- a/include/allegro5/platform/almsvc.h
+++ b/include/allegro5/platform/almsvc.h
@@ -74,7 +74,7 @@
 
 #define INLINE       __inline
 
-#define LONG_LONG    __int64
+#define AL_LONG_LONG __int64
 
 /* VC10 is the first version to define int64_t and uint64_t */
 #if _MSC_VER < 1600

--- a/include/allegro5/platform/alwatcom.h
+++ b/include/allegro5/platform/alwatcom.h
@@ -50,7 +50,7 @@
 #define ALLEGRO_I386
 #define ALLEGRO_LITTLE_ENDIAN
 
-#define LONG_LONG    long long
+#define AL_LONG_LONG long long
 #ifdef ALLEGRO_GUESS_INTTYPES_OK
    #define int64_t   signed long long
    #define uint64_t  unsigned long long


### PR DESCRIPTION
- LONG_LONG clashes with other 3rd party library.
- Please prefix Allegro types with AL_.

### Fix install

- This also fixes install as a header is missing from internal.