### PR TITLE
Several fixes to DirectDraw Windows backend

### DIFF
--- a/src/win/wdispsw.c
+++ b/src/win/wdispsw.c
@@ -111,6 +111,8 @@ void _win_switch_in(void)
 
    _TRACE(PREFIX_I "switch in\n");
 
+   _enter_gfx_critical();
+
    _win_app_foreground = TRUE;
 
    key_dinput_acquire();
@@ -132,6 +134,8 @@ void _win_switch_in(void)
    }
 
    _switch_in();
+
+   _exit_gfx_critical();
 }
 
 
@@ -144,6 +148,10 @@ void _win_switch_out(void)
    int mode;
 
    _TRACE(PREFIX_I "switch out\n");
+
+   _enter_gfx_critical();
+
+   _switch_out();
 
    _win_app_foreground = FALSE;
 
@@ -169,7 +177,7 @@ void _win_switch_out(void)
          SetThreadPriority(allegro_thread, THREAD_PRIORITY_LOWEST);
    }
 
-   _switch_out();
+   _exit_gfx_critical();
 }
 
 


### PR DESCRIPTION
 - the switch-in and switch-out handlers need mutexes to prevent race conditions with drawing when alt-tabbing into or out of fullscreen.
 - added message handlers to restore the palette if the system palette changed while the program was tabbed out
 - critical section needs to be initialized before installing the user window hook