### PR TITLE
Replaced the custom _al_set_error method 

### DIFF
--- a/addons/audio/allegro5/internal/aintern_audio.h
+++ b/addons/audio/allegro5/internal/aintern_audio.h
@@ -353,15 +353,6 @@ extern void _al_kcm_mixer_read(void *source, void **buf, unsigned int *samples,
    ALLEGRO_AUDIO_DEPTH buffer_depth, size_t dest_maxc);
 
 
-typedef enum {
-   ALLEGRO_NO_ERROR       = 0,
-   ALLEGRO_INVALID_PARAM  = 1,
-   ALLEGRO_INVALID_OBJECT = 2,
-   ALLEGRO_GENERIC_ERROR  = 255
-} AL_ERROR_ENUM;
-
-extern void _al_set_error(int error, char* string);
-
 /* Supposedly internal */
 ALLEGRO_KCM_AUDIO_FUNC(void*, _al_kcm_feed_stream, (ALLEGRO_THREAD *self, void *vstream));
 

--- a/addons/audio/audio.c
+++ b/addons/audio/audio.c
@@ -18,11 +18,6 @@
 
 ALLEGRO_DEBUG_CHANNEL("audio")
 
-void _al_set_error(int error, char* string)
-{
-   ALLEGRO_ERROR("%s (error code: %d)\n", string, error);
-}
-
 ALLEGRO_AUDIO_DRIVER *_al_kcm_driver = NULL;
 
 #if defined(ALLEGRO_CFG_KCM_OPENAL)
@@ -202,7 +197,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
 
    /* check to see if a driver is already installed and running */
    if (_al_kcm_driver) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR, "A driver already running");
+      ALLEGRO_ERROR("A driver is already running");
       return false;
    }
 
@@ -259,7 +254,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             return retVal;
 #endif
 
-         _al_set_error(ALLEGRO_INVALID_PARAM, "No audio driver can be used.");
+         ALLEGRO_ERROR("No audio driver can be used.");
          _al_kcm_driver = NULL;
          return false;
 
@@ -272,7 +267,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             }
             return false;
          #else
-            _al_set_error(ALLEGRO_INVALID_PARAM, "Audio Queue driver not available on this platform");
+            ALLEGRO_ERROR("Audio Queue driver not available on this platform");
             return false;
          #endif
 
@@ -285,7 +280,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             }
             return false;
          #else
-            _al_set_error(ALLEGRO_INVALID_PARAM, "OpenAL not available on this platform");
+            ALLEGRO_ERROR("OpenAL not available on this platform");
             return false;
          #endif
 
@@ -298,7 +293,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             }
             return false;
          #else
-            _al_set_error(ALLEGRO_INVALID_PARAM, "OpenSL not available on this platform");
+            ALLEGRO_ERROR("OpenSL not available on this platform");
             return false;
          #endif
 
@@ -311,7 +306,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             }
             return false;
          #else
-            _al_set_error(ALLEGRO_INVALID_PARAM, "ALSA not available on this platform");
+            ALLEGRO_ERROR("ALSA not available on this platform");
             return false;
          #endif
 
@@ -324,7 +319,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             }
             return false;
          #else
-            _al_set_error(ALLEGRO_INVALID_PARAM, "OSS not available on this platform");
+            ALLEGRO_ERROR("OSS not available on this platform");
             return false;
          #endif
 
@@ -337,7 +332,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             }
             return false;
          #else
-            _al_set_error(ALLEGRO_INVALID_PARAM, "PulseAudio not available on this platform");
+            ALLEGRO_ERROR("PulseAudio not available on this platform");
             return false;
          #endif
 
@@ -350,7 +345,7 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             }
             return false;
          #else
-            _al_set_error(ALLEGRO_INVALID_PARAM, "DirectSound not available on this platform");
+            ALLEGRO_ERROR("DirectSound not available on this platform");
             return false;
          #endif
 
@@ -363,12 +358,12 @@ static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
             }
             return false;
          #else
-            _al_set_error(ALLEGRO_INVALID_PARAM, "SDL not available on this platform");
+            ALLEGRO_ERROR("SDL not available on this platform");
             return false;
          #endif
 
       default:
-         _al_set_error(ALLEGRO_INVALID_PARAM, "Invalid audio driver");
+         ALLEGRO_ERROR("Invalid audio driver");
          return false;
    }
 }

--- a/addons/audio/kcm_instance.c
+++ b/addons/audio/kcm_instance.c
@@ -15,6 +15,8 @@
 #include "allegro5/internal/aintern_audio.h"
 #include "allegro5/internal/aintern_audio_cfg.h"
 
+ALLEGRO_DEBUG_CHANNEL("audio")
+
 
 static void maybe_lock_mutex(ALLEGRO_MUTEX *mutex)
 {
@@ -151,8 +153,7 @@ ALLEGRO_SAMPLE_INSTANCE *al_create_sample_instance(ALLEGRO_SAMPLE *sample_data)
 
    spl = al_calloc(1, sizeof(*spl));
    if (!spl) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Out of memory allocating sample object");
+      ALLEGRO_ERROR("Out of memory allocating sample object");
       return NULL;
    }
 
@@ -391,8 +392,7 @@ bool al_set_sample_instance_length(ALLEGRO_SAMPLE_INSTANCE *spl,
    ASSERT(spl);
 
    if (spl->is_playing) {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to change the length of a playing sample");
+      ALLEGRO_ERROR("Attempted to change the length of a playing sample");
       return false;
    }
 
@@ -409,14 +409,12 @@ bool al_set_sample_instance_speed(ALLEGRO_SAMPLE_INSTANCE *spl, float val)
    ASSERT(spl);
 
    if (fabsf(val) < (1.0f/64.0f)) {
-      _al_set_error(ALLEGRO_INVALID_PARAM,
-         "Attempted to set zero speed");
+      ALLEGRO_ERROR("Attempted to set zero speed");
       return false;
    }
 
    if (spl->parent.u.ptr && spl->parent.is_voice) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Could not set voice playback speed");
+      ALLEGRO_ERROR("Could not set voice playback speed");
       return false;
    }
 
@@ -450,8 +448,7 @@ bool al_set_sample_instance_gain(ALLEGRO_SAMPLE_INSTANCE *spl, float val)
    ASSERT(spl);
 
    if (spl->parent.u.ptr && spl->parent.is_voice) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Could not set gain of sample attached to voice");
+      ALLEGRO_ERROR("Could not set gain of sample attached to voice");
       return false;
    }
 
@@ -481,12 +478,11 @@ bool al_set_sample_instance_pan(ALLEGRO_SAMPLE_INSTANCE *spl, float val)
    ASSERT(spl);
 
    if (spl->parent.u.ptr && spl->parent.is_voice) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Could not set panning of sample attached to voice");
+      ALLEGRO_ERROR("Could not set panning of sample attached to voice");
       return false;
    }
    if (val != ALLEGRO_AUDIO_PAN_NONE && (val < -1.0 || val > 1.0)) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR, "Invalid pan value");
+      ALLEGRO_ERROR("Invalid pan value");
       return false;
    }
 
@@ -517,8 +513,7 @@ bool al_set_sample_instance_playmode(ALLEGRO_SAMPLE_INSTANCE *spl,
    ASSERT(spl);
 
    if (val < ALLEGRO_PLAYMODE_ONCE || val > ALLEGRO_PLAYMODE_BIDIR) {
-      _al_set_error(ALLEGRO_INVALID_PARAM,
-         "Invalid loop mode");
+      ALLEGRO_ERROR("Invalid loop mode");
       return false;
    }
 
@@ -661,8 +656,7 @@ bool al_set_sample_instance_channel_matrix(ALLEGRO_SAMPLE_INSTANCE *spl, const f
    ASSERT(matrix);
 
    if (spl->parent.u.ptr && spl->parent.is_voice) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Could not set channel matrix of sample attached to voice");
+      ALLEGRO_ERROR("Could not set channel matrix of sample attached to voice");
       return false;
    }
 

--- a/addons/audio/kcm_mixer.c
+++ b/addons/audio/kcm_mixer.c
@@ -367,8 +367,7 @@ void _al_kcm_mixer_read(void *source, void **buf, unsigned int *samples,
       al_free(m->ss.spl_data.buffer.ptr);
       m->ss.spl_data.buffer.ptr = al_malloc(samples_l*maxc*al_get_audio_depth_size(m->ss.spl_data.depth));
       if (!m->ss.spl_data.buffer.ptr) {
-         _al_set_error(ALLEGRO_GENERIC_ERROR,
-            "Out of memory allocating mixer buffer");
+         ALLEGRO_ERROR("Out of memory allocating mixer buffer");
          m->ss.spl_data.len = 0;
          return;
       }
@@ -632,21 +631,19 @@ ALLEGRO_MIXER *al_create_mixer(unsigned int freq,
    }
 
    if (!freq) {
-      _al_set_error(ALLEGRO_INVALID_PARAM,
-         "Attempted to create mixer with no frequency");
+      ALLEGRO_ERROR("Attempted to create mixer with no frequency");
       return NULL;
    }
 
    if (depth != ALLEGRO_AUDIO_DEPTH_FLOAT32 &&
          depth != ALLEGRO_AUDIO_DEPTH_INT16) {
-      _al_set_error(ALLEGRO_INVALID_PARAM, "Unsupported mixer depth");
+      ALLEGRO_ERROR("Unsupported mixer depth");
       return NULL;
    }
 
    mixer = al_calloc(1, sizeof(ALLEGRO_MIXER));
    if (!mixer) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Out of memory allocating mixer object");
+      ALLEGRO_ERROR("Out of memory allocating mixer object");
       return NULL;
    }
 
@@ -697,8 +694,7 @@ bool al_attach_sample_instance_to_mixer(ALLEGRO_SAMPLE_INSTANCE *spl,
 
    /* Already referenced, do not attach. */
    if (spl->parent.u.ptr) {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to attach a sample that's already attached");
+      ALLEGRO_ERROR("Attempted to attach a sample that's already attached");
       return false;
    }
 
@@ -711,8 +707,7 @@ bool al_attach_sample_instance_to_mixer(ALLEGRO_SAMPLE_INSTANCE *spl,
       if (mixer->ss.mutex) {
          al_unlock_mutex(mixer->ss.mutex);
       }
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Out of memory allocating attachment pointers");
+      ALLEGRO_ERROR("Out of memory allocating attachment pointers");
       return false;
    }
    (*slot) = spl;
@@ -804,20 +799,17 @@ bool al_attach_mixer_to_mixer(ALLEGRO_MIXER *stream, ALLEGRO_MIXER *mixer)
    ASSERT(mixer != stream);
 
    if (mixer->ss.spl_data.frequency != stream->ss.spl_data.frequency) {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to attach a mixer with different frequencies");
+      ALLEGRO_ERROR("Attempted to attach a mixer with different frequencies");
       return false;
    }
 
    if (mixer->ss.spl_data.depth != stream->ss.spl_data.depth) {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Mixers of different audio depths cannot be attached to one another");
+      ALLEGRO_ERROR("Mixers of different audio depths cannot be attached to one another");
       return false;
    }
 
    if (mixer->ss.spl_data.chan_conf != stream->ss.spl_data.chan_conf) {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Mixers of different channel configurations cannot be attached to one another");
+      ALLEGRO_ERROR("Mixers of different channel configurations cannot be attached to one another");
       return false;
    }
 
@@ -924,8 +916,7 @@ bool al_set_mixer_frequency(ALLEGRO_MIXER *mixer, unsigned int val)
     * to anything.
     */
    if (mixer->ss.parent.u.ptr) {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-            "Attempted to change the frequency of an attached mixer");
+      ALLEGRO_ERROR("Attempted to change the frequency of an attached mixer");
       return false;
    }
 
@@ -951,8 +942,7 @@ bool al_set_mixer_quality(ALLEGRO_MIXER *mixer, ALLEGRO_MIXER_QUALITY new_qualit
       ret = true;
    }
    else {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to change the quality of a mixer with attachments");
+      ALLEGRO_ERROR("Attempted to change the quality of a mixer with attachments");
       ret = false;
    }
 

--- a/addons/audio/kcm_sample.c
+++ b/addons/audio/kcm_sample.c
@@ -135,14 +135,13 @@ ALLEGRO_SAMPLE *al_create_sample(void *buf, unsigned int samples,
    ASSERT(buf);
 
    if (!freq) {
-      _al_set_error(ALLEGRO_INVALID_PARAM, "Invalid sample frequency");
+      ALLEGRO_ERROR("Invalid sample frequency");
       return NULL;
    }
 
    spl = al_calloc(1, sizeof(*spl));
    if (!spl) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Out of memory allocating sample data object");
+      ALLEGRO_ERROR("Out of memory allocating sample data object");
       return NULL;
    }
 

--- a/addons/audio/kcm_stream.c
+++ b/addons/audio/kcm_stream.c
@@ -57,18 +57,15 @@ ALLEGRO_AUDIO_STREAM *al_create_audio_stream(size_t fragment_count,
    size_t i;
 
    if (!fragment_count) {
-      _al_set_error(ALLEGRO_INVALID_PARAM,
-         "Attempted to create stream with no buffers");
+      ALLEGRO_ERROR("Attempted to create stream with no buffers");
       return NULL;
    }
    if (!frag_samples) {
-      _al_set_error(ALLEGRO_INVALID_PARAM,
-          "Attempted to create stream with no buffer size");
+      ALLEGRO_ERROR("Attempted to create stream with no buffer size");
       return NULL;
    }
    if (!freq) {
-      _al_set_error(ALLEGRO_INVALID_PARAM,
-         "Attempted to create stream with no frequency");
+      ALLEGRO_ERROR("Attempted to create stream with no frequency");
       return NULL;
    }
 
@@ -78,8 +75,7 @@ ALLEGRO_AUDIO_STREAM *al_create_audio_stream(size_t fragment_count,
 
    stream = al_calloc(1, sizeof(*stream));
    if (!stream) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Out of memory allocating stream object");
+      ALLEGRO_ERROR("Out of memory allocating stream object");
       return NULL;
    }
 
@@ -104,8 +100,7 @@ ALLEGRO_AUDIO_STREAM *al_create_audio_stream(size_t fragment_count,
    if (!stream->used_bufs) {
       al_free(stream->used_bufs);
       al_free(stream);
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Out of memory allocating stream buffer pointers");
+      ALLEGRO_ERROR("Out of memory allocating stream buffer pointers");
       return NULL;
    }
    stream->pending_bufs = stream->used_bufs + fragment_count;
@@ -120,8 +115,7 @@ ALLEGRO_AUDIO_STREAM *al_create_audio_stream(size_t fragment_count,
    if (!stream->main_buffer) {
       al_free(stream->used_bufs);
       al_free(stream);
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Out of memory allocating stream buffer");
+      ALLEGRO_ERROR("Out of memory allocating stream buffer");
       return NULL;
    }
 
@@ -364,14 +358,12 @@ bool al_set_audio_stream_speed(ALLEGRO_AUDIO_STREAM *stream, float val)
    ASSERT(stream);
 
    if (val <= 0.0f) {
-      _al_set_error(ALLEGRO_INVALID_PARAM,
-         "Attempted to set stream speed to a zero or negative value");
+      ALLEGRO_ERROR("Attempted to set stream speed to a zero or negative value");
       return false;
    }
 
    if (stream->spl.parent.u.ptr && stream->spl.parent.is_voice) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Could not set voice playback speed");
+      ALLEGRO_ERROR("Could not set voice playback speed");
       return false;
    }
 
@@ -401,8 +393,7 @@ bool al_set_audio_stream_gain(ALLEGRO_AUDIO_STREAM *stream, float val)
    ASSERT(stream);
 
    if (stream->spl.parent.u.ptr && stream->spl.parent.is_voice) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Could not set gain of stream attached to voice");
+      ALLEGRO_ERROR("Could not set gain of stream attached to voice");
       return false;
    }
 
@@ -431,12 +422,11 @@ bool al_set_audio_stream_pan(ALLEGRO_AUDIO_STREAM *stream, float val)
    ASSERT(stream);
 
    if (stream->spl.parent.u.ptr && stream->spl.parent.is_voice) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Could not set gain of stream attached to voice");
+      ALLEGRO_ERROR("Could not set gain of stream attached to voice");
       return false;
    }
    if (val != ALLEGRO_AUDIO_PAN_NONE && (val < -1.0 || val > 1.0)) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR, "Invalid pan value");
+      ALLEGRO_ERROR("Invalid pan value");
       return false;
    }
 
@@ -479,7 +469,7 @@ bool al_set_audio_stream_playmode(ALLEGRO_AUDIO_STREAM *stream,
       return true;
    }
 
-   // XXX _al_set_error
+   ALLEGRO_ERROR("Invalid stream playmode selected!");
    return false;
 }
 
@@ -595,8 +585,7 @@ bool al_set_audio_stream_fragment(ALLEGRO_AUDIO_STREAM *stream, void *val)
       ret = true;
    }
    else {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to set a stream buffer with a full pending list");
+      ALLEGRO_ERROR("Attempted to set a stream buffer with a full pending list");
       ret = false;
    }
 
@@ -901,8 +890,7 @@ bool al_set_audio_stream_channel_matrix(ALLEGRO_AUDIO_STREAM *stream, const floa
    ASSERT(stream);
 
    if (stream->spl.parent.u.ptr && stream->spl.parent.is_voice) {
-      _al_set_error(ALLEGRO_GENERIC_ERROR,
-         "Could not set channel matrix of stream attached to voice");
+      ALLEGRO_ERROR("Could not set channel matrix of stream attached to voice");
       return false;
    }
 

--- a/addons/audio/kcm_voice.c
+++ b/addons/audio/kcm_voice.c
@@ -68,7 +68,7 @@ ALLEGRO_VOICE *al_create_voice(unsigned int freq,
    ALLEGRO_VOICE *voice = NULL;
 
    if (!freq) {
-      _al_set_error(ALLEGRO_INVALID_PARAM, "Invalid Voice Frequency");
+      ALLEGRO_ERROR("Invalid Voice Frequency");
       return NULL;
    }
 
@@ -132,17 +132,12 @@ bool al_attach_sample_instance_to_voice(ALLEGRO_SAMPLE_INSTANCE *spl,
    ASSERT(spl);
 
    if (voice->attached_stream) {
-      ALLEGRO_WARN(
-         "Attempted to attach to a voice that already has an attachment\n");
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to attach to a voice that already has an attachment");
+      ALLEGRO_ERROR("Attempted to attach to a voice that already has an attachment\n");
       return false;
    }
 
    if (spl->parent.u.ptr) {
-      ALLEGRO_WARN("Attempted to attach a sample that is already attached\n");
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to attach a sample that is already attached");
+      ALLEGRO_ERROR("Attempted to attach a sample that is already attached\n");
       return false;
    }
 
@@ -150,9 +145,7 @@ bool al_attach_sample_instance_to_voice(ALLEGRO_SAMPLE_INSTANCE *spl,
       voice->frequency != spl->spl_data.frequency ||
       voice->depth != spl->spl_data.depth)
    {
-      ALLEGRO_WARN("Sample settings do not match voice settings\n");
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Sample settings do not match voice settings");
+      ALLEGRO_ERROR("Sample settings do not match voice settings\n");
       return false;
    }
 
@@ -255,14 +248,12 @@ bool al_attach_audio_stream_to_voice(ALLEGRO_AUDIO_STREAM *stream,
    ASSERT(stream);
 
    if (voice->attached_stream) {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to attach to a voice that already has an attachment");
+      ALLEGRO_ERROR("Attempted to attach to a voice that already has an attachment");
       return false;
    }
 
    if (stream->spl.parent.u.ptr) {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Attempted to attach a stream that is already attached");
+      ALLEGRO_ERROR("Attempted to attach a stream that is already attached");
       return false;
    }
 
@@ -270,8 +261,7 @@ bool al_attach_audio_stream_to_voice(ALLEGRO_AUDIO_STREAM *stream,
       voice->frequency != stream->spl.spl_data.frequency ||
       voice->depth != stream->spl.spl_data.depth)
    {
-      _al_set_error(ALLEGRO_INVALID_OBJECT,
-         "Stream settings do not match voice settings");
+      ALLEGRO_ERROR("Stream settings do not match voice settings");
       return false;
    }
 
@@ -299,7 +289,7 @@ bool al_attach_audio_stream_to_voice(ALLEGRO_AUDIO_STREAM *stream,
       stream->spl.parent.u.voice = NULL;
       stream->spl.spl_read = NULL;
 
-      _al_set_error(ALLEGRO_GENERIC_ERROR, "Unable to start stream");
+      ALLEGRO_ERROR("Unable to start stream");
       ret = false;
    }
    else {


### PR DESCRIPTION
with the default ALLEGRO_ERROR call as it does not do anything else

Removed all traces of the _al_set_error functionality

refers to issue #194 