### PR TITLE
Android: fix LocalRef leak when opening files using APK interface

### DIFF
--- a/src/android/android_apk_file.c
+++ b/src/android/android_apk_file.c
@@ -37,7 +37,7 @@ static jobject APK_openRead(const char *filename)
    JNIEnv *jnienv;
    jmethodID ctor;
    jstring str;
-   jobject is;
+   jobject is, ref;
    jboolean res;
 
    jnienv = _al_android_get_jnienv();
@@ -46,11 +46,11 @@ static jobject APK_openRead(const char *filename)
       "(L" ALLEGRO_ANDROID_PACKAGE_NAME_SLASH "/AllegroActivity;Ljava/lang/String;)V");
    str = (*jnienv)->NewStringUTF(jnienv, filename);
 
-   is = _jni_call(jnienv, jobject, NewObject, _al_android_apk_stream_class(),
+   ref = _jni_call(jnienv, jobject, NewObject, _al_android_apk_stream_class(),
       ctor, _al_android_activity_object(), str);
 
-   is = _jni_call(jnienv, jobject, NewGlobalRef, is);
-
+   is = _jni_call(jnienv, jobject, NewGlobalRef, ref);
+   _jni_callv(jnienv, DeleteLocalRef, ref);
    _jni_callv(jnienv, DeleteLocalRef, str);
 
    res = _jni_callBooleanMethodV(_al_android_get_jnienv(), is, "open", "()Z");


### PR DESCRIPTION
LocalRef pool is limited in size to 512 elements, so code like
```c
for (int i=0; i<512; i++) {
  ALLEGRO_FILE *file = al_fopen(filename, "r");
  if (file) {
    al_fclose(file);
  }
}
```
was crashing the application. This also applied to functions like al_filename_exists, making it even easier to trigger.