### PR TITLE
[PATCH] fs_stdio_read_directory appends an extra slash

### DIFF
--- a/src/fshook_stdio.c
+++ b/src/fshook_stdio.c
@@ -441,9 +441,19 @@ static ALLEGRO_FS_ENTRY *fs_stdio_read_directory(ALLEGRO_FS_ENTRY *fp)
          return NULL;
       }
       memcpy(buf, fp_stdio->abs_path, abs_path_len);
-      buf[abs_path_len] = ALLEGRO_NATIVE_PATH_SEP;
-      memcpy(buf + abs_path_len + 1, ent->d_name, ent_name_len);
-      buf[abs_path_len + 1 + ent_name_len] = '\0';
+      if (  (abs_path_len >= 1) &&
+            buf[abs_path_len - 1] == ALLEGRO_NATIVE_PATH_SEP)
+      {
+         /* do NOT add a new separator if we have one already */
+         memcpy(buf + abs_path_len, ent->d_name, ent_name_len);
+         buf[abs_path_len + ent_name_len] = '\0';
+      }
+      else {
+         /* append separator */
+         buf[abs_path_len] = ALLEGRO_NATIVE_PATH_SEP;
+         memcpy(buf + abs_path_len + 1, ent->d_name, ent_name_len);
+         buf[abs_path_len + 1 + ent_name_len] = '\0';
+      }
       ret = create_abs_path_entry(buf);
       al_free(buf);
    }


### PR DESCRIPTION
**Description**:
`fs_stdio_read_directory()` appends an extra slash even if it already exists.

This is a patch for #714 
The bug affects *nixes too. I have tested it under GNU/Linux & Windows 7, but seems to be it affects all systems with stdio.

Contents of **al_bug_fs_stdio_read_directory.c** (*nix version):
```c
#include "allegro5/allegro.h"
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

#define PATH1 			"/"
#define PATH1_TEST		"/etc"

#define PATH2			"/home/"
#define PATH2_TEST		"/home/my_user"


static int
fs_entry_cb(ALLEGRO_FS_ENTRY *e, void *extra)
{
	static uint32_t emode;
	static const char *ename;
	(void) extra;

	ename = al_get_fs_entry_name(e);
	emode = al_get_fs_entry_mode(e);

	if (emode & ALLEGRO_FILEMODE_ISDIR) {
		if (strcmp(ename, PATH1_TEST) == 0)
			fprintf(stderr, "OK path1: %s\n", ename);
		else if (strcmp(ename, PATH2_TEST) == 0)
			fprintf(stderr, "OK path2: %s\n", ename);
		else
			fprintf(stderr, "FAIL: %s\n", ename);
	}

	return ALLEGRO_FOR_EACH_FS_ENTRY_SKIP;
}


static void
list_directory(const char *path)
{
	ALLEGRO_FS_ENTRY *entry = al_create_fs_entry(path);

	if (! al_open_directory(entry)) {
		fprintf(stderr, "open directory: %s\n",
			strerror(al_get_errno()));
		return;
	}

	fprintf(stderr, "dir %s\n", path);

	switch (al_for_each_fs_entry(entry, fs_entry_cb, NULL)) {
	case ALLEGRO_FOR_EACH_FS_ENTRY_OK:
		fprintf(stderr, "al_for_each_fs_entry: %s\n\n", "OK");
		break;
	case ALLEGRO_FOR_EACH_FS_ENTRY_ERROR:	/* with    al_set_errno() */
		fprintf(stderr, "al_for_each_fs_entry: %s\n\n",
			strerror(al_get_errno()));
		break;
	case ALLEGRO_FOR_EACH_FS_ENTRY_STOP:	/* without al_set_errno() */
		fprintf(stderr, "al_for_each_fs_entry: %s\n\n", "STOP");
		break;
	default:
		fprintf(stderr, "al_for_each_fs_entry: UNKNOWN\n");
		break;
	}

	if (! al_close_directory(entry))
		fprintf(stderr, "close directory\n");
}

int main()
{	
	const char pathA[] = PATH1;
	const char pathB[] = PATH2;


	if (al_init()) {
		list_directory(pathA);
		list_directory(pathB);
	}
	else {
		fprintf(stderr, "failed to initialize Allegro\n");
	}

	return 0;
}
```

Contents of **Makefile**:
```Makefile
ALLEGRO_SUFFIX = -debug
ALLEGRO_MODS = allegro$(ALLEGRO_SUFFIX)-5 allegro_main$(ALLEGRO_SUFFIX)-5
ALLEGRO_LIBS = $(shell pkg-config --libs $(ALLEGRO_MODS))
ALLEGRO_CFLAGS = $(shell pkg-config --cflags $(ALLEGRO_MODS))

CFLAGS ?= -Wall -Wextra -std=c99 $(ALLEGRO_CFLAGS)
LDFLAGS ?=
LIBS ?= $(ALLEGRO_LIBS)

TARGET = t1
SOURCES = $(wildcard *.c)
OBJECTS = $(patsubst %.c,%.o,$(SOURCES))

all: $(TARGET)

devel: CFLAGS += -D_DEBUG -g
devel: all

$(TARGET): $(OBJECTS)
	$(CC) $(LDFLAGS) -o $@ $(OBJECTS) $(LIBS)

%.o: %.c
	$(CC) -c $(CFLAGS) -o $@ $<

clean:
	$(RM) $(TARGET) $(OBJECTS)

.PHONY: all clean
```
