### PR TITLE
allegro5.cfg: fix incorrect config file name referenced in the comments

### DIFF
--- a/docs/src/refman/system.txt
+++ b/docs/src/refman/system.txt
@@ -206,6 +206,8 @@ from a few different locations, in this order:
 
 - *Unix only:* $HOME/allegro5rc
 
+- *Unix only:* $HOME/.allegro5rc
+
 - allegro5.cfg next to the executable
 
 If multiple copies are found, then they are merged using [al_merge_config_into].

--- a/src/system.c
+++ b/src/system.c
@@ -142,6 +142,12 @@ static void read_allegro_cfg(void)
          al_merge_config_into(sys_config, temp);
          al_destroy_config(temp);
       }
+      al_set_path_filename(path, ".allegro5rc");
+      temp = al_load_config_file(al_path_cstr(path, '/'));
+      if (temp) {
+         al_merge_config_into(sys_config, temp);
+         al_destroy_config(temp);
+      }
       al_destroy_path(path);
    }
 #endif


### PR DESCRIPTION
I've got burned by this once or twice already :P