### PR TITLE
Ensure detach from buffers before deleting.

### DIFF
--- a/addons/audio/openal.c
+++ b/addons/audio/openal.c
@@ -273,6 +273,7 @@ static int _openal_load_voice(ALLEGRO_VOICE *voice, const void *data)
 
    ex_data->buffers = al_malloc(sizeof(ALuint) * ex_data->num_buffers);
    if (!ex_data->buffers) {
+      alSourcei(ex_data->source, AL_BUFFER, 0);
       alDeleteSources(1, &ex_data->source);
       ALLEGRO_ERROR("Could not allocate voice buffer memory\n");
       return 1;
@@ -280,6 +281,7 @@ static int _openal_load_voice(ALLEGRO_VOICE *voice, const void *data)
 
    alGenBuffers(ex_data->num_buffers, ex_data->buffers);
    if ((openal_err = alGetError()) != AL_NO_ERROR) {
+      alSourcei(ex_data->source, AL_BUFFER, 0);
       alDeleteSources(1, &ex_data->source);
       al_free(ex_data->buffers);
       ex_data->buffers = NULL;
@@ -303,6 +305,7 @@ static int _openal_load_voice(ALLEGRO_VOICE *voice, const void *data)
    alSourcef(ex_data->source, AL_GAIN, 1.0f);
 
    if ((openal_err = alGetError()) != AL_NO_ERROR) {
+      alSourcei(ex_data->source, AL_BUFFER, 0);
       alDeleteSources(1, &ex_data->source);
       alDeleteBuffers(ex_data->num_buffers, ex_data->buffers);
       al_free(ex_data->buffers);
@@ -321,6 +324,7 @@ static void _openal_unload_voice(ALLEGRO_VOICE *voice)
 {
    ALLEGRO_AL_DATA *ex_data = voice->extra;
 
+   alSourcei(ex_data->source, AL_BUFFER, 0);
    alDeleteSources(1, &ex_data->source);
    alDeleteBuffers(ex_data->num_buffers, ex_data->buffers);
    al_free(ex_data->buffers);
@@ -378,12 +382,14 @@ static int _openal_start_voice(ALLEGRO_VOICE *voice)
 
       ex_data->buffers = al_malloc(sizeof(ALuint) * ex_data->num_buffers);
       if (!ex_data->buffers) {
+         alSourcei(ex_data->source, AL_BUFFER, 0);
          alDeleteSources(1, &ex_data->source);
          return 1;
       }
 
       alGenBuffers(ex_data->num_buffers, ex_data->buffers);
       if (alGetError() != AL_NO_ERROR) {
+         alSourcei(ex_data->source, AL_BUFFER, 0);
          alDeleteSources(1, &ex_data->source);
          al_free(ex_data->buffers);
          ex_data->buffers = NULL;
@@ -392,6 +398,7 @@ static int _openal_start_voice(ALLEGRO_VOICE *voice)
 
       alSourcef(ex_data->source, AL_GAIN, 1.0f);
       if (alGetError() != AL_NO_ERROR) {
+         alSourcei(ex_data->source, AL_BUFFER, 0);
          alDeleteSources(1, &ex_data->source);
          alDeleteBuffers(ex_data->num_buffers, ex_data->buffers);
          al_free(ex_data->buffers);
@@ -440,11 +447,13 @@ static int _openal_stop_voice(ALLEGRO_VOICE* voice)
       ex_data->thread = NULL;
       ex_data->stopped = false;
    }
-
+   
+   alSourcei(ex_data->source, AL_BUFFER, 0);
+   alDeleteSources(1, &ex_data->source);
    alDeleteBuffers(ex_data->num_buffers, ex_data->buffers);
    al_free(ex_data->buffers);
    ex_data->buffers = NULL;
-   alDeleteSources(1, &ex_data->source);
+   
    alGetError(); /* required! */
    return 0;
 }


### PR DESCRIPTION
Need to detach from buffers before deleting otherwise openal will complain:

```bash
AL lib: (WW) FreeDevice: (0x227d7f0) Deleting 4 Buffer(s)
```
Sources should be deleted before buffer is deleted [line 447](https://github.com/liballeg/allegro5/blob/master/addons/audio/openal.c#L447)

Test **code**:
```cpp
#include <stdio.h>
#include <allegro5/allegro.h>
#include <allegro5/allegro_audio.h>
#include <allegro5/allegro_acodec.h>

int main(int argc, char ** argv){
    al_init();
    al_install_audio();
    al_init_acodec_addon();
    al_reserve_samples(8);
    return 0;
}
```