### PR TITLE
Fix newlines being added ad-infinitum to config files

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -408,9 +408,9 @@ static bool config_write_section(ALLEGRO_FILE *file,
                al_fputs(file, "# ");
             }
             al_fputs(file, al_cstr(e->key));
+            al_fputc(file, '\n');
+            *should_blank = false;
          }
-         al_fputc(file, '\n');
-         *should_blank = false;
       }
       else {
          al_fputs(file, al_cstr(e->key));


### PR DESCRIPTION
Prevent config_write_section from adding superfluous newlines for empty comments, which spontaneously arise when using al_remove_config_* functions.

When saving settings to its main configuration file, MININIM (my Allegro-based game) uses al_get_first_\*, al_get_next_\* and al_remove_config_\* functions to remove any duplicate keys (irregardless of case) to ensure each entry is unique.  Oddly enough, this results in new lines being added before reinserted entries for each removal.  Over time the configuration file gets bigger, sparse and thus confuse to human readers.