### PR TITLE
fix allegro_opengl.h comment

### DIFF
--- a/include/allegro5/allegro_opengl.h
+++ b/include/allegro5/allegro_opengl.h
@@ -99,7 +99,7 @@
 #define glDeleteFramebuffersEXT glDeleteFramebuffers
 #endif
 
-#else /* ALLEGRO_MACOSX */
+#else /* ALLEGRO_WINDOWS */
 
 /* HACK: Prevent both Mesa and SGI's broken headers from screwing us */
 #define __glext_h_
@@ -108,7 +108,7 @@
 #undef  __glext_h_
 #undef  __glxext_h_
 
-#endif /* ALLEGRO_MACOSX */
+#endif /* ALLEGRO_WINDOWS */
 
 #ifdef ALLEGRO_RASPBERRYPI
 #include <EGL/egl.h>


### PR DESCRIPTION
I know it's just the comment, but that codepath is not the macos one. I've tried in windows and it's taken there, so I've changed the comment :p