### PR TITLE
In docs, clarify al_clone_bitmap and bitmap flags

### DIFF
--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -506,8 +506,10 @@ See also: [al_create_bitmap]
 ### API: al_clone_bitmap
 
 Create a new bitmap with [al_create_bitmap], and copy the pixel data from the
-old bitmap across. If the new bitmap is a memory bitmap, its projection bitmap
-is reset to be orthographic.
+old bitmap across. The newly created bitmap will be created with the current
+new bitmap flags, and not the ones that were used to create the original
+bitmap.  If the new bitmap is a memory bitmap, its projection bitmap is reset
+to be orthographic.
 
 See also: [al_create_bitmap], [al_set_new_bitmap_format],
 [al_set_new_bitmap_flags], [al_convert_bitmap]


### PR DESCRIPTION
## Problem

It wasn't clear if `al_clone_bitmap` would preserve the bitmap flags used when creating the source bitmap, or if it would use the current new bitmap flags.  I had to go to the source, and then also test it in production to see what happened to the flags.

## Solution

Update the docs to add a bit of clarity. 😊 