### PR TITLE
Fix a crash when activity is destroy on Android.

### DIFF
--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -285,7 +285,8 @@ JNI_FUNC(bool, AllegroActivity, nativeOnCreate, (JNIEnv *env, jobject obj))
 
 JNI_FUNC(void, AllegroActivity, nativeOnPause, (JNIEnv *env, jobject obj))
 {
-   (void)env; (void)obj;
+   (void)env;
+   (void)obj;
 
    ALLEGRO_DEBUG("pause activity\n");
 
@@ -293,12 +294,15 @@ JNI_FUNC(void, AllegroActivity, nativeOnPause, (JNIEnv *env, jobject obj))
 
    ALLEGRO_SYSTEM *sys = (void *)al_get_system_driver();
 
-   if(!system_data.system || !sys) {
+   if (!system_data.system || !sys) {
       ALLEGRO_DEBUG("no system driver");
       return;
    }
 
-   // ASSERT(sys != NULL);
+   if (!_al_vector_size(&sys->displays)) {
+      ALLEGRO_DEBUG("no display, not sending SWITCH_OUT event");
+      return;
+   }
 
    ALLEGRO_DISPLAY *display = *(ALLEGRO_DISPLAY**)_al_vector_ref(&sys->displays, 0);
 
@@ -312,10 +316,6 @@ JNI_FUNC(void, AllegroActivity, nativeOnPause, (JNIEnv *env, jobject obj))
          _al_event_source_emit_event(&display->es, &event);
       }
       _al_event_source_unlock(&display->es);
-
-      ALLEGRO_DISPLAY_ANDROID *d = (ALLEGRO_DISPLAY_ANDROID*)display;
-      if (d->created)
-         _al_android_destroy_surface(env, d, false);
    }
 }
 

--- a/src/system.c
+++ b/src/system.c
@@ -282,7 +282,9 @@ bool al_install_system(int version, int (*atexit_ptr)(void (*)(void)))
       active_sysdrv->vt->heartbeat_init();
 
    if (atexit_ptr && atexit_virgin) {
+#ifndef ALLEGRO_ANDROID
       atexit_ptr(al_uninstall_system);
+#endif
       atexit_virgin = false;
    }
 


### PR DESCRIPTION
The crash occurred when onDestroy was called before main exited.
This can happen when memory is low and possibly other instances.
The only way I could reproduce it was setting "Don't keep activities"
in developer options. Previously, games would crash as soon as
you closed them with this option on. Presumably the activity isn't
in a complete state when onDestroy is called like this: the crash
occurred in android_cleanup at the calls to finish_activity and
DetachThread. The exit(0) is needed or else resuming (restarting)
the game will not work.

Some ALLEGRO_DEBUGs were also removed for good measure: anything
after Allegro has been shut down or the activity is dying has
been removed.