### PR TITLE
image: make compression/quality levels and gamma handling configurable

### DIFF
--- a/addons/image/iio.h
+++ b/addons/image/iio.h
@@ -28,11 +28,6 @@ typedef struct PalEntry {
  */
 extern double _al_png_screen_gamma;
 
-/* Choose zlib compression level for saving file.
- * Default is Z_BEST_COMPRESSION.
- */
-extern int _al_png_compression_level;
-
 
 
 #endif

--- a/addons/image/iio.h
+++ b/addons/image/iio.h
@@ -12,23 +12,5 @@ typedef struct PalEntry {
 } PalEntry;
 
 
-/* FIXME: Not sure if these should be made accessible. Hide them for now. */
-
-/* _al_png_screen_gamma is slightly overloaded (sorry):
- *
- * A value of 0.0 means: Don't do any gamma correction in load_png()
- * and load_memory_png().  This meaning was introduced in v1.4.
- *
- * A value of -1.0 means: Use the value from the environment variable
- * SCREEN_GAMMA (if available), otherwise fallback to a value of 2.2
- * (a good guess for PC monitors, and the value for sRGB colourspace).
- * This is the default.
- *
- * Otherwise, the value of _al_png_screen_gamma is taken as-is.
- */
-extern double _al_png_screen_gamma;
-
-
-
 #endif
 

--- a/addons/image/jpg.c
+++ b/addons/image/jpg.c
@@ -325,6 +325,9 @@ static void save_jpg_entry_helper(ALLEGRO_FILE *fp, ALLEGRO_BITMAP *bmp,
    cinfo.in_color_space = JCS_RGB;
    jpeg_set_defaults(&cinfo);
 
+   const char* level = al_get_config_value(al_get_system_config(), "image", "jpeg_quality_level");
+   jpeg_set_quality(&cinfo, level ? strtol(level, NULL, 10) : 75, true);
+
    jpeg_start_compress(&cinfo, 1);
 
    /* See comment in load_jpg_entry_helper. */

--- a/addons/image/png.c
+++ b/addons/image/png.c
@@ -16,7 +16,6 @@ ALLEGRO_DEBUG_CHANNEL("image")
 
 
 double _al_png_screen_gamma = -1.0;
-int _al_png_compression_level = Z_DEFAULT_COMPRESSION;
 
 
 
@@ -450,6 +449,25 @@ static void flush_data(png_structp png_ptr)
    (void)png_ptr;
 }
 
+/* translate_compression_level:
+ *  Translate string with config value into proper zlib's
+ *  compression level. Assumes default on NULL.
+ */
+static int translate_compression_level(const char* value) {
+   if (!value || strcmp(value, "default") == 0) {
+      return Z_DEFAULT_COMPRESSION;
+   }
+   if (strcmp(value, "best") == 0) {
+      return Z_BEST_COMPRESSION;
+   }
+   if (strcmp(value, "fastest") == 0) {
+      return Z_BEST_SPEED;
+   }
+   if (strcmp(value, "none") == 0) {
+      return Z_NO_COMPRESSION;
+   }
+   return strtol(value, NULL, 10);
+}
 
 /* save_rgba:
  *  Core save routine for 32 bpp images.
@@ -520,7 +538,10 @@ bool _al_save_png_f(ALLEGRO_FILE *fp, ALLEGRO_BITMAP *bmp)
    colour_type = PNG_COLOR_TYPE_RGB_ALPHA;
 
    /* Set compression level. */
-   png_set_compression_level(png_ptr, _al_png_compression_level);
+   int z_level = translate_compression_level(
+      al_get_config_value(al_get_system_config(), "image", "png_compression_level")
+   );
+   png_set_compression_level(png_ptr, z_level);
 
    png_set_IHDR(png_ptr, info_ptr,
                 al_get_bitmap_width(bmp), al_get_bitmap_height(bmp),

--- a/addons/image/png.c
+++ b/addons/image/png.c
@@ -15,25 +15,26 @@
 ALLEGRO_DEBUG_CHANNEL("image")
 
 
-double _al_png_screen_gamma = -1.0;
-
-
-
 /* get_gamma:
  *  Get screen gamma value one of three ways.
  */
 static double get_gamma(void)
 {
-   if (_al_png_screen_gamma == -1.0) {
+   double gamma = -1.0;
+   const char* config = al_get_config_value(al_get_system_config(), "image", "png_screen_gamma");
+   if (config) {
+      gamma = strtod(config, NULL);
+   }
+   if (gamma == -1.0) {
       /* Use the environment variable if available.
        * 2.2 is a good guess for PC monitors.
        * 1.1 is good for my laptop.
        */
       const char *gamma_str = getenv("SCREEN_GAMMA");
-      return (gamma_str) ? atof(gamma_str) : 2.2;
+      return (gamma_str) ? strtod(gamma_str, NULL) : 2.2;
    }
 
-   return _al_png_screen_gamma;
+   return gamma;
 }
 
 
@@ -145,9 +146,8 @@ static ALLEGRO_BITMAP *really_load_png(png_structp png_ptr, png_infop info_ptr,
       png_set_gray_to_rgb(png_ptr);
 
    /* Optionally, tell libpng to handle the gamma correction for us. */
-   if (_al_png_screen_gamma != 0.0) {
-      screen_gamma = get_gamma();
-
+   screen_gamma = get_gamma();
+   if (screen_gamma != 0.0) {
       if (png_get_sRGB(png_ptr, info_ptr, &intent))
          png_set_gamma(png_ptr, screen_gamma, 0.45455);
       else {

--- a/addons/image/png.c
+++ b/addons/image/png.c
@@ -16,7 +16,7 @@ ALLEGRO_DEBUG_CHANNEL("image")
 
 
 double _al_png_screen_gamma = -1.0;
-int _al_png_compression_level = Z_BEST_COMPRESSION;
+int _al_png_compression_level = Z_DEFAULT_COMPRESSION;
 
 
 

--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -105,6 +105,9 @@ buffer_size = 8192
 # "none" or "default" (a sane compromise between size and speed).
 png_compression_level = default
 
+# Quality level for JPEG files. Possible values: 0-100
+jpeg_quality_level = 75
+
 [joystick]
 
 # Linux: Allegro normally searches for joystick device N at /dev/input/jsN.

--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -99,6 +99,12 @@ buffer_size = 8192
 # GL_ARB_texture_non_power_of_two=0
 # GL_EXT_framebuffer_object=0
 
+[image]
+
+# Compression level for PNG files. Possible values: 0-9, "best", "fastest",
+# "none" or "default" (a sane compromise between size and speed).
+png_compression_level = default
+
 [joystick]
 
 # Linux: Allegro normally searches for joystick device N at /dev/input/jsN.

--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -101,6 +101,14 @@ buffer_size = 8192
 
 [image]
 
+# Gamma handling of PNG files.
+# A value of 0.0 means: Don't do any gamma correction.
+# A value of -1.0 means: Use the value from the environment variable
+# SCREEN_GAMMA (if available), otherwise fallback to a value of 2.2
+# (a good guess for PC monitors, and the value for sRGB colourspace).
+# Otherwise, the value is taken as-is.
+png_screen_gamma = -1.0
+
 # Compression level for PNG files. Possible values: 0-9, "best", "fastest",
 # "none" or "default" (a sane compromise between size and speed).
 png_compression_level = default

--- a/docs/src/refman/image.txt
+++ b/docs/src/refman/image.txt
@@ -7,6 +7,10 @@ Link with allegro_image.
  #include <allegro5/allegro_image.h>
 ~~~~
 
+Some of the format handlers define configuration options for specifying things
+like compression level or gamma handling. Refer to [al_get_system_config] for
+their documentation.
+
 ## API: al_init_image_addon
 
 Initializes the image addon.  This registers bitmap format handlers for


### PR DESCRIPTION
With my 3200x1800 screen, Z_BEST_COMPRESSION meant that saving fullscreen
bitmap into PNG file took 15-20 seconds on my i5-4200U CPU.
With Z_DEFAULT_COMPRESSION it takes 3-5 seconds now and the resulting files
aren't much bigger (4.6M and 8.3M with DEFAULT vs. 4.5M and 8.2M with BEST
on the same test images).

Z_DEFAULT_COMPRESSION, per zlib's documentation, is a good compromise
between speed and size, while Z_BEST_COMPRESSION is extremely slow and
desirable only when trying to squeeze every bit out of the compressed file.
Seems like Z_DEFAULT_COMPRESSION would be a good default option to use by Allegro.