### PR TITLE
Fix transform docs typo.

### DIFF
--- a/docs/src/refman/transformations.txt
+++ b/docs/src/refman/transformations.txt
@@ -75,7 +75,7 @@ al_identity_transform(&T);
 al_compose_transform(&T, &T1);
 al_compose_transform(&T, &T2);
 
-al_use_transform(T);
+al_use_transform(&T);
 ~~~~
 
 it does exactly the same as:
@@ -84,7 +84,7 @@ it does exactly the same as:
 al_identity_transform(&T);
 al_scale_transform(&T, 2, 2);
 al_translate_transform(&T, 100, 0);
-al_use_transform(T);
+al_use_transform(&T);
 ~~~~
 
 ## API: ALLEGRO_TRANSFORM


### PR DESCRIPTION
al_use_transform takes a pointer, just like the other transform
functions. Depict this correctly in the docs.