### PR TITLE
Implement al_path_ustr()

### DIFF
--- a/docs/src/refman/path.txt
+++ b/docs/src/refman/path.txt
@@ -218,7 +218,25 @@ To use the current native path separator, use ALLEGRO_NATIVE_PATH_SEP
 for 'delim'.
 
 The returned pointer is valid only until the path is modified in any way,
-or until the path is destroyed.
+or until the path is destroyed.  This returns a null-terminated string.  If you
+need an ALLEGRO_USTR instead, use [al_path_ustr].
+
+See also: [al_path_ustr]
+
+## API: al_path_ustr
+
+Convert a path to its string representation, i.e. optional drive,
+followed by directory components separated by 'delim',
+followed by an optional filename.
+
+To use the current native path separator, use ALLEGRO_NATIVE_PATH_SEP
+for 'delim'.
+
+The returned pointer is valid only until the path is modified in any way,
+or until the path is destroyed.  This returns an ALLEGRO_USTR.  If you need
+a null-terminated string instead, use [al_path_cstr].
+
+See also: [al_path_cstr]
 
 ## API: al_make_path_canonical
 

--- a/include/allegro5/path.h
+++ b/include/allegro5/path.h
@@ -2,6 +2,7 @@
 #define __al_included_allegro5_path_h
 
 #include "allegro5/base.h"
+#include "allegro5/utf8.h"
 
 #ifdef __cplusplus
    extern "C" {
@@ -33,6 +34,7 @@ AL_FUNC(void, al_append_path_component, (ALLEGRO_PATH *path, const char *s));
 AL_FUNC(bool, al_join_paths, (ALLEGRO_PATH *path, const ALLEGRO_PATH *tail));
 AL_FUNC(bool, al_rebase_path, (const ALLEGRO_PATH *head, ALLEGRO_PATH *tail));
 AL_FUNC(const char*, al_path_cstr, (const ALLEGRO_PATH *path, char delim));
+AL_FUNC(const ALLEGRO_USTR*, al_path_ustr, (const ALLEGRO_PATH *path, char delim));
 AL_FUNC(void, al_destroy_path, (ALLEGRO_PATH *path));
 
 AL_FUNC(void, al_set_path_drive, (ALLEGRO_PATH *path, const char *drive));

--- a/src/path.c
+++ b/src/path.c
@@ -412,8 +412,15 @@ static void path_to_ustr(const ALLEGRO_PATH *path, int32_t delim,
  */
 const char *al_path_cstr(const ALLEGRO_PATH *path, char delim)
 {
+   return al_cstr(al_path_ustr(path, delim));
+}
+
+/* Function: al_path_ustr
+ */
+const ALLEGRO_USTR *al_path_ustr(const ALLEGRO_PATH *path, char delim)
+{
    path_to_ustr(path, delim, path->full_string);
-   return al_cstr(path->full_string);
+   return path->full_string;
 }
 
 


### PR DESCRIPTION
Adds a new `al_path_ustr()` function which returns the full path as an `ALLEGRO_USTR*` instead of a null-terminated string.  This is sometimes useful since many Allegro APIs use ALLEGRO_USTR in lieu of plain C strings.

Fixes #708.