### PR TITLE
Mac OS X 10.6 fixes

### DIFF
--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -119,6 +119,7 @@ void _al_shutdown_native_dialog_addon(void)
 bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
                                  ALLEGRO_NATIVE_DIALOG *fd)
 {
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     (void)display;
     
     [ALLEGFileDialog performSelectorOnMainThread: @selector(displayFileDialog:)
@@ -126,6 +127,8 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
                                 waitUntilDone: YES];
     _al_osx_clear_mouse_state();
     
+    [pool release];
+
     return true;
 }
 
@@ -588,6 +591,7 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amenu)
 // Insert an item, keep the NSMenu in sync
 -(void) insertItem:(ALLEGRO_MENU_ITEM*) aitem atIndex: (int) index
 {
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     NSMenuItem* item = [self buildMenuItemFor:aitem];
     [self.menu insertItem:item atIndex:index];
     if (aitem->popup) {
@@ -595,23 +599,28 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amenu)
         [[sub menu] setTitle:[item title]];
         [item setSubmenu:[sub menu]];
     }
+    [pool release];
 }
 // Update an item (caption only, see -validateMenuItem: )
 -(void) updateItem:(ALLEGRO_MENU_ITEM *)aitem atIndex:(int)index
 {
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     (void) index;
     NSMenuItem* item = [self itemForAllegroItem:aitem];
     NSMutableString* caption = [NSMutableString stringWithUTF8String:al_cstr(aitem->caption)];
     NSString* key = extract_accelerator(caption);
     [item setTitle:caption];
     [item setKeyEquivalent:key];
+    [pool release];
 }
 // Remove an item, keep the NSMenu in sync
 -(void) destroyItem:(ALLEGRO_MENU_ITEM *)aitem atIndex:(int)index
 {
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     (void) index;
     NSMenuItem* item = [self itemForAllegroItem:aitem];
     [item.menu removeItem:item];
+    [pool release];
 }
 // Show the menu on the main application menu bar
 -(void) show
@@ -714,6 +723,7 @@ static ALLEGTargetManager* _sharedmanager = nil;
 // Link a menu with a window, replace any existing link
 -(void) setMenu:(NSMenu *)menu forWindow:(NSWindow *)window
 {
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     NSUInteger index = [self indexForWindow:window];
     if (menu) {
         NSDictionary* newentry = [NSDictionary dictionaryWithObjectsAndKeys:menu, @"menu", window, @"window", nil];
@@ -729,5 +739,6 @@ static ALLEGTargetManager* _sharedmanager = nil;
             [self->_items removeObjectAtIndex:index];
         }
     }
+    [pool release];
 }
 @end // ALLEGTargetManager

--- a/include/allegro5/opengl/gl_ext.h
+++ b/include/allegro5/opengl/gl_ext.h
@@ -2,8 +2,6 @@
 #ifndef __al_included_allegro5_gl_ext_h
 #define __al_included_allegro5_gl_ext_h
 
-typedef struct ALLEGRO_OGL_EXT_LIST ALLEGRO_OGL_EXT_LIST;
-
 #if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 
 /*
@@ -136,6 +134,10 @@ typedef struct ALLEGRO_OGL_EXT_API {
 #undef AGL_API
 #endif
 } ALLEGRO_OGL_EXT_API;
+
+#else
+
+typedef struct ALLEGRO_OGL_EXT_LIST ALLEGRO_OGL_EXT_LIST;
 
 #endif
 


### PR DESCRIPTION
- Fix build in Mac OS X 10.6. The default compiler provided by XCode 4.2 is llvm-gcc-4.2 which fails to compile modules for which gl_ext.h redefines type ALLEGRO_OGL_EXT_LIST. This isn't an issue for later versions of GCC which allow for such redefinitions. This fix is important, though, because that's the latest GCC officially released by Apple for such system, and I couldn't build an working Allegro using compilers provided by MacPorts, since although builds were successfully completed, Allegro systematically segfaulted at misaligned_stack_error system function for any program.

- Fix warnings "__NSAutoreleaseNoPool(): Object ? of class ? autoreleased with no pool in place - just leaking" when building or modifying menus under Mac OS X 10.6.