### PR TITLE
Disable DEPTH_TEST Render State Before Drawing HUD

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -16,6 +16,7 @@ Edgar Reynaldo
 ElectricSolstice
 Elias Pschernig
 Eric Botcazou
+Erich Erstu
 Evert Glebbeek
 gameovera
 George Foot

--- a/examples/ex_camera.c
+++ b/examples/ex_camera.c
@@ -403,7 +403,6 @@ static void handle_input(void)
          camera_move_along_direction(&ex.camera, ex.movement_speed * x,
             ex.movement_speed * y);
       }
-         
    }
 
    /* Rotate the camera, either freely or around world up only. */

--- a/examples/ex_camera.c
+++ b/examples/ex_camera.c
@@ -315,6 +315,7 @@ static void draw_scene(void)
    al_identity_transform(&t);
    al_use_transform(&t);
    al_use_projection_transform(&projection);
+   al_set_render_state(ALLEGRO_DEPTH_TEST, 0);
 
    /* Draw some text. */
    th = al_get_font_line_height(ex.font);


### PR DESCRIPTION
When playing around with the ex_camera example I ran into a weird bug that made the checkerboard to be drawn on top of the debug texts in the upper left corner of the screen. This happened when the control style was switched to the spaceship or airplane mode and I moved the camera halfway inside the checkerboard. Since I debugged the situation for quite some time I figured that I should better commit a fix so that others would not waste their time on debugging the same exact issue in the future.