### PR TITLE
Don't add blank lines before config sections when writing them out.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -386,7 +386,7 @@ ALLEGRO_CONFIG *al_load_config_file_f(ALLEGRO_FILE *file)
 
 
 static bool config_write_section(ALLEGRO_FILE *file,
-   const ALLEGRO_CONFIG_SECTION *s, bool *should_blank)
+   const ALLEGRO_CONFIG_SECTION *s)
 {
    ALLEGRO_CONFIG_ENTRY *e;
 
@@ -394,7 +394,6 @@ static bool config_write_section(ALLEGRO_FILE *file,
       al_fputc(file, '[');
       al_fputs(file, al_cstr(s->name));
       al_fputs(file, "]\n");
-      *should_blank = false;
       if (al_ferror(file)) {
          return false;
       }
@@ -410,14 +409,12 @@ static bool config_write_section(ALLEGRO_FILE *file,
             al_fputs(file, al_cstr(e->key));
          }
          al_fputc(file, '\n');
-         *should_blank = false;
       }
       else {
          al_fputs(file, al_cstr(e->key));
          al_fputc(file, '=');
          al_fputs(file, al_cstr(e->value));
          al_fputc(file, '\n');
-         *should_blank = true;
       }
       if (al_ferror(file)) {
          return false;
@@ -452,13 +449,12 @@ bool al_save_config_file(const char *filename, const ALLEGRO_CONFIG *config)
 bool al_save_config_file_f(ALLEGRO_FILE *file, const ALLEGRO_CONFIG *config)
 {
    ALLEGRO_CONFIG_SECTION *s;
-   bool should_blank = false;
 
    /* Save global section */
    s = config->head;
    while (s != NULL) {
       if (al_ustr_size(s->name) == 0) {
-         if (!config_write_section(file, s, &should_blank)) {
+         if (!config_write_section(file, s)) {
             return false;
          }
          break;
@@ -470,10 +466,7 @@ bool al_save_config_file_f(ALLEGRO_FILE *file, const ALLEGRO_CONFIG *config)
    s = config->head;
    while (s != NULL) {
       if (al_ustr_size(s->name) > 0) {
-         if (should_blank) {
-            al_fputs(file, "\n");
-         }
-         if (!config_write_section(file, s, &should_blank)) {
+         if (!config_write_section(file, s)) {
             return false;
          }
       }


### PR DESCRIPTION
This interacts badly when the entries have been moved around after file loading.

E.g. consider this config file:

```ini
[section1]
key=val
<BLANK_LINE>
[section2]
```

If, after loading, a 'key' is removed and a new key is added, the configuration will look like this (in memory):

```ini
[section1]
<BLANK_LINE>
key=val
[section2]
```

When saving, the old code would add an additional blank line before [section2].
It's bad enough that the blank line got moved to a strange location, but it's
even worse that it got duplicated. This change keeps the odd line
rearrangement, but removes the code to add a blank line before a section.

Ultimately the current code is only adequate when no entries are added or
removed, otherwise the comments will be misplaced. The philosophy of this
change is that Allegro only writes out what it has read from the file, and what
the user added via al_add_config_comment etc. The fact that the amount of
control using those operations is still kind of low remains, but at least
everything is semantically consistent.

If a blank line is required, it's easy to call al_add_config_comment.