### PR TITLE
fix dumb_off_t recognition

### DIFF
--- a/addons/acodec/modaudio.c
+++ b/addons/acodec/modaudio.c
@@ -64,11 +64,9 @@ static void *dumb_dll = NULL;
  * dumb_ssize_t is a platform-independent signed size_t.
  * DUMB 0.9.3 expects long wherever dumb_off_t or dumb_ssize_t appear.
  */
-#ifndef dumb_off_t
-#define dumb_off_t long
-#endif
-#ifndef dumb_ssize_t
-#define dumb_ssize_t long
+#if (DUMB_MAJOR_VERSION) < 2
+typedef long dumb_off_t;
+typedef long dumb_ssize_t;
 #endif
 
 static struct


### PR DESCRIPTION
`dumb_off_t` is not a macro, it is a typedef. The preprocessor can't
see `dumb_off_t` even in DUMB 2.0.0, but I assumed it could.

And let's use a typedef to get proper errors.