### PR TITLE
cosmic-protector: fix Android build on default toolchain by not providing STL

### DIFF
--- a/demos/cosmic_protector/CMakeLists.txt
+++ b/demos/cosmic_protector/CMakeLists.txt
@@ -72,7 +72,7 @@ if(ANDROID)
     add_android_app(cosmic_protector
         "${DEMO_SRCS};${ASSETS}"
         "${ALLEGRO_LINK_WITH};${IMAGE_LINK_WITH};${FONT_LINK_WITH};${AUDIO_LINK_WITH};${ACODEC_LINK_WITH};${PRIMITIVES_LINK_WITH}"
-        "stlport_shared"
+        ""
         )
     return()
 endif(ANDROID)


### PR DESCRIPTION
Fix Android build on default toolchain by not providing STL

Hardcoding STL only breaks things instead of fixing them.

Closes #799