### PR TITLE
Added support of HarfBuzz in FreeType

### DIFF
--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -55,7 +55,8 @@ if(SUPPORT_FONT AND WANT_TTF)
     option(FREETYPE_ZLIB "Enable if FreeType static library needs zlib linked in." off)
     option(FREETYPE_BZIP2 "Enable if FreeType static library needs bzip2 linked in." off)
     option(FREETYPE_PNG "Enable if FreeType static library needs png linked in." off)
-
+    option(FREETYPE_HARFBUZZ "Enable if FreeType static library needs harfbuzz linked in." off)
+	
     if(FREETYPE_FOUND)
         set(FREETYPE_TEST_SOURCE "
             #include <ft2build.h>
@@ -91,6 +92,10 @@ if(SUPPORT_FONT AND WANT_TTF)
             if(FREETYPE_PNG)
                 find_package(PNG)
             endif()
+			
+            if (FREETYPE_HARFBUZZ)
+                find_package(HarfBuzz)
+            endif()
 
             # Try compiling with the extra dependencies.
             set(FREETYPE_STATIC_LIBRARIES ${FREETYPE_LIBRARIES})
@@ -104,6 +109,10 @@ if(SUPPORT_FONT AND WANT_TTF)
 
             if(FREETYPE_PNG AND PNG_FOUND)
                 list(APPEND FREETYPE_STATIC_LIBRARIES "${PNG_LIBRARIES}")
+            endif()
+			
+            if (FREETYPE_HARFBUZZ AND HARFBUZZ_FOUND)
+                list(APPEND FREETYPE_STATIC_LIBRARIES "${HARFBUZZ_LIBRARIES}")
             endif()
 
             set(CMAKE_REQUIRED_LIBRARIES ${FREETYPE_STATIC_LIBRARIES})

--- a/cmake/FindHarfBuzz.cmake
+++ b/cmake/FindHarfBuzz.cmake
@@ -1,0 +1,93 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindHarfBuzz
+# ------------
+#
+# Find the HarfBuzz text shaping engine includes and library.
+#
+# Imported Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following :prop_tgt:`IMPORTED` target:
+#
+# ``HarfBuzz::HarfBuzz``
+#   The Harfbuzz ``harfbuzz`` library, if found
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables in your project:
+#
+# ``HARFBUZZ_FOUND``
+#   true if the HarfBuzz headers and libraries were found
+# ``HARFBUZZ_INCLUDE_DIRS``
+#   directories containing the Harfbuzz headers.
+# ``HARFBUZZ_LIBRARIES``
+#   the library to link against
+# ``HARFBUZZ_VERSION_STRING``
+#   the version of harfbuzz found
+
+# Created by Ebrahim Byagowi.
+
+set(HARFBUZZ_FIND_ARGS
+  HINTS
+    ENV HARFBUZZ_DIR
+  PATHS
+    ENV GTKMM_BASEPATH
+    [HKEY_CURRENT_USER\\SOFTWARE\\gtkmm\\2.4;Path]
+    [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]
+)
+
+find_path(
+  HARFBUZZ_INCLUDE_DIRS
+  hb.h
+  ${HARFBUZZ_FIND_ARGS}
+  PATH_SUFFIXES
+    src
+    harfbuzz
+)
+
+if(NOT HARFBUZZ_LIBRARY)
+  find_library(HARFBUZZ_LIBRARY
+    NAMES
+      harfbuzz
+      libharfbuzz
+    ${HARFBUZZ_FIND_ARGS}
+    PATH_SUFFIXES
+      lib
+  )
+  include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
+  select_library_configurations(HARFBUZZ)
+else()
+  # on Windows, ensure paths are in canonical format (forward slahes):
+  file(TO_CMAKE_PATH "${HARFBUZZ_LIBRARY}" HARFBUZZ_LIBRARY)
+endif()
+
+unset(HARFBUZZ_FIND_ARGS)
+
+# set the user variables
+set(HARFBUZZ_LIBRARIES "${HARFBUZZ_LIBRARY}")
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+  HarfBuzz
+  REQUIRED_VARS
+    HARFBUZZ_LIBRARY
+    HARFBUZZ_INCLUDE_DIRS
+  VERSION_VAR
+  HARFBUZZ_VERSION_STRING
+)
+
+if(HARFBUZZ_FOUND)
+  if(NOT TARGET HarfBuzz::HarfBuzz)
+    add_library(HarfBuzz::HarfBuzz UNKNOWN IMPORTED)
+    set_target_properties(HarfBuzz::HarfBuzz PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${HARFBUZZ_INCLUDE_DIRS}")
+    set_target_properties(HarfBuzz::HarfBuzz PROPERTIES
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${HARFBUZZ_LIBRARY}")
+  endif()
+endif()


### PR DESCRIPTION
I've added HarfBuzz compilation support for FreeType, since the current CMakeLists dosen't support it, it pops up some linking error.
HarfBuzz MUST be compiled with HB_HAVE_FREETYPE otherwise the linking won't succed.