### PR TITLE
fix python3 string return bug

### DIFF
--- a/python/generate_python_ctypes.py
+++ b/python/generate_python_ctypes.py
@@ -420,6 +420,10 @@ def _dll(func, ret, params):
             f = dll[func]
             f.restype = ret
             f.argtypes = params
+            if ret is _AL_UTF8String:
+                # ctypes cannot do parameter conversion of the return type for us
+                f.restype = c_char_p
+                if sys.version_info[0] > 2: return lambda *x: f(*x).decode("utf8")
             return f
         except AttributeError: pass
     sys.stderr.write("Cannot find function " + func + "\n")


### PR DESCRIPTION
It seems the python wrapper never allowed using functions returning a string under Python3. This patch will fix calling any functions returning a string from Python3 and will have them return a normal Python string.