### PR TITLE
[PATCH] clearance of the ALLEGRO_MAXIMIZED flag from display->flags under X11

### DIFF
--- a/src/x/xdisplay.c
+++ b/src/x/xdisplay.c
@@ -425,7 +425,7 @@ static ALLEGRO_DISPLAY_XGLX *xdpy_create_display_locked(
       }
    }
 
-   if (display->flags & ALLEGRO_MAXIMIZED) {
+   if (flags & ALLEGRO_MAXIMIZED) {
       _al_xwin_maximize(display, true);
    }
 


### PR DESCRIPTION
Hi,

I'd already said about this bug on the allegro's mail list. I'd expanded details a bit.

**Short version**:
Due the asynchronous nature of X11 allegro clears the ALLEGRO_MAXIMIZED flag from display->flags before check against existence of ALLEGRO_MAXIMIZED and later do request to X11 to maximize the window.

**Long version**:
1. Creation of a window starts from the `xdpy_create_display()` function (`src/x/display.c`).
2. It calls `xdpy_create_display_locked()` (`srx/x/xdisplay.c`).
3. `xdpy_create_display_locked()` copies display flags passed to it: `display->flags = flags;`.
4. Then the function creates the window for us. At this moment we sent some requests to X11 and it answers to us.
5. Allegro, in another thread, is processing X11 events for us.
6. When X11 sends to us the `ConfigureNotify` event (see function `process_x11_event()` in `src/x/xevents.c`) it calls `_al_xglx_display_configure_event()` from `src/x/xdisplay.c`.
7. The `_al_xglx_display_configure_event()` function calls `_al_xglx_display_configure()` (`src/x/xdisplay.c`).
8. The last one calls `_al_xwin_check_maximized()` from `src/x/xwindow.c` and it **clears** the ALLEGRO_MAXIMIZED flag.
9. We are still inside of the function `xdpy_create_display_locked()` at this moment...
10. The check and the request to maximize the window fails: `if (display->flags & ALLEGRO_MAXIMIZED) {...}`
11. As result we even do NOT call the appropriate function `_al_xwin_maximize()` (`src/x/xwindow.c`).

Honestly, I am not sure why we need to modify `display->flags` for this task. Anyway, seems to be the patch not affects the internal logic of Allegro. Advices are welcome!

Thanks!

**References**:
1. [Information about ConfigureNotify Events](https://www.x.org/releases/current/doc/libX11/libX11/libX11.html#ConfigureNotify_Events)
