### PR TITLE
Removed stdint.h in allegro/image/bmp.c

### DIFF
--- a/addons/image/bmp.c
+++ b/addons/image/bmp.c
@@ -18,7 +18,6 @@
  */
 
 
-#include <stdint.h>
 #include <string.h>
 
 #include "allegro5/allegro.h"


### PR DESCRIPTION
My compiler (Visual studio 2008) dosen't contain stdint.h, so i remove the inclusion.
Didn't allegro already include astdint.h, making the inclusion pointless?