### PR TITLE
Fix `ptr` assert in file.c

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -101,7 +101,7 @@ bool al_fclose(ALLEGRO_FILE *f)
 size_t al_fread(ALLEGRO_FILE *f, void *ptr, size_t size)
 {
    ASSERT(f);
-   ASSERT(ptr);
+   ASSERT(ptr || size == 0);
 
    if (f->ungetc_len) {
       int bytes_ungetc = 0;
@@ -126,7 +126,7 @@ size_t al_fread(ALLEGRO_FILE *f, void *ptr, size_t size)
 size_t al_fwrite(ALLEGRO_FILE *f, const void *ptr, size_t size)
 {
    ASSERT(f);
-   ASSERT(ptr);
+   ASSERT(ptr || size == 0);
 
    f->ungetc_len = 0;
    return f->vtable->fi_fwrite(f, ptr, size);


### PR DESCRIPTION
According to the C specification `malloc(0)` can return a null pointer.  It turns out that this actually happens in practice, notably on Ubuntu.  Therefore NULL is actually a valid buffer pointer, *if and only if* size == 0.  This adjusts the assertions in al_fread() and al_fwrite() to align.