### PR TITLE
opengl: don't force POT bitmaps on GLES

### DIFF
--- a/src/opengl/ogl_bitmap.c
+++ b/src/opengl/ogl_bitmap.c
@@ -1033,8 +1033,7 @@ ALLEGRO_BITMAP *_al_ogl_create_bitmap(ALLEGRO_DISPLAY *d, int w, int h,
       }
    }
 
-   /* Android included because some devices require POT FBOs */
-   if (IS_OPENGLES || !d->extra_settings.settings[ALLEGRO_SUPPORT_NPOT_BITMAP]) {
+   if (!d->extra_settings.settings[ALLEGRO_SUPPORT_NPOT_BITMAP]) {
       true_w = pot(true_w);
       true_h = pot(true_h);
    }


### PR DESCRIPTION
Android devices that don't like NPOT FBOs are probably long gone and incompatible
with current versions of Allegro anyway.

If you need it, POT bitmaps can be always forced using Allegro configuration by
masking GL_ARB_texture_non_power_of_two and GL_OES_texture_npot extensions.