### PR TITLE
Allow 32-bit build on OSX

### DIFF
--- a/src/macosx/qzmouse.m
+++ b/src/macosx/qzmouse.m
@@ -342,7 +342,11 @@ static bool osx_set_mouse_xy(ALLEGRO_DISPLAY *dpy_, int x, int y)
 
       CGPoint point_pos = CGPointMake(x, y);
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+#if __LP64__ || TARGET_OS_EMBEDDED || TARGET_OS_IPHONE || TARGET_OS_WIN32 || NS_BUILD_32_LIKE_64
       point_pos = [[window contentView] convertPointFromBacking: point_pos];
+#else
+      point_pos = NSPointToCGPoint([[window contentView] convertPointFromBacking: NSPointFromCGPoint(point_pos)]);
+#endif
 #endif
       pos.x = content.origin.x + point_pos.x;
       pos.y = rect.size.height - content.origin.y - content.size.height + point_pos.y;

--- a/src/macosx/qzmouse.m
+++ b/src/macosx/qzmouse.m
@@ -342,11 +342,7 @@ static bool osx_set_mouse_xy(ALLEGRO_DISPLAY *dpy_, int x, int y)
 
       CGPoint point_pos = CGPointMake(x, y);
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
-#if __LP64__ || TARGET_OS_EMBEDDED || TARGET_OS_IPHONE || TARGET_OS_WIN32 || NS_BUILD_32_LIKE_64
-      point_pos = [[window contentView] convertPointFromBacking: point_pos];
-#else
       point_pos = NSPointToCGPoint([[window contentView] convertPointFromBacking: NSPointFromCGPoint(point_pos)]);
-#endif
 #endif
       pos.x = content.origin.x + point_pos.x;
       pos.y = rect.size.height - content.origin.y - content.size.height + point_pos.y;


### PR DESCRIPTION
On 64-bit systems, NSPoint is an alias of CGPoint.
NSPoint is an alias of CGPoint if any of the following are true:
__LP64__, TARGET_OS_EMBEDDED, TARGET_OS_IPHONE, TARGET_OS_WIN32, or
NS_BUILD_32_LIKE_64.
See
/System/Library/Frameworks/Foundation.framework/Headers/NSGeometry.h.
If NSPoint and CGPoint are different data types, convert between them.