### PR TITLE
Fix OSX magic main with the LTO switch.

### DIFF
--- a/include/allegro5/platform/alosx.h
+++ b/include/allegro5/platform/alosx.h
@@ -53,7 +53,7 @@ ALLEGRO_PATH *_al_osx_get_path(int id);
    #ifndef ALLEGRO_NO_MAGIC_MAIN
       #define ALLEGRO_MAGIC_MAIN
       #if __GNUC__ >= 4
-         #define main __attribute__ ((visibility("default"))) _al_mangled_main
+         #define main __attribute__ ((visibility("default"),used)) _al_mangled_main
       #else
          #define main _al_mangled_main
       #endif


### PR DESCRIPTION
Using -flto with clang 8.1 strips out _al_mangled_main() because it things the
function is not used. Removing -flto as a linker flag fixes this, but the
following change fixes the issue properly.

Fixes #758