### PR TITLE
4.4: Make use of <stdint.h> in MSVS 2010 and higher

### DIFF
--- a/include/allegro/platform/almsvc.h
+++ b/include/allegro/platform/almsvc.h
@@ -78,8 +78,12 @@
 #define INLINE       __inline
 
 #define LONG_LONG    __int64
-#define int64_t      signed __int64
-#define uint64_t     unsigned __int64
+#if (_MSC_VER >= 1600)
+   #define ALLEGRO_HAVE_STDINT_H
+#else
+   #define int64_t      signed __int64
+   #define uint64_t     unsigned __int64
+#endif
 
 #define AL_CONST     const
 


### PR DESCRIPTION
This is a small fix that lets compile Allegro-based programs in MSVS 2010 and higher (tested VS 2010, *15 and *17).

MSVS introduced stdint.h starting with VS2010, but if it is included in Allegro 4 program, this will cause conflicts with Allegro's astdint.h. Provided fix seem to deal with the issue.