### PR TITLE
SDL: fix segfaults in mutex handling

### DIFF
--- a/include/allegro5/platform/allegro_sdl_thread.h
+++ b/include/allegro5/platform/allegro_sdl_thread.h
@@ -11,7 +11,6 @@
 struct _AL_MUTEX
 {
    SDL_mutex *mutex;
-   SDL_TLSID lock_count;
 };
 
 struct _AL_THREAD
@@ -47,23 +46,11 @@ AL_FUNC(void, _al_mutex_init, (struct _AL_MUTEX*));
 AL_FUNC(void, _al_mutex_destroy, (struct _AL_MUTEX*));
 AL_INLINE(void, _al_mutex_lock, (struct _AL_MUTEX *m),
 {
-   if (m->lock_count) {
-      int *v = (int *)SDL_TLSGet(m->lock_count);
-      (*v)++;
-      if (*v > 1)
-         return;
-   }
    if (m->mutex)
       SDL_LockMutex(m->mutex);
 })
 AL_INLINE(void, _al_mutex_unlock, (struct _AL_MUTEX *m),
 {
-   if (m->lock_count) {
-      int *v = (int *)SDL_TLSGet(m->lock_count);
-      (*v)--;
-      if (*v > 0)
-         return;
-   }
    if (m->mutex)
       SDL_UnlockMutex(m->mutex);
 })

--- a/src/sdl/sdl_thread.c
+++ b/src/sdl/sdl_thread.c
@@ -48,7 +48,6 @@ void _al_mutex_init(_AL_MUTEX *mutex)
    ASSERT(mutex);
     
    mutex->mutex = SDL_CreateMutex();
-   mutex->lock_count = 0;
 }
 
 static void free_tls(void *v)
@@ -58,12 +57,7 @@ static void free_tls(void *v)
 
 void _al_mutex_init_recursive(_AL_MUTEX *mutex)
 {
-   ASSERT(mutex);
-    
-   mutex->mutex = SDL_CreateMutex();
-   mutex->lock_count = SDL_TLSCreate();
-   int *v = al_calloc(1, sizeof *v);
-   SDL_TLSSet(mutex->lock_count, v, free_tls);
+   _al_mutex_init(mutex);
 }
 
 void _al_mutex_destroy(_AL_MUTEX *mutex)


### PR DESCRIPTION
This is fixed by just removing the code as SDL mutexes are already recursive.

The removed code segfaulted when locking the mutex from another thread than the one that created it (SDL_TLSGet returned NULL, because nothing set it for that thread before).