### PR TITLE
Mark the backup and the glyph API as unstable.

### DIFF
--- a/addons/font/allegro5/allegro_font.h
+++ b/addons/font/allegro5/allegro_font.h
@@ -2,7 +2,6 @@
 #define __al_included_allegro5_allegro_font_h
 
 #include "allegro5/allegro.h"
-#include "allegro5/internal/aintern_list.h"
 
 #if (defined ALLEGRO_MINGW32) || (defined ALLEGRO_MSVC) || (defined ALLEGRO_BCC32)
    #ifndef ALLEGRO_STATICLINK
@@ -47,19 +46,11 @@
 /* Type: ALLEGRO_FONT
 */
 typedef struct ALLEGRO_FONT ALLEGRO_FONT;
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_FONT_SRC)
+
 /* Type: ALLEGRO_GLYPH
 */
 typedef struct ALLEGRO_GLYPH ALLEGRO_GLYPH;
-typedef struct ALLEGRO_FONT_VTABLE ALLEGRO_FONT_VTABLE;
-
-struct ALLEGRO_FONT
-{
-   void *data;
-   int height;
-   ALLEGRO_FONT *fallback;
-   ALLEGRO_FONT_VTABLE *vtable;
-   _AL_LIST_ITEM *dtor_item;
-};
 
 struct ALLEGRO_GLYPH
 {
@@ -73,30 +64,7 @@ struct ALLEGRO_GLYPH
    int offset_y;
    int advance;
 };
-
-/* text- and font-related stuff */
-struct ALLEGRO_FONT_VTABLE
-{
-   ALLEGRO_FONT_METHOD(int, font_height, (const ALLEGRO_FONT *f));
-   ALLEGRO_FONT_METHOD(int, font_ascent, (const ALLEGRO_FONT *f));
-   ALLEGRO_FONT_METHOD(int, font_descent, (const ALLEGRO_FONT *f));
-   ALLEGRO_FONT_METHOD(int, char_length, (const ALLEGRO_FONT *f, int ch));
-   ALLEGRO_FONT_METHOD(int, text_length, (const ALLEGRO_FONT *f, const ALLEGRO_USTR *text));
-   ALLEGRO_FONT_METHOD(int, render_char, (const ALLEGRO_FONT *f, ALLEGRO_COLOR color, int ch, float x, float y));
-   ALLEGRO_FONT_METHOD(int, render, (const ALLEGRO_FONT *f, ALLEGRO_COLOR color, const ALLEGRO_USTR *text, float x, float y));
-   ALLEGRO_FONT_METHOD(void, destroy, (ALLEGRO_FONT *f));
-   ALLEGRO_FONT_METHOD(void, get_text_dimensions, (const ALLEGRO_FONT *f,
-      const ALLEGRO_USTR *text, int *bbx, int *bby, int *bbw, int *bbh));
-   ALLEGRO_FONT_METHOD(int, get_font_ranges, (ALLEGRO_FONT *font,
-      int ranges_count, int *ranges));
-      
-   ALLEGRO_FONT_METHOD(bool, get_glyph_dimensions, (const ALLEGRO_FONT *f,
-      int codepoint, int *bbx, int *bby, int *bbw, int *bbh));      
-   ALLEGRO_FONT_METHOD(int, get_glyph_advance, (const ALLEGRO_FONT *font,
-      int codepoint1, int codepoint2));
-
-   ALLEGRO_FONT_METHOD(bool, get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
-};
+#endif
 
 enum {
    ALLEGRO_NO_KERNING       = -1,
@@ -147,7 +115,9 @@ ALLEGRO_FONT_FUNC(bool, al_get_glyph_dimensions, (const ALLEGRO_FONT *f,
    int codepoint, int *bbx, int *bby, int *bbw, int *bbh));
 ALLEGRO_FONT_FUNC(int, al_get_glyph_advance, (const ALLEGRO_FONT *f,
    int codepoint1, int codepoint2));
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_FONT_SRC)
 ALLEGRO_FONT_FUNC(bool, al_get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
+#endif
 
 ALLEGRO_FONT_FUNC(void, al_draw_multiline_text, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *text));
 ALLEGRO_FONT_FUNC(void, al_draw_multiline_textf, (const ALLEGRO_FONT *font, ALLEGRO_COLOR color, float x, float y, float max_width, float line_height, int flags, const char *format, ...));

--- a/addons/font/allegro5/internal/aintern_font.h
+++ b/addons/font/allegro5/internal/aintern_font.h
@@ -1,0 +1,41 @@
+#ifndef __al_included_allegro_aintern_font_h
+#define __al_included_allegro_aintern_font_h
+
+#include "allegro5/internal/aintern_list.h"
+
+typedef struct ALLEGRO_FONT_VTABLE ALLEGRO_FONT_VTABLE;
+
+struct ALLEGRO_FONT
+{
+   void *data;
+   int height;
+   ALLEGRO_FONT *fallback;
+   ALLEGRO_FONT_VTABLE *vtable;
+   _AL_LIST_ITEM *dtor_item;
+};
+
+/* text- and font-related stuff */
+struct ALLEGRO_FONT_VTABLE
+{
+   ALLEGRO_FONT_METHOD(int, font_height, (const ALLEGRO_FONT *f));
+   ALLEGRO_FONT_METHOD(int, font_ascent, (const ALLEGRO_FONT *f));
+   ALLEGRO_FONT_METHOD(int, font_descent, (const ALLEGRO_FONT *f));
+   ALLEGRO_FONT_METHOD(int, char_length, (const ALLEGRO_FONT *f, int ch));
+   ALLEGRO_FONT_METHOD(int, text_length, (const ALLEGRO_FONT *f, const ALLEGRO_USTR *text));
+   ALLEGRO_FONT_METHOD(int, render_char, (const ALLEGRO_FONT *f, ALLEGRO_COLOR color, int ch, float x, float y));
+   ALLEGRO_FONT_METHOD(int, render, (const ALLEGRO_FONT *f, ALLEGRO_COLOR color, const ALLEGRO_USTR *text, float x, float y));
+   ALLEGRO_FONT_METHOD(void, destroy, (ALLEGRO_FONT *f));
+   ALLEGRO_FONT_METHOD(void, get_text_dimensions, (const ALLEGRO_FONT *f,
+      const ALLEGRO_USTR *text, int *bbx, int *bby, int *bbw, int *bbh));
+   ALLEGRO_FONT_METHOD(int, get_font_ranges, (ALLEGRO_FONT *font,
+      int ranges_count, int *ranges));
+
+   ALLEGRO_FONT_METHOD(bool, get_glyph_dimensions, (const ALLEGRO_FONT *f,
+      int codepoint, int *bbx, int *bby, int *bbw, int *bbh));
+   ALLEGRO_FONT_METHOD(int, get_glyph_advance, (const ALLEGRO_FONT *font,
+      int codepoint1, int codepoint2));
+
+   ALLEGRO_FONT_METHOD(bool, get_glyph, (const ALLEGRO_FONT *f, int prev_codepoint, int codepoint, ALLEGRO_GLYPH *glyph));
+};
+
+#endif

--- a/addons/font/font.c
+++ b/addons/font/font.c
@@ -17,6 +17,7 @@
 #include "allegro5/allegro_font.h"
 #include "allegro5/internal/aintern.h"
 #include "allegro5/internal/aintern_bitmap.h"
+#include "allegro5/internal/aintern_font.h"
 #include "allegro5/internal/aintern_exitfunc.h"
 #include "allegro5/internal/aintern_vector.h"
 

--- a/addons/font/font.h
+++ b/addons/font/font.h
@@ -1,6 +1,8 @@
 #ifndef __al_included_allegro5_font_h
 #define __al_included_allegro5_font_h
 
+#include "allegro5/internal/aintern_font.h"
+
 extern ALLEGRO_FONT_VTABLE _al_font_vtable_color;
 
 typedef struct ALLEGRO_FONT_COLOR_DATA

--- a/addons/font/text.c
+++ b/addons/font/text.c
@@ -26,6 +26,7 @@
 
 #include "allegro5/allegro_font.h"
 #include "allegro5/internal/aintern_dtor.h"
+#include "allegro5/internal/aintern_font.h"
 #include "allegro5/internal/aintern_system.h"
 
 /* If you call this, you're probably making a mistake. */

--- a/addons/ttf/ttf.c
+++ b/addons/ttf/ttf.c
@@ -1,3 +1,5 @@
+#define ALLEGRO_INTERNAL_UNSTABLE
+
 #include "allegro5/allegro.h"
 #ifdef ALLEGRO_CFG_OPENGL
 #include "allegro5/allegro_opengl.h"
@@ -6,6 +8,7 @@
 #include "allegro5/internal/aintern_vector.h"
 
 #include "allegro5/allegro_ttf.h"
+#include "allegro5/internal/aintern_font.h"
 #include "allegro5/internal/aintern_ttf_cfg.h"
 #include "allegro5/internal/aintern_dtor.h"
 #include "allegro5/internal/aintern_system.h"

--- a/cmake/FileList.cmake
+++ b/cmake/FileList.cmake
@@ -263,7 +263,6 @@ set(ALLEGRO_INCLUDE_ALLEGRO_INLINE_FILES
 set(ALLEGRO_INCLUDE_ALLEGRO_INTERNAL_FILES
     # Only files which need to be installed.
     include/allegro5/internal/alconfig.h
-    include/allegro5/internal/aintern_list.h
     )
 
 set(ALLEGRO_INCLUDE_ALLEGRO_OPENGL_FILES

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -48,6 +48,8 @@ next character in a string and includes kerning.
 
 Since: 5.2.1
 
+> *[Unstable API]:* This API is new and subject to refinement.
+
 See also: [al_get_glyph]
 
 ### API: al_init_font_addon
@@ -782,5 +784,7 @@ about. You should clear the 'glyph' structure to 0 with memset before passing it
 to this function for future compatibility.
 
 Since: 5.2.1
+
+> *[Unstable API]:* This API is new and subject to refinement.
 
 See also: [ALLEGRO_GLYPH]

--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -1895,6 +1895,8 @@ bitmap is backed up right away instead of during the next flip.
 
 Since: 5.2.1
 
+> *[Unstable API]:* This API is new and subject to refinement.
+
 See also: [al_backup_dirty_bitmaps], [al_create_bitmap]
 
 
@@ -1903,6 +1905,8 @@ See also: [al_backup_dirty_bitmaps], [al_create_bitmap]
 Backs up all of a display's bitmaps to system memory.
 
 Since: 5.2.1
+
+> *[Unstable API]:* This API is new and subject to refinement.
 
 See also: [al_backup_dirty_bitmap]
 

--- a/examples/ex_ttf.c
+++ b/examples/ex_ttf.c
@@ -1,3 +1,5 @@
+#define ALLEGRO_UNSTABLE
+
 #include <stdio.h>
 #include <allegro5/allegro.h>
 #include <allegro5/allegro_ttf.h>

--- a/include/allegro5/bitmap.h
+++ b/include/allegro5/bitmap.h
@@ -82,7 +82,9 @@ AL_FUNC(void, al_reparent_bitmap, (ALLEGRO_BITMAP *bitmap,
 AL_FUNC(ALLEGRO_BITMAP *, al_clone_bitmap, (ALLEGRO_BITMAP *bitmap));
 AL_FUNC(void, al_convert_bitmap, (ALLEGRO_BITMAP *bitmap));
 AL_FUNC(void, al_convert_memory_bitmaps, (void));
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 AL_FUNC(void, al_backup_dirty_bitmap, (ALLEGRO_BITMAP *bitmap));
+#endif
 
 #ifdef __cplusplus
    }

--- a/include/allegro5/display.h
+++ b/include/allegro5/display.h
@@ -175,7 +175,9 @@ AL_FUNC(bool, al_is_bitmap_drawing_held, (void));
 /* Miscellaneous */
 AL_FUNC(void, al_acknowledge_drawing_halt, (ALLEGRO_DISPLAY *display));
 AL_FUNC(void, al_acknowledge_drawing_resume, (ALLEGRO_DISPLAY *display));
+#if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 AL_FUNC(void, al_backup_dirty_bitmaps, (ALLEGRO_DISPLAY *display));
+#endif
 
 #ifdef __cplusplus
    }


### PR DESCRIPTION
Also, split out some internals from allegro_font.h into an internal header, so we don't have to install aintern_list.h.