### PR TITLE
OSX mouse movement and warp fixes.

### DIFF
--- a/include/allegro5/inline/fmaths.inl
+++ b/include/allegro5/inline/fmaths.inl
@@ -110,7 +110,7 @@ AL_INLINE(al_fixed, al_fixsub, (al_fixed x, al_fixed y),
  *
  * PS. Don't move the #ifs inside the AL_INLINE; BCC doesn't like it.
  */
-#if (defined ALLEGRO_I386) || (!defined AL_LONG_LONG)
+#if defined ALLEGRO_I386
    AL_INLINE(al_fixed, al_fixmul, (al_fixed x, al_fixed y),
    {
       return al_ftofix(al_fixtof(x) * al_fixtof(y));
@@ -118,9 +118,9 @@ AL_INLINE(al_fixed, al_fixsub, (al_fixed x, al_fixed y),
 #else
    AL_INLINE(al_fixed, al_fixmul, (al_fixed x, al_fixed y),
    {
-      AL_LONG_LONG lx = x;
-      AL_LONG_LONG ly = y;
-      AL_LONG_LONG lres = (lx*ly);
+      int64_t lx = x;
+      int64_t ly = y;
+      int64_t lres = (lx*ly);
 
       if (lres > 0x7FFFFFFF0000LL) {
          al_set_errno(ERANGE);
@@ -138,10 +138,10 @@ AL_INLINE(al_fixed, al_fixsub, (al_fixed x, al_fixed y),
 #endif	    /* al_fixmul() C implementations */
 
 
-#if (defined ALLEGRO_CFG_NO_FPU) && (defined AL_LONG_LONG)
+#if defined ALLEGRO_CFG_NO_FPU
 AL_INLINE(al_fixed, al_fixdiv, (al_fixed x, al_fixed y),
 {
-   AL_LONG_LONG lres = x;
+   int64_t lres = x;
    if (y == 0) {
       al_set_errno(ERANGE);
       return (x < 0) ? -0x7FFFFFFF : 0x7FFFFFFF;

--- a/include/allegro5/internal/alconfig.h
+++ b/include/allegro5/internal/alconfig.h
@@ -107,12 +107,9 @@
       #endif
    #endif
    
-   #ifndef AL_LONG_LONG
-      #define AL_LONG_LONG    long long
-      #ifdef ALLEGRO_GUESS_INTTYPES_OK
-         #define int64_t      signed long long
-         #define uint64_t     unsigned long long
-      #endif
+   #ifdef ALLEGRO_GUESS_INTTYPES_OK
+      #define int64_t      signed long long
+      #define uint64_t     unsigned long long
    #endif
 
    #ifdef __i386__

--- a/include/allegro5/platform/albcc32.h
+++ b/include/allegro5/platform/albcc32.h
@@ -75,7 +75,6 @@
 #define AL_INLINE(type, name, args, code)        extern __inline type __cdecl name args code END_OF_INLINE(name)
 #define AL_INLINE_STATIC(type, name, args, code) static __inline type name args code END_OF_INLINE(name)
 
-#define AL_LONG_LONG __int64
 #define int64_t      signed __int64
 #define uint64_t     unsigned __int64
 

--- a/include/allegro5/platform/almsvc.h
+++ b/include/allegro5/platform/almsvc.h
@@ -74,8 +74,6 @@
 
 #define INLINE       __inline
 
-#define AL_LONG_LONG __int64
-
 /* VC10 is the first version to define int64_t and uint64_t */
 #if _MSC_VER < 1600
 #define int64_t      signed __int64

--- a/include/allegro5/platform/alwatcom.h
+++ b/include/allegro5/platform/alwatcom.h
@@ -50,7 +50,6 @@
 #define ALLEGRO_I386
 #define ALLEGRO_LITTLE_ENDIAN
 
-#define AL_LONG_LONG long long
 #ifdef ALLEGRO_GUESS_INTTYPES_OK
    #define int64_t   signed long long
    #define uint64_t  unsigned long long

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -373,52 +373,52 @@ void _al_osx_mouse_was_installed(BOOL install) {
 -(void) mouseUp: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) mouseDragged: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) rightMouseDown: (NSEvent*) evt
 {
-   if (_osx_mouse_installed)
+      if (_osx_mouse_installed)
    _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) rightMouseUp: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) rightMouseDragged: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) otherMouseDown: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) otherMouseUp: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) otherMouseDragged: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) mouseMoved: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 -(void) scrollWheel: (NSEvent*) evt
 {
    if (_osx_mouse_installed)
-   _al_osx_mouse_generate_event(evt, dpy_ptr);
+      _al_osx_mouse_generate_event(evt, dpy_ptr);
 }
 /* Cursor handling */
 - (void) viewDidMoveToWindow {

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -423,6 +423,9 @@ void _al_osx_mouse_was_installed(BOOL install) {
 /* Cursor handling */
 - (void) viewDidMoveToWindow {
    ALLEGRO_DISPLAY_OSX_WIN* dpy =  (ALLEGRO_DISPLAY_OSX_WIN*) dpy_ptr;
+   if (dpy->tracking) {
+      [self removeTrackingArea: dpy->tracking];
+   }
    dpy->tracking = create_tracking_area(self);
    [self addTrackingArea: dpy->tracking];
 }

--- a/src/macosx/qzmouse.m
+++ b/src/macosx/qzmouse.m
@@ -174,8 +174,10 @@ void _al_osx_mouse_generate_event(NSEvent* evt, ALLEGRO_DISPLAY* dpy)
    }
    dx *= scaling_factor;
    dy *= scaling_factor;
-   if (osx_mouse.warped) {
-      osx_mouse.warped = FALSE;
+   if (osx_mouse.warped && type == ALLEGRO_EVENT_MOUSE_AXES) {
+       dx -= osx_mouse.warped_x;
+       dy -= osx_mouse.warped_y;
+       osx_mouse.warped = FALSE;
    }
    _al_event_source_lock(&osx_mouse.parent.es);
    if ((within || b_change || type == ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY)

--- a/src/macosx/qzmouse.m
+++ b/src/macosx/qzmouse.m
@@ -189,7 +189,7 @@ void _al_osx_mouse_generate_event(NSEvent* evt, ALLEGRO_DISPLAY* dpy)
       // Note: we use 'allegro time' rather than the time stamp
       // from the event
       mouse_event->timestamp = al_get_time();
-                mouse_event->display = dpy;
+      mouse_event->display = dpy;
       mouse_event->button = b;
       mouse_event->x = pos.x * scaling_factor;
       mouse_event->y = pos.y * scaling_factor;


### PR DESCRIPTION
@goobliata, could you test this on your OSX machine? In particular, ex_mouse_warp should work and ex_mouse_events should still register the mouse leaving the display.