### PR TITLE
ljoynu: fix build with older Android NDKs

### DIFF
--- a/src/linux/ljoynu.c
+++ b/src/linux/ljoynu.c
@@ -47,6 +47,14 @@
    #include <sys/inotify.h>
 #endif
 
+#ifndef KEY_CNT
+   #define KEY_CNT (KEY_MAX+1)
+#endif
+
+#ifndef ABS_CNT
+   #define ABS_CNT (ABS_MAX+1)
+#endif
+
 ALLEGRO_DEBUG_CHANNEL("ljoy");
 
 #include "allegro5/internal/aintern_ljoynu.h"


### PR DESCRIPTION
Commit 76f076e70de5e42eb2122b56e5367f9e3550bd9e removed those defines
to fix some warnings - probably about symbol redefinition. However,
on my setup with NDK r14b and build tools 26.0.1, those defines were
in fact needed and that commit made the build fail. Let's reintroduce
them, but this time guarded by ifndefs, so they don't fail builds on
older NDKs and don't generate warnings on newer ones.