### PR TITLE
fix and clarify shader docs

### DIFF
--- a/docs/src/refman/primitives.txt
+++ b/docs/src/refman/primitives.txt
@@ -1084,8 +1084,31 @@ Enumerates the types of vertex attributes that a custom vertex may have.
     `ALLEGRO_PRIM_USER_ATTR + 1` and so on.
 
     To access these custom attributes from GLSL shaders you need to declare
-    attributes that follow this nomenclature: `user_attr_#` where # is the index
+    attributes that follow this nomenclature: `al_user_attr_#` where # is the index
     of the attribute.
+
+    For example to have a position and a normal vector for each vertex
+    you could declare it like this:
+   
+    ~~~~c
+    ALLEGRO_VERTEX_ELEMENT elements[3] = {
+        {ALLEGRO_PRIM_POSITION, ALLEGRO_PRIM_FLOAT_3, 0},
+        {ALLEGRO_PRIM_USER_ATTR + 0, ALLEGRO_PRIM_FLOAT_3, 12},
+        {0, 0, 0}};
+    ~~~~
+
+    And then in your vertex shader access it like this:
+
+    ~~~~c
+    attribute vec3 al_pos; // ALLEGRO_PRIM_POSITION
+    attribute vec3 al_user_attr_0; // ALLEGRO_PRIM_USER_ATTR + 0
+    varying float light;
+    const vec3 light_direction = vec3(0, 0, 1);
+    void main() {
+        light = dot(al_user_attr_0, light_direction);
+        gl_Position = al_pos;
+    }
+    ~~~~
 
     To access these custom attributes from HLSL you need to declare a parameter
     with the following semantics: `TEXCOORD{# + 2}` where # is the index of the
@@ -1095,7 +1118,7 @@ Enumerates the types of vertex attributes that a custom vertex may have.
     Since: 5.1.6
 
 See also:
-[ALLEGRO_VERTEX_DECL], [ALLEGRO_PRIM_STORAGE]
+[ALLEGRO_VERTEX_DECL], [ALLEGRO_PRIM_STORAGE], [al_attach_shader_source]
 
 ### API: ALLEGRO_PRIM_STORAGE
 

--- a/docs/src/refman/shader.txt
+++ b/docs/src/refman/shader.txt
@@ -133,6 +133,13 @@ al_texcoord
 al_color
 :   vertex color attribute. Type is `vec4`.
 
+al_user_attr_0
+:   The vertex attribute declared as ALLEGRO_PRIM_USER_ATTR
+
+al_user_attr_1, ..., al_user_attr_9
+:   The vertex attribute declared as ALLEGRO_PRIM_USER_ATTR + X where X is an integer from 1 to 9
+
+
 For HLSL shaders the vertex attributes are passed using the following semantics:
 
 POSITION0
@@ -166,7 +173,7 @@ updated. The error log can be retrieved with [al_get_shader_log].
 Since: 5.1.0
 
 See also: [al_attach_shader_source_file], [al_build_shader],
-[al_get_default_shader_source], [al_get_shader_log]
+[al_get_default_shader_source], [al_get_shader_log], [ALLEGRO_PRIM_ATTR]
 
 ## API: al_attach_shader_source_file
 


### PR DESCRIPTION
The user attributes are named al_user_attr_# and not user_attr_# as
claimed in the documentation. Also clarify how you can use those
attributes.