### PR TITLE
use dynamic OpenGL ES version for checks

### DIFF
--- a/android/allegro_activity/src/AllegroEGL.java
+++ b/android/allegro_activity/src/AllegroEGL.java
@@ -63,7 +63,7 @@ class AllegroEGL
 
       egl_Display = dpy;
 
-      Log.d(TAG, "egl_Init end");
+      Log.d(TAG, "egl_Init OpenGL ES " + egl_version[0] + "." + egl_version[1]);
       return true;
    }
 
@@ -213,12 +213,9 @@ class AllegroEGL
          return 0;
       }
 
-      Log.d(TAG, "EGL context created");
+      Log.d(TAG, "EGL context (OpenGL ES " + version + ") created");
 
       egl_Context = ctx;
-
-      Log.d(TAG, "egl_createContext end");
-
       return 1;
    }
 

--- a/src/opengl/extensions.c
+++ b/src/opengl/extensions.c
@@ -98,6 +98,15 @@ static uint32_t parse_opengl_version(const char *s)
    int n;
    uint32_t ver;
 
+   /* For OpenGL ES version strings have the form:
+    * "OpenGL ES-<profile> <major>.<minor>"
+    * So for example: "OpenGL ES-CM 2.0". We simply skip any non-digit
+    * characters and then parse it like for normal OpenGL.
+    */
+   while (*p && !isdigit(*p)) {
+      p++;
+   }
+
    /* e.g. "4.0.0 Vendor blah blah" */
    for (n = 0; n < 4; n++) {
       char *end;

--- a/src/opengl/ogl_draw.c
+++ b/src/opengl/ogl_draw.c
@@ -36,6 +36,22 @@ ALLEGRO_DEBUG_CHANNEL("opengl")
 #endif
 #endif
 
+static void try_const_color(ALLEGRO_DISPLAY *ogl_disp, ALLEGRO_COLOR *c)
+{
+   #ifdef ALLEGRO_CFG_OPENGLES
+      #ifndef ALLEGRO_CFG_OPENGLES2
+         return;
+      #endif
+      // Only OpenGL ES 2.0 has glBlendColor
+      if (ogl_disp->ogl_extras->ogl_info.version < _ALLEGRO_OPENGL_VERSION_2_0) {
+         return;
+      }
+   #else
+   (void)ogl_disp;
+   #endif
+   glBlendColor(c->r, c->g, c->b, c->a);
+}
+
 bool _al_opengl_set_blender(ALLEGRO_DISPLAY *ogl_disp)
 {
    int op, src_color, dst_color, op_alpha, src_alpha, dst_alpha;
@@ -75,11 +91,7 @@ bool _al_opengl_set_blender(ALLEGRO_DISPLAY *ogl_disp)
 #endif
 #endif
       glEnable(GL_BLEND);
-#if defined(ALLEGRO_CFG_OPENGLES2) || !defined(ALLEGRO_CFG_OPENGLES)
-   #ifndef ALLEGRO_ANDROID_HACK_X86_64
-      glBlendColor(const_color.r, const_color.g, const_color.b, const_color.a);
-   #endif
-#endif
+      try_const_color(ogl_disp, &const_color);
       glBlendFuncSeparate(blend_modes[src_color], blend_modes[dst_color],
          blend_modes[src_alpha], blend_modes[dst_alpha]);
       if (ogl_disp->ogl_extras->ogl_info.version >= _ALLEGRO_OPENGL_VERSION_2_0) {
@@ -94,11 +106,7 @@ bool _al_opengl_set_blender(ALLEGRO_DISPLAY *ogl_disp)
    else {
       if (src_color == src_alpha && dst_color == dst_alpha) {
          glEnable(GL_BLEND);
-#if defined(ALLEGRO_CFG_OPENGLES2) || !defined(ALLEGRO_CFG_OPENGLES)
-   #ifndef ALLEGRO_ANDROID_HACK_X86_64
-         glBlendColor(const_color.r, const_color.g, const_color.b, const_color.a);
-   #endif
-#endif
+         try_const_color(ogl_disp, &const_color);
          glBlendFunc(blend_modes[src_color], blend_modes[dst_color]);
       }
       else {


### PR DESCRIPTION
That way we can compile the OpenGL ES 2 version and still allow programs
to work with OpenGL ES 1.