### PR TITLE
4.4: implement load_midi_pf

### DIFF
--- a/include/allegro/midi.h
+++ b/include/allegro/midi.h
@@ -24,6 +24,10 @@
 #ifdef __cplusplus
    extern "C" {
 #endif
+
+struct PACKFILE;
+
+
                                        /* Theoretical maximums: */
 #define MIDI_VOICES           64       /* actual drivers may not be */
 #define MIDI_TRACKS           32       /* able to handle this many */
@@ -116,6 +120,7 @@ AL_VAR(long, midi_loop_end);           /* loop when we hit this position */
 AL_FUNC(int, detect_midi_driver, (int driver_id));
 
 AL_FUNC(MIDI *, load_midi, (AL_CONST char *filename));
+AL_FUNC(MIDI *, load_midi_pf, (struct PACKFILE *f));
 AL_FUNC(void, destroy_midi, (MIDI *midi));
 AL_FUNC(int, play_midi, (MIDI *midi, int loop));
 AL_FUNC(int, play_looped_midi, (MIDI *midi, int loop_start, int loop_end));


### PR DESCRIPTION
This adds **load_midi_pf** function as a part of Allegro 4.4 API.

Resource loading functions in Allegro 4 usually come in pairs, one takes filename as parameter, another takes PACKFILE, which may be convenient if program uses custom resource storage. But midi does not provide PACKFILE variant.

I tried to keep code changes at minimum, basically splitting existing load_midi into two functions, using existing function pairs (such as **load_wav** & **load_wav_pf**) as an example.

This request is related to an old issue created several years ago: #460  I found that the root of the issue was that some objects could not be created using program's own PACKFILEs at that time. MIDI seem to be the only object left that still missing this possibility. If this pull request is accepted, I believe #460 could be closed.