### PR TITLE
Add deps/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ build_android_mips64/
 build_android_mips/
 build_android_x86/
 build_android_x86_64/
+
+# build dependencies optionally go in deps/, ignore them
+deps/


### PR DESCRIPTION
The CMake build is set up to pull dependencies from `deps/`.  Because of that `git diff` gets polluted with all the includes there making it basically useless.  Since we never want to commit these anyway, I figured we might want to add the whole directory to `.gitignore`.