### PR TITLE
Resize the display on Windows when hiding/showing the menu.

### DIFF
--- a/addons/native_dialog/allegro5/internal/aintern_native_dialog.h
+++ b/addons/native_dialog/allegro5/internal/aintern_native_dialog.h
@@ -137,4 +137,8 @@ extern bool _al_show_display_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu);
 extern bool _al_hide_display_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu);
 extern bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu);
 
+/* Returns the height of the display taken up by the menu, so we can resize
+ * the display to compensate. Windows only at the moment.*/
+extern int _al_get_menu_display_height(void);
+
 #endif

--- a/addons/native_dialog/gtk_menu.c
+++ b/addons/native_dialog/gtk_menu.c
@@ -443,4 +443,9 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu)
    return _al_gtk_wait_for_args(do_show_popup_menu, &args);
 }
 
+int _al_get_menu_display_height(void)
+{
+   return 0;
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/addons/native_dialog/iphone_dialog.m
+++ b/addons/native_dialog/iphone_dialog.m
@@ -161,3 +161,8 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu)
     (void) menu;
     return false;
 }
+
+int _al_get_menu_display_height(void)
+{
+   return 0;
+}

--- a/addons/native_dialog/menu.c
+++ b/addons/native_dialog/menu.c
@@ -724,6 +724,11 @@ bool al_set_display_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu)
    DISPLAY_MENU *dm = NULL;
    size_t i;
    int menu_height = _al_get_menu_display_height();
+   bool automatic_menu_display_resize = true;
+   const char* automatic_menu_display_resize_value =
+      al_get_config_value(al_get_system_config(), "compatibility", "automatic_menu_display_resize");
+   if (automatic_menu_display_resize_value && strcmp(automatic_menu_display_resize_value, "false") == 0)
+      automatic_menu_display_resize = false; 
 
    ASSERT(display);
 
@@ -748,7 +753,7 @@ bool al_set_display_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu)
       _al_walk_over_menu(dm->menu, set_menu_display_r, NULL);
       _al_vector_delete_at(&display_menus, i);
 
-      if (menu_height > 0) {
+      if (automatic_menu_display_resize && menu_height > 0) {
          display->extra_resize_height = 0;
          al_resize_display(display, al_get_display_width(display), al_get_display_height(display));
       }
@@ -779,7 +784,7 @@ bool al_set_display_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu)
       if (!dm)
          dm = _al_vector_alloc_back(&display_menus);
 
-      if (menu_height > 0) {
+      if (automatic_menu_display_resize && menu_height > 0) {
          /* Temporarily disable the constraints so we don't send a RESIZE_EVENT. */
          bool old_constraints = display->use_constraints;
          display->use_constraints = false;

--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -463,6 +463,11 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *amenu)
     return true;
 }
 
+int _al_get_menu_display_height(void)
+{
+   return 0;
+}
+
 @implementation ALLEGMenuTarget
 /* Initial conversion of ALLEGRO_MENU_ITEM to NSMenuItem.
  * The target (self) is set for the item.

--- a/addons/native_dialog/win_dialog.c
+++ b/addons/native_dialog/win_dialog.c
@@ -878,4 +878,9 @@ bool _al_show_popup_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu)
    return true;
 }
 
+int _al_get_menu_display_height(void)
+{
+   return GetSystemMetrics(SM_CYMENU);
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -207,3 +207,11 @@ max_page_size = 0
 
 # Uncomment if you want only the characters in the cache_text entry to ever be drawn
 # skip_cache_misses = true
+
+[compatibility]
+
+# Prior to 5.2.4 on Windows you had to manually resize the display when
+# showing the menu using the dialog addon. After 5.2.4 this is done
+# automatically, but may break old code that handled this eventuality.
+# Set this to false for such code.
+automatic_menu_display_resize = true

--- a/examples/ex_menu.c
+++ b/examples/ex_menu.c
@@ -61,7 +61,6 @@ int main(int argc, char **argv)
 {
    const int initial_width = 320;
    const int initial_height = 200;
-   int windows_menu_height = 0;
    int dcount = 0;
 
    ALLEGRO_DISPLAY *display;
@@ -235,10 +234,7 @@ int main(int argc, char **argv)
                   w = 960;
                if (h > 600)
                   h = 600;
-               if (menu_visible)
-                  al_resize_display(display, w, h + windows_menu_height);
-               else
-                  al_resize_display(display, w, h);
+               al_resize_display(display, w, h);
             }
             else if (event.user.data1 == FILE_FULLSCREEN_ID) {
                int flags = al_get_display_flags(display);

--- a/examples/ex_menu.c
+++ b/examples/ex_menu.c
@@ -280,18 +280,6 @@ int main(int argc, char **argv)
       else if (event.type == ALLEGRO_EVENT_DISPLAY_RESIZE) {
          al_acknowledge_resize(display);
          redraw = true;
-
-#ifdef ALLEGRO_WINDOWS
-         /* XXX The Windows implementation currently uses part of the client's
-          * height to render the window. This triggers a resize event, which
-          * can be trapped and used to compute the menu height, and then
-          * resize the display again to what we expect it to be.
-          */
-         if (event.display.source == display && windows_menu_height == 0) {
-            windows_menu_height = initial_height - al_get_display_height(display);
-            al_resize_display(display, initial_width, initial_height + windows_menu_height);
-         }
-#endif
       }
       else if (event.type == ALLEGRO_EVENT_TIMER) {
          redraw = true;

--- a/include/allegro5/internal/aintern_display.h
+++ b/include/allegro5/internal/aintern_display.h
@@ -158,6 +158,11 @@ struct ALLEGRO_DISPLAY
 
    /* Issue #725 */
    bool use_constraints;
+
+   /* On Windows, menus take up the display's height so whenever doing a
+    * manual resize we need to add this number to the height for things
+    * to work correctly. See issue #860. */
+   int extra_resize_height;
 };
 
 int  _al_score_display_settings(ALLEGRO_EXTRA_DISPLAY_SETTINGS *eds, ALLEGRO_EXTRA_DISPLAY_SETTINGS *ref);

--- a/src/display.c
+++ b/src/display.c
@@ -69,6 +69,7 @@ ALLEGRO_DISPLAY *al_create_display(int w, int h)
    display->max_w = 0;
    display->max_h = 0;
    display->use_constraints = false;
+   display->extra_resize_height = 0;
 
    display->vertex_cache = 0;
    display->num_cache_vertices = 0;
@@ -234,10 +235,10 @@ bool al_resize_display(ALLEGRO_DISPLAY *display, int width, int height)
    ASSERT(display);
    ASSERT(display->vt);
 
-   ALLEGRO_INFO("Requested display resize %dx%d\n", width, height);
+   ALLEGRO_INFO("Requested display resize %dx%d+%d\n", width, height, display->extra_resize_height);
 
    if (display->vt->resize_display) {
-      return display->vt->resize_display(display, width, height);
+      return display->vt->resize_display(display, width, height + display->extra_resize_height);
    }
    return false;
 }


### PR DESCRIPTION
Prior to this, when the menu was shown this would shrink the drawable
area while keeping the window size the same. Now, the window size will
change while keeping the drawable area the same. The value returned by
al_get_display_height is unnaffected by this change.

Tested this with window constraints and things appear to work fine. A
remaining issue is the user changing the windows theme (thus changing
the menu height), which might cause issues. This should be a rare
occurence.

ex_menu had a workaround for this issue, and my testing has shown that
even if kept around, it still appears to work fine with this change in
place, suggesting that this change is backwards compatible.

Fixes #860.