### PR TITLE
docs: take note that al_invert_transform and friends work only with 2D transforms

### DIFF
--- a/docs/src/refman/transformations.txt
+++ b/docs/src/refman/transformations.txt
@@ -202,6 +202,9 @@ If there is no target bitmap, this function returns NULL.
 This is similar to calling `al_invert_transform(al_get_current_transform())`
 but the result of this function is cached.
 
+> *Note*: Allegro's transformation inversion functions work correctly only 
+with 2D transformations.
+
 Since: 5.1.0
 
 ## API: al_invert_transform
@@ -214,6 +217,9 @@ inverse before inverting it if you are in doubt.
 *Parameters:*
 
 * trans - Transformation to invert
+
+> *Note*: Allegro's transformation inversion functions work correctly only 
+with 2D transformations.
 
 See also: [al_check_inverse]
 
@@ -246,6 +252,9 @@ the transformation will be invertible.
 
 *Returns:*
 1 if the transformation is invertible, 0 otherwise
+
+> *Note*: Allegro's transformation inversion functions work correctly only 
+with 2D transformations.
 
 See also: [al_invert_transform]
 


### PR DESCRIPTION
It might be useful to add al_invert_transform_3d and al_invert_transform_4d sometime, but for now just document that al_invert_transform doesn't work with 3- and 4- dimensional transforms.