### PR TITLE
Add ALLEGRO_GLYPH structure and al_get_glyph.

### DIFF
--- a/addons/font/allegro5/allegro_font.h
+++ b/addons/font/allegro5/allegro_font.h
@@ -47,6 +47,7 @@
 /* Type: ALLEGRO_FONT
 */
 typedef struct ALLEGRO_FONT ALLEGRO_FONT;
+typedef struct ALLEGRO_GLYPH ALLEGRO_GLYPH;
 typedef struct ALLEGRO_FONT_VTABLE ALLEGRO_FONT_VTABLE;
 
 struct ALLEGRO_FONT
@@ -56,6 +57,18 @@ struct ALLEGRO_FONT
    ALLEGRO_FONT *fallback;
    ALLEGRO_FONT_VTABLE *vtable;
    _AL_LIST_ITEM *dtor_item;
+};
+
+struct ALLEGRO_GLYPH
+{
+   ALLEGRO_BITMAP *bitmap;
+   int x;
+   int y;
+   int w;
+   int h;
+   int kerning;
+   int offset_x;
+   int offset_y;
 };
 
 /* text- and font-related stuff */
@@ -78,7 +91,8 @@ struct ALLEGRO_FONT_VTABLE
       int codepoint, int *bbx, int *bby, int *bbw, int *bbh));      
    ALLEGRO_FONT_METHOD(int, get_glyph_advance, (const ALLEGRO_FONT *font,
       int codepoint1, int codepoint2));
-      
+
+   ALLEGRO_FONT_METHOD(int, get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
 };
 
 enum {
@@ -130,6 +144,7 @@ ALLEGRO_FONT_FUNC(bool, al_get_glyph_dimensions, (const ALLEGRO_FONT *f,
    int codepoint, int *bbx, int *bby, int *bbw, int *bbh));
 ALLEGRO_FONT_FUNC(int, al_get_glyph_advance, (const ALLEGRO_FONT *f,
    int codepoint1, int codepoint2));
+ALLEGRO_FONT_FUNC(int, al_get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
 
 ALLEGRO_FONT_FUNC(void, al_draw_multiline_text, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *text));
 ALLEGRO_FONT_FUNC(void, al_draw_multiline_textf, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *format, ...));

--- a/addons/font/allegro5/allegro_font.h
+++ b/addons/font/allegro5/allegro_font.h
@@ -47,6 +47,8 @@
 /* Type: ALLEGRO_FONT
 */
 typedef struct ALLEGRO_FONT ALLEGRO_FONT;
+/* Type: ALLEGRO_GLYPH
+*/
 typedef struct ALLEGRO_GLYPH ALLEGRO_GLYPH;
 typedef struct ALLEGRO_FONT_VTABLE ALLEGRO_FONT_VTABLE;
 
@@ -69,6 +71,7 @@ struct ALLEGRO_GLYPH
    int kerning;
    int offset_x;
    int offset_y;
+   int advance;
 };
 
 /* text- and font-related stuff */
@@ -92,7 +95,7 @@ struct ALLEGRO_FONT_VTABLE
    ALLEGRO_FONT_METHOD(int, get_glyph_advance, (const ALLEGRO_FONT *font,
       int codepoint1, int codepoint2));
 
-   ALLEGRO_FONT_METHOD(int, get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
+   ALLEGRO_FONT_METHOD(bool, get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
 };
 
 enum {
@@ -144,7 +147,7 @@ ALLEGRO_FONT_FUNC(bool, al_get_glyph_dimensions, (const ALLEGRO_FONT *f,
    int codepoint, int *bbx, int *bby, int *bbw, int *bbh));
 ALLEGRO_FONT_FUNC(int, al_get_glyph_advance, (const ALLEGRO_FONT *f,
    int codepoint1, int codepoint2));
-ALLEGRO_FONT_FUNC(int, al_get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
+ALLEGRO_FONT_FUNC(bool, al_get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
 
 ALLEGRO_FONT_FUNC(void, al_draw_multiline_text, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *text));
 ALLEGRO_FONT_FUNC(void, al_draw_multiline_textf, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *format, ...));

--- a/addons/font/font.c
+++ b/addons/font/font.c
@@ -209,6 +209,27 @@ static int color_render(const ALLEGRO_FONT* f, ALLEGRO_COLOR color,
 }
 
 
+static int color_get_glyph(const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
+{
+   ALLEGRO_BITMAP *g = _al_font_color_find_glyph(f, codepoint);
+   if (g) {
+      glyph->bitmap = g;
+      glyph->x = 0;
+      glyph->y = 0;
+      glyph->w = al_get_bitmap_width(g);
+      glyph->h = al_get_bitmap_height(g);
+      glyph->kerning = 0;
+      glyph->offset_x = 0;
+      glyph->offset_y = 0;
+      return glyph->w;
+   }
+   if (f->fallback) {
+      return f->fallback->vtable->get_glyph(f->fallback, prev_codepoint, codepoint, glyph);
+   }
+   glyph->bitmap = NULL;
+   return 0;
+}
+
 
 /* color_destroy:
  *  (color vtable entry)
@@ -317,7 +338,8 @@ ALLEGRO_FONT_VTABLE _al_font_vtable_color = {
     color_get_text_dimensions,
     color_get_font_ranges,
     color_get_glyph_dimensions,
-    color_get_glyph_advance
+    color_get_glyph_advance,
+    color_get_glyph
 };
 
 

--- a/addons/font/font.c
+++ b/addons/font/font.c
@@ -209,7 +209,7 @@ static int color_render(const ALLEGRO_FONT* f, ALLEGRO_COLOR color,
 }
 
 
-static int color_get_glyph(const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
+static bool color_get_glyph(const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
 {
    ALLEGRO_BITMAP *g = _al_font_color_find_glyph(f, codepoint);
    if (g) {
@@ -221,13 +221,13 @@ static int color_get_glyph(const ALLEGRO_FONT *f, int prev_codepoint, int codepo
       glyph->kerning = 0;
       glyph->offset_x = 0;
       glyph->offset_y = 0;
-      return glyph->w;
+      glyph->advance = glyph->w;
+      return true;
    }
    if (f->fallback) {
       return f->fallback->vtable->get_glyph(f->fallback, prev_codepoint, codepoint, glyph);
    }
-   glyph->bitmap = NULL;
-   return 0;
+   return false;
 }
 
 

--- a/addons/font/text.c
+++ b/addons/font/text.c
@@ -402,6 +402,12 @@ int al_get_glyph_advance(const ALLEGRO_FONT *f, int codepoint1, int codepoint2)
    return f->vtable->get_glyph_advance(f, codepoint1, codepoint2);
 }
 
+/* Function: al_get_glyph
+ */
+int al_get_glyph(const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
+{
+   return f->vtable->get_glyph(f, prev_codepoint, codepoint, glyph);
+};
 
 
 /* This helper function helps splitting an ustr in several delimited parts.

--- a/addons/font/text.c
+++ b/addons/font/text.c
@@ -404,7 +404,7 @@ int al_get_glyph_advance(const ALLEGRO_FONT *f, int codepoint1, int codepoint2)
 
 /* Function: al_get_glyph
  */
-int al_get_glyph(const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
+bool al_get_glyph(const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
 {
    return f->vtable->get_glyph(f, prev_codepoint, codepoint, glyph);
 };

--- a/addons/ttf/ttf.c
+++ b/addons/ttf/ttf.c
@@ -495,7 +495,7 @@ static int get_kerning(ALLEGRO_TTF_FONT_DATA const *data, FT_Face face,
 }
 
 
-static int ttf_get_glyph_worker(ALLEGRO_FONT const *f, int prev_ft_index, int ft_index, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *info)
+static bool ttf_get_glyph_worker(ALLEGRO_FONT const *f, int prev_ft_index, int ft_index, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *info)
 {
    ALLEGRO_TTF_FONT_DATA *data = f->data;
    FT_Face face = data->face;
@@ -527,7 +527,7 @@ static int ttf_get_glyph_worker(ALLEGRO_FONT const *f, int prev_ft_index, int ft
    }
    else if (glyph->region.x > 0) {
       ALLEGRO_ERROR("Glyph %d not on any page.\n", ft_index);
-      info->bitmap = NULL;
+      return false;
    }
    else {
       info->bitmap = 0;
@@ -535,11 +535,13 @@ static int ttf_get_glyph_worker(ALLEGRO_FONT const *f, int prev_ft_index, int ft
 
    advance += glyph->advance;
 
-   return advance;
+   info->advance = advance;
+
+   return true;
 }
 
 
-static int ttf_get_glyph(ALLEGRO_FONT const *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
+static bool ttf_get_glyph(ALLEGRO_FONT const *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
 {
    ALLEGRO_TTF_FONT_DATA *data = f->data;
    FT_Face face = data->face;
@@ -553,9 +555,9 @@ static int render_glyph(ALLEGRO_FONT const *f, ALLEGRO_COLOR color,
    int prev_ft_index, int ft_index, int32_t prev_ch, int32_t ch, float xpos, float ypos)
 {
    ALLEGRO_GLYPH glyph;
-   int advance;
 
-   advance = ttf_get_glyph_worker(f, prev_ft_index, ft_index, prev_ch, ch, &glyph);
+   if (ttf_get_glyph_worker(f, prev_ft_index, ft_index, prev_ch, ch, &glyph) == false)
+      return 0;
 
    if (glyph.bitmap != NULL) {
       al_draw_tinted_bitmap_region(
@@ -567,7 +569,7 @@ static int render_glyph(ALLEGRO_FONT const *f, ALLEGRO_COLOR color,
       );
    }
 
-   return advance;
+   return glyph.advance;
 }
 
 

--- a/addons/ttf/ttf.c
+++ b/addons/ttf/ttf.c
@@ -495,8 +495,7 @@ static int get_kerning(ALLEGRO_TTF_FONT_DATA const *data, FT_Face face,
 }
 
 
-static int render_glyph(ALLEGRO_FONT const *f, ALLEGRO_COLOR color,
-   int prev_ft_index, int ft_index, int32_t ch, float xpos, float ypos)
+static int ttf_get_glyph_worker(ALLEGRO_FONT const *f, int prev_ft_index, int ft_index, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *info)
 {
    ALLEGRO_TTF_FONT_DATA *data = f->data;
    FT_Face face = data->face;
@@ -504,33 +503,69 @@ static int render_glyph(ALLEGRO_FONT const *f, ALLEGRO_COLOR color,
    int advance = 0;
 
    if (!get_glyph(data, ft_index, &glyph)) {
-      if (f->fallback) {
-         al_draw_glyph(f->fallback, color, xpos, ypos, ch);
-         return al_get_glyph_advance(f->fallback, ch,
-            ALLEGRO_NO_KERNING);
-      }
+      if (f->fallback)
+         return f->fallback->vtable->get_glyph(f->fallback, prev_codepoint, codepoint, info);
       else {
          get_glyph(data, 0, &glyph);
          ft_index = 0;
       }
    }
+
    cache_glyph(data, face, ft_index, glyph, false);
 
    advance += get_kerning(data, face, prev_ft_index, ft_index);
 
    if (glyph->page_bitmap) {
-      /* Each glyph has a 1-pixel border all around. */
-      al_draw_tinted_bitmap_region(glyph->page_bitmap, color,
-         glyph->region.x + 1, glyph->region.y + 1,
-         glyph->region.w - 2, glyph->region.h - 2,
-         xpos + glyph->offset_x + advance,
-         ypos + glyph->offset_y, 0);
+      info->bitmap = glyph->page_bitmap;
+      info->x = glyph->region.x + 1;
+      info->y = glyph->region.y + 1;
+      info->w = glyph->region.w - 2;
+      info->h = glyph->region.h - 2;
+      info->kerning = advance;
+      info->offset_x = glyph->offset_x;
+      info->offset_y = glyph->offset_y;
    }
    else if (glyph->region.x > 0) {
       ALLEGRO_ERROR("Glyph %d not on any page.\n", ft_index);
+      info->bitmap = NULL;
+   }
+   else {
+      info->bitmap = 0;
    }
 
    advance += glyph->advance;
+
+   return advance;
+}
+
+
+static int ttf_get_glyph(ALLEGRO_FONT const *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph)
+{
+   ALLEGRO_TTF_FONT_DATA *data = f->data;
+   FT_Face face = data->face;
+   int prev_ft_index = (prev_codepoint == -1) ? -1 : FT_Get_Char_Index(face, prev_codepoint);
+   int ft_index = FT_Get_Char_Index(face, codepoint);
+   return ttf_get_glyph_worker(f, prev_ft_index, ft_index, prev_codepoint, codepoint, glyph);
+}
+
+
+static int render_glyph(ALLEGRO_FONT const *f, ALLEGRO_COLOR color,
+   int prev_ft_index, int ft_index, int32_t prev_ch, int32_t ch, float xpos, float ypos)
+{
+   ALLEGRO_GLYPH glyph;
+   int advance;
+
+   advance = ttf_get_glyph_worker(f, prev_ft_index, ft_index, prev_ch, ch, &glyph);
+
+   if (glyph.bitmap != NULL) {
+      al_draw_tinted_bitmap_region(
+         glyph.bitmap, color,
+         glyph.x, glyph.y, glyph.w, glyph.h,
+         xpos + glyph.offset_x + glyph.kerning,
+         ypos + glyph.offset_y,
+         0
+      );
+   }
 
    return advance;
 }
@@ -578,10 +613,10 @@ static int ttf_render_char(ALLEGRO_FONT const *f, ALLEGRO_COLOR color,
    FT_Face face = data->face;
    int advance = 0;
    int32_t ch32 = (int32_t) ch;
-   
+
    int ft_index = FT_Get_Char_Index(face, ch32);
-   advance = render_glyph(f, color, -1, ft_index, ch, xpos, ypos);
-   
+   advance = render_glyph(f, color, -1, ft_index, -1, ch, xpos, ypos);
+
    return advance;
 }
 
@@ -591,7 +626,7 @@ static int ttf_char_length(ALLEGRO_FONT const *f, int ch)
    int result;
    ALLEGRO_TTF_FONT_DATA *data = f->data;
    ALLEGRO_TTF_GLYPH_DATA *glyph;
-   FT_Face face = data->face;   
+   FT_Face face = data->face;
    int ft_index = FT_Get_Char_Index(face, ch);
    if (!get_glyph(data, ft_index, &glyph)) {
       if (f->fallback) {
@@ -604,7 +639,7 @@ static int ttf_char_length(ALLEGRO_FONT const *f, int ch)
    }
    cache_glyph(data, face, ft_index, glyph, false);
    result = glyph->region.w - 2;
-     
+
    return result;
 }
 
@@ -617,6 +652,7 @@ static int ttf_render(ALLEGRO_FONT const *f, ALLEGRO_COLOR color,
    int pos = 0;
    int advance = 0;
    int prev_ft_index = -1;
+   int32_t prev_ch = -1;
    int32_t ch;
    bool hold;
 
@@ -625,9 +661,10 @@ static int ttf_render(ALLEGRO_FONT const *f, ALLEGRO_COLOR color,
 
    while ((ch = al_ustr_get_next(text, &pos)) >= 0) {
       int ft_index = FT_Get_Char_Index(face, ch);
-      advance += render_glyph(f, color, prev_ft_index, ft_index, ch,
+      advance += render_glyph(f, color, prev_ft_index, ft_index, prev_ch, ch,
          x + advance, y);
       prev_ft_index = ft_index;
+      prev_ch = ch;
    }
 
    al_hold_bitmap_drawing(hold);
@@ -699,7 +736,7 @@ static void ttf_get_text_dimensions(ALLEGRO_FONT const *f,
 
    *bby = ymin;
    *bbw = x - *bbx;
-   *bbh = ymax - ymin; 
+   *bbh = ymax - ymin;
 }
 
 
@@ -803,7 +840,7 @@ ALLEGRO_FONT *al_load_ttf_font_stretch_f(ALLEGRO_FILE *file,
       al_get_config_value(system_cfg, "ttf", "max_page_size");
     const char* cache_str =
       al_get_config_value(system_cfg, "ttf", "cache_text");
-    const char* skip_cache_misses_str = 
+    const char* skip_cache_misses_str =
       al_get_config_value(system_cfg, "ttf", "skip_cache_misses");
 
     if ((h > 0 && w < 0) || (h < 0 && w > 0)) {
@@ -904,7 +941,7 @@ ALLEGRO_FONT *al_load_ttf_font_stretch_f(ALLEGRO_FILE *file,
 
     _al_vector_init(&data->glyph_ranges, sizeof(ALLEGRO_TTF_GLYPH_RANGE));
     _al_vector_init(&data->page_bitmaps, sizeof(ALLEGRO_BITMAP*));
-    
+
     if (data->skip_cache_misses) {
        cache_glyphs(data, "\0", 1);
     }
@@ -992,7 +1029,7 @@ static bool ttf_get_glyph_dimensions(ALLEGRO_FONT const *f,
 {
    ALLEGRO_TTF_FONT_DATA *data = f->data;
    ALLEGRO_TTF_GLYPH_DATA *glyph;
-   FT_Face face = data->face;   
+   FT_Face face = data->face;
    int ft_index = FT_Get_Char_Index(face, codepoint);
    if (!get_glyph(data, ft_index, &glyph)) {
       if (f->fallback) {
@@ -1009,7 +1046,7 @@ static bool ttf_get_glyph_dimensions(ALLEGRO_FONT const *f,
    *bbw = glyph->region.w - 2;
    *bbh = glyph->region.h - 2;
    *bby = glyph->offset_y;
-      
+
    return true;
 }
 
@@ -1019,10 +1056,10 @@ static int ttf_get_glyph_advance(ALLEGRO_FONT const *f, int codepoint1,
    ALLEGRO_TTF_FONT_DATA *data = f->data;
    FT_Face face = data->face;
    int ft_index = FT_Get_Char_Index(face, codepoint1);
-   ALLEGRO_TTF_GLYPH_DATA *glyph; 
+   ALLEGRO_TTF_GLYPH_DATA *glyph;
    int kerning = 0;
    int advance = 0;
-   
+
    if (codepoint1 == ALLEGRO_NO_KERNING) {
       return 0;
    }
@@ -1037,13 +1074,13 @@ static int ttf_get_glyph_advance(ALLEGRO_FONT const *f, int codepoint1,
       }
    }
    cache_glyph(data, face, ft_index, glyph, false);
-   
-   if (codepoint2 != ALLEGRO_NO_KERNING) { 
+
+   if (codepoint2 != ALLEGRO_NO_KERNING) {
       int ft_index1 = FT_Get_Char_Index(face, codepoint1);
-      int ft_index2 = FT_Get_Char_Index(face, codepoint2); 
+      int ft_index2 = FT_Get_Char_Index(face, codepoint2);
       kerning = get_kerning(data, face, ft_index1, ft_index2);
    }
-   
+
    advance = glyph->advance;
    return advance + kerning;
 }
@@ -1072,6 +1109,7 @@ bool al_init_ttf_addon(void)
    vt.get_font_ranges = ttf_get_font_ranges;
    vt.get_glyph_dimensions = ttf_get_glyph_dimensions;
    vt.get_glyph_advance = ttf_get_glyph_advance;
+   vt.get_glyph = ttf_get_glyph;
 
    al_register_font_loader(".ttf", al_load_ttf_font);
 

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -17,6 +17,39 @@ the FreeType library. If you instead pass the filename of a bitmap file, it will
 be loaded with [al_load_bitmap] and a font in Allegro's bitmap font format will
 be created from it with [al_grab_font_from_bitmap].
 
+### API: ALLEGRO_GLYPH
+
+A structure containing the properties of a character in a font.
+
+~~~~c
+typedef struct ALLEGRO_GLYPH {
+   ALLEGRO_BITMAP *bitmap;   // the bitmap the character is on
+   int x;                    // the x position of the glyph on bitmap
+   int y;                    // the y position of the glyph on bitmap
+   int w;                    // the width of the glyph in pixels
+   int h;                    // the height of the glyph in pixels
+   int kerning;              // pixels of kerning (see below)
+   int offset_x;             // x offset to draw the glyph at
+   int offset_y;             // y offset to draw the glyph at
+   int advance;              // number of pixels to advance after this character
+} ALLEGRO_GLYPH;
+~~~~
+
+bitmap may be a sub-bitmap in the case of color fonts.
+
+kerning should be added to the x position you draw to if you want your text
+kerned and depends on which codepoints [al_get_glyph] was called with.
+
+Glyphs are tightly packed onto the bitmap, so you need to add offset_x and
+offset_y to your draw position for the text to look right.
+
+advance is the number of pixels to add to your x position to advance to the
+next character in a string and includes kerning.
+
+Since: 5.2.1
+
+See also: [al_get_glyph]
+
 ### API: al_init_font_addon
 
 Initialise the font addon.
@@ -739,3 +772,14 @@ See also: [al_load_ttf_font_stretch]
 
 Returns the (compiled) version of the addon, in the same format as
 [al_get_allegro_version].
+
+### API: al_get_glyph
+
+Gets all the information about a glyph, including the bitmap, needed to draw it
+yourself. prev_codepoint is the codepoint in the string before the one you want
+to draw and is used for kerning. codepoint is the character you want to get info
+about.
+
+Since: 5.2.1
+
+See also: [ALLEGRO_GLYPH]

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -778,7 +778,8 @@ Returns the (compiled) version of the addon, in the same format as
 Gets all the information about a glyph, including the bitmap, needed to draw it
 yourself. prev_codepoint is the codepoint in the string before the one you want
 to draw and is used for kerning. codepoint is the character you want to get info
-about.
+about. You should clear the 'glyph' structure to 0 with memset before passing it
+to this function for future compatibility.
 
 Since: 5.2.1
 

--- a/examples/ex_ttf.c
+++ b/examples/ex_ttf.c
@@ -61,6 +61,8 @@ static void render(void)
     ALLEGRO_USTR *tulip = al_ustr_new("Tulip");
     ALLEGRO_USTR *dimension_text = al_ustr_new("Tulip");
     ALLEGRO_USTR *vertical_text  = al_ustr_new("Rose.");
+    ALLEGRO_USTR *dimension_label = al_ustr_new("(dimensions)");
+    int prev_cp = -1;
 
     al_clear_to_color(white);
 
@@ -81,7 +83,17 @@ static void render(void)
        x += al_get_glyph_advance(ex.f2, cp, ALLEGRO_NO_KERNING);
     }
     al_draw_line(50.5, y+0.5, x+0.5, y+0.5, red, 1);
-    al_draw_textf(ex.f2, black, x + 10, y, 0, "(dimensions)");
+
+    for (index = 0; index < al_ustr_length(dimension_label); index++) {
+       int cp = ustr_at(dimension_label, index);
+       ALLEGRO_GLYPH g;
+       if (al_get_glyph(ex.f2, prev_cp, cp, &g)) {
+       printf("YIP\n");
+          al_draw_tinted_bitmap_region(g.bitmap, black, g.x, g.y, g.w, g.h, x + 10 + g.offset_x, y + g.offset_y, 0);
+          x += g.advance;
+       }
+       prev_cp = cp;
+    }
 
     al_draw_textf(ex.f3, black, 50, 200, 0, "This font has a size of 12 pixels, "
         "the one above has 48 pixels.");

--- a/examples/ex_ttf.c
+++ b/examples/ex_ttf.c
@@ -88,7 +88,6 @@ static void render(void)
        int cp = ustr_at(dimension_label, index);
        ALLEGRO_GLYPH g;
        if (al_get_glyph(ex.f2, prev_cp, cp, &g)) {
-       printf("YIP\n");
           al_draw_tinted_bitmap_region(g.bitmap, black, g.x, g.y, g.w, g.h, x + 10 + g.offset_x, y + g.offset_y, 0);
           x += g.advance;
        }


### PR DESCRIPTION
The structure contains all the info needed (including the bitmap)
to draw text. The ttf addon's render_glyph was used to make the
vtable function for the ttf addon.

This should allow the user the draw their own text. This hasn't
been tested much, I'm just looking for feedback on the API
right now.