### PR TITLE
Fix al_set_clipping_rectangle() when out-of-bounds

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -384,6 +384,12 @@ void al_set_clipping_rectangle(int x, int y, int width, int height)
    if (y + height > bitmap->h) {
       height = bitmap->h - y;
    }
+   if (width < 0) {
+      width = 0;
+   }
+   if (height < 0) {
+      height = 0;
+   }
 
    bitmap->cl = x;
    bitmap->ct = y;


### PR DESCRIPTION
When using OpenGL and calling `al_set_clipping_rectangle()` specifying a rectangle that resides completely off-surface, the width and height of the scissor box are currently calculated as negative, causing `glScissor()` to post a `GL_INVALID_VALUE` error.  That error gets picked up later when an unrelated function checks `glGetError()`, causing mysterious failures.

This fixes the bug by explicitly clamping the scissor box to width/height 0.

Fixes #786.