### PR TITLE
4.4: implement play_fli_pf and open_fli_pf

### DIFF
--- a/include/allegro/fli.h
+++ b/include/allegro/fli.h
@@ -20,6 +20,7 @@
 #define ALLEGRO_FLI_H
 
 #include "base.h"
+#include "file.h"
 #include "palette.h"
 
 #ifdef __cplusplus
@@ -34,9 +35,11 @@ struct BITMAP;
 #define FLI_NOT_OPEN    -3
 
 AL_FUNC(int, play_fli, (AL_CONST char *filename, struct BITMAP *bmp, int loop, AL_METHOD(int, callback, (void))));
+AL_FUNC(int, play_fli_pf, (PACKFILE *pf, struct BITMAP *bmp, AL_METHOD(int, callback, (void))));
 AL_FUNC(int, play_memory_fli, (void *fli_data, struct BITMAP *bmp, int loop, AL_METHOD(int, callback, (void))));
 
 AL_FUNC(int, open_fli, (AL_CONST char *filename));
+AL_FUNC(int, open_fli_pf, (PACKFILE *pf));
 AL_FUNC(int, open_memory_fli, (void *fli_data));
 AL_FUNC(void, close_fli, (void));
 AL_FUNC(int, next_fli_frame, (int loop));


### PR DESCRIPTION
This adds **play_fli_pf** and **open_fli_pf** functions as a part of Allegro 4.4 API.

This pull request has similar reasoning behind it as my previous one (#729). I was trying to remove various hacks from our olde engine and properly use latest version of Allegro 4, but Allegro 4's API does not provide method to play FLIC from provided PACKFILE, which is very inconvenient if these videos are stored in a custom data package. There are indeed methods play_memory_fli/open_memory_fli, but they demand video be loaded fully into memory before playing it, hence I was reluctant to switch to these.

TBH, I could not find an easy way to keep looping playback working with user's PACKFILE stream. With play_fli/open_fli Allegro simply reopens the file, since it knows its name. With play_memory_fli/open_memory_fli it reverts to the beginning of data array. But PACKFILE does not support seeking back. So I made a restriction that if video is played of custom stream, looping is not supported (users will have to restart video themselves).
If someone knows better solution, I would be happy to fix mine (unless it requires big overhaul, because sadly I cannot spare much time to this).