### PR TITLE
update dependences in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ before_install:
          export DISPLAY=:99.0;
          sh -e /etc/init.d/xvfb start;
          sudo apt-get update;
-         sudo apt-get install -y libvorbis-dev libtheora-dev libphysfs-dev libdumb1-dev libflac-dev libpulse-dev libgtk2.0-dev pandoc libcurl4-nss-dev libenet-dev pulseaudio;
+         sudo apt-get install -y libvorbis-dev libtheora-dev libphysfs-dev libopusfile-dev libdumb1-dev libflac-dev libpulse-dev libgtk2.0-dev pandoc libcurl4-nss-dev libenet-dev pulseaudio libasound2-dev libopenal-dev;
       elif [ `uname` = "Darwin" ]; then
-         brew install opusfile libvorbis freetype flac physfs;
+         brew install opusfile libvorbis freetype flac physfs dumb theora enet;
       fi
 
 env:


### PR DESCRIPTION
When checking whether I did my WebP patch correctly, I've found some other missing dependencies in Travis config (DUMB, Theora and Enet on macOS; Opus, ALSA and OpenAL on GNU/Linux); this PR adds them.