### PR TITLE
Add al_backup_dirty_bitmap and al_backup_dirty_bitmaps to give

### DIFF
--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -1893,7 +1893,7 @@ This function gives you more control over when your bitmaps get backed up.
 By calling this function after modifying a bitmap, you can make sure the
 bitmap is backed up right away instead of during the next flip.
 
-Since: 5.2.2
+Since: 5.2.1
 
 See also: [al_backup_dirty_bitmaps], [al_create_bitmap]
 
@@ -1902,7 +1902,7 @@ See also: [al_backup_dirty_bitmaps], [al_create_bitmap]
 
 Backs up all of a display's bitmaps to system memory.
 
-Since: 5.2.2
+Since: 5.2.1
 
 See also: [al_backup_dirty_bitmap]
 

--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -1879,3 +1879,30 @@ Since: 5.1.2
 
 See also: [ALLEGRO_RENDER_STATE], [ALLEGRO_RENDER_FUNCTION],
 [ALLEGRO_WRITE_MASK_FLAGS]
+
+
+### API: al_backup_dirty_bitmap
+
+On some platforms, notably Windows Direct3D and Android, textures may be
+lost at any time for events such as display resize or switching out of the
+app. On those platforms, bitmaps created without the ALLEGRO_NO_PRESERVE_TEXTURE
+flag automatically get backed up to system memory every time
+al_flip_display is called.
+
+This function gives you more control over when your bitmaps get backed up.
+By calling this function after modifying a bitmap, you can make sure the
+bitmap is backed up right away instead of during the next flip.
+
+Since: 5.2.2
+
+See also: [al_backup_dirty_bitmaps], [al_create_bitmap]
+
+
+### API: al_backup_dirty_bitmaps
+
+Backs up all of a display's bitmaps to system memory.
+
+Since: 5.2.2
+
+See also: [al_backup_dirty_bitmap]
+

--- a/include/allegro5/bitmap.h
+++ b/include/allegro5/bitmap.h
@@ -82,6 +82,7 @@ AL_FUNC(void, al_reparent_bitmap, (ALLEGRO_BITMAP *bitmap,
 AL_FUNC(ALLEGRO_BITMAP *, al_clone_bitmap, (ALLEGRO_BITMAP *bitmap));
 AL_FUNC(void, al_convert_bitmap, (ALLEGRO_BITMAP *bitmap));
 AL_FUNC(void, al_convert_memory_bitmaps, (void));
+AL_FUNC(void, al_backup_dirty_bitmap, (ALLEGRO_BITMAP *bitmap));
 
 #ifdef __cplusplus
    }

--- a/include/allegro5/display.h
+++ b/include/allegro5/display.h
@@ -172,8 +172,10 @@ AL_FUNC(int, al_get_display_option, (ALLEGRO_DISPLAY *display, int option));
 AL_FUNC(void, al_hold_bitmap_drawing, (bool hold));
 AL_FUNC(bool, al_is_bitmap_drawing_held, (void));
 
+/* Miscellaneous */
 AL_FUNC(void, al_acknowledge_drawing_halt, (ALLEGRO_DISPLAY *display));
 AL_FUNC(void, al_acknowledge_drawing_resume, (ALLEGRO_DISPLAY *display));
+AL_FUNC(void, al_backup_dirty_bitmaps, (ALLEGRO_DISPLAY *display));
 
 #ifdef __cplusplus
    }

--- a/include/allegro5/internal/aintern_bitmap.h
+++ b/include/allegro5/internal/aintern_bitmap.h
@@ -134,6 +134,9 @@ struct ALLEGRO_BITMAP_INTERFACE
 
    /* Used to update any dangling pointers the bitmap driver might keep. */
    void (*bitmap_pointer_changed)(ALLEGRO_BITMAP *bitmap, ALLEGRO_BITMAP *old);
+
+   /* Back up texture to system RAM */
+   void (*backup_dirty_bitmap)(ALLEGRO_BITMAP *bitmap);
 };
 
 ALLEGRO_BITMAP *_al_create_bitmap_params(ALLEGRO_DISPLAY *current_display,

--- a/include/allegro5/internal/aintern_display.h
+++ b/include/allegro5/internal/aintern_display.h
@@ -80,7 +80,6 @@ struct ALLEGRO_DISPLAY_INTERFACE
    char *(*get_clipboard_text)(ALLEGRO_DISPLAY *display);
    bool  (*set_clipboard_text)(ALLEGRO_DISPLAY *display, const char *text);
    bool  (*has_clipboard_text)(ALLEGRO_DISPLAY *display);
-   
 };
 
 

--- a/src/android/android_display.c
+++ b/src/android/android_display.c
@@ -664,7 +664,7 @@ static void android_flip_display(ALLEGRO_DISPLAY *dpy)
    /* Backup bitmaps created without ALLEGRO_NO_PRESERVE_TEXTURE that are
     * dirty, to system memory.
     */
-   _al_opengl_backup_dirty_bitmaps(dpy, true);
+   al_backup_dirty_bitmaps(dpy);
 }
 
 static void android_update_display_region(ALLEGRO_DISPLAY *dpy, int x, int y,

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -673,4 +673,12 @@ ALLEGRO_BITMAP *al_clone_bitmap(ALLEGRO_BITMAP *bitmap)
    return clone;
 }
 
+/* Function: al_backup_dirty_bitmap
+ */
+void al_backup_dirty_bitmap(ALLEGRO_BITMAP *bitmap)
+{
+   if (bitmap->vt && bitmap->vt->backup_dirty_bitmap)
+      bitmap->vt->backup_dirty_bitmap(bitmap);
+}
+
 /* vim: set ts=8 sts=3 sw=3 et: */

--- a/src/display.c
+++ b/src/display.c
@@ -633,7 +633,7 @@ void al_backup_dirty_bitmaps(ALLEGRO_DISPLAY *display)
    for (i = 0; i < display->bitmaps._size; i++) {
       ALLEGRO_BITMAP **bptr = (ALLEGRO_BITMAP **)_al_vector_ref(&display->bitmaps, i);
       ALLEGRO_BITMAP *bmp = *bptr;
-      if ((void *)_al_get_bitmap_display(bmp) == (void *)display) {
+      if (_al_get_bitmap_display(bmp) == display) {
          if (bmp->vt && bmp->vt->backup_dirty_bitmap) {
             bmp->vt->backup_dirty_bitmap(bmp);
 	 }

--- a/src/display.c
+++ b/src/display.c
@@ -624,4 +624,21 @@ void al_set_render_state(ALLEGRO_RENDER_STATE state, int value)
    }
 }
 
+/* Function: al_backup_dirty_bitmaps
+ */
+void al_backup_dirty_bitmaps(ALLEGRO_DISPLAY *display)
+{
+   unsigned int i;
+
+   for (i = 0; i < display->bitmaps._size; i++) {
+      ALLEGRO_BITMAP **bptr = (ALLEGRO_BITMAP **)_al_vector_ref(&display->bitmaps, i);
+      ALLEGRO_BITMAP *bmp = *bptr;
+      if ((void *)_al_get_bitmap_display(bmp) == (void *)display) {
+         if (bmp->vt && bmp->vt->backup_dirty_bitmap) {
+            bmp->vt->backup_dirty_bitmap(bmp);
+	 }
+      }
+   }
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/src/sdl/sdl_display.c
+++ b/src/sdl/sdl_display.c
@@ -190,7 +190,7 @@ static void sdl_flip_display(ALLEGRO_DISPLAY *d)
    SDL_RenderPresent(sdl->renderer);
 
    // SDL loses texture contents, for example on resize.
-    _al_opengl_backup_dirty_bitmaps(d, true);
+   al_backup_dirty_bitmaps(d);
 }
 
 static void sdl_update_display_region(ALLEGRO_DISPLAY *d, int x, int y,

--- a/src/win/d3d.h
+++ b/src/win/d3d.h
@@ -50,7 +50,6 @@ bool _al_d3d_render_to_texture_supported(void);
 void _al_d3d_set_bitmap_clip(ALLEGRO_BITMAP *bitmap);
 
 void _al_d3d_release_default_pool_textures(ALLEGRO_DISPLAY *display);
-void _al_d3d_prepare_bitmaps_for_reset(ALLEGRO_DISPLAY_D3D *disp);
 void _al_d3d_refresh_texture_memory(ALLEGRO_DISPLAY *display);
 bool _al_d3d_recreate_bitmap_textures(ALLEGRO_DISPLAY_D3D *disp);
 void _al_d3d_set_bitmap_clip(ALLEGRO_BITMAP *bitmap);

--- a/src/win/d3d_disp.cpp
+++ b/src/win/d3d_disp.cpp
@@ -2048,8 +2048,6 @@ static void d3d_draw_pixel(ALLEGRO_DISPLAY *disp, float x, float y, ALLEGRO_COLO
    }
 }
 
-
-
 static void d3d_flip_display(ALLEGRO_DISPLAY *al_display)
 {
    ALLEGRO_DISPLAY_D3D* d3d_display = (ALLEGRO_DISPLAY_D3D*)al_display;
@@ -2074,7 +2072,7 @@ static void d3d_flip_display(ALLEGRO_DISPLAY *al_display)
       return;
    }
    else {
-      _al_d3d_prepare_bitmaps_for_reset(d3d_display);
+      al_backup_dirty_bitmaps(al_display);
    }
 }
 
@@ -2319,7 +2317,7 @@ static bool d3d_resize_display(ALLEGRO_DISPLAY *d, int width, int height)
    int orig_h = d->h;
    bool ret;
 
-   _al_d3d_prepare_bitmaps_for_reset(d3d_display);
+   al_backup_dirty_bitmaps(d);
 
    win_display->ignore_resize = true;
 


### PR DESCRIPTION
the user some control over when their bitmaps get backed up
to system memory.