### PR TITLE
acodec/wav: fix swapping for big endian

### DIFF
--- a/addons/acodec/wav.c
+++ b/addons/acodec/wav.c
@@ -175,16 +175,13 @@ static size_t wav_read(WAVFILE *wavfile, void *data, size_t samples)
     */
 #ifdef ALLEGRO_BIG_ENDIAN
    if (wavfile->bits == 16) {
-      uint8_t *p = data;
-      const uint8_t *const end = p + bytes_read - 1; /* in case bytes_read is not even */
+      uint16_t *p = data;
+      const uint16_t *const end = p + (bytes_read >> 1);
 
       /* swap high/low bytes */
       while (p < end) {
-         uint8_t *const q = p + 1;
-         const uint8_t tmp = *p;
-         *p = *q;
-         *q = tmp;
-         p = q;       
+         *p = ((*p << 8) | (*p >> 8));
+         p++;
       }
    }
 #endif

--- a/addons/audio/aqueue.m
+++ b/addons/audio/aqueue.m
@@ -261,6 +261,9 @@ static void *stream_proc(void *in_data)
    else
       desc.mFormatFlags = kLinearPCMFormatFlagIsFloat |
       kLinearPCMFormatFlagIsPacked;
+#ifdef ALLEGRO_BIG_ENDIAN
+   desc.mFormatFlags |= kLinearPCMFormatFlagIsBigEndian;
+#endif
    desc.mBytesPerPacket = ex_data->channels * (ex_data->bits_per_sample/8);
    desc.mFramesPerPacket = 1;
    desc.mBytesPerFrame = ex_data->channels * (ex_data->bits_per_sample/8);
@@ -498,12 +501,15 @@ static int _aqueue_allocate_recorder(ALLEGRO_AUDIO_RECORDER *recorder)
    data->data_format.mBytesPerFrame = 
    data->data_format.mBytesPerPacket = data->data_format.mChannelsPerFrame * al_get_audio_depth_size(recorder->depth);
    
-   data->data_format.mFormatFlags = kLinearPCMFormatFlagIsPacked;   
+   data->data_format.mFormatFlags = kLinearPCMFormatFlagIsPacked;
+#ifdef ALLEGRO_BIG_ENDIAN
+   data->data_format.mFormatFlags |= kLinearPCMFormatFlagIsBigEndian;
+#endif
    if (recorder->depth == ALLEGRO_AUDIO_DEPTH_FLOAT32)
       data->data_format.mFormatFlags |= kLinearPCMFormatFlagIsFloat;
    else if (!(recorder->depth & ALLEGRO_AUDIO_DEPTH_UNSIGNED))
       data->data_format.mFormatFlags |= kLinearPCMFormatFlagIsSignedInteger;
-      
+
    data->buffer_size = 2048; // in bytes
   
    ret = AudioQueueNewInput(


### PR DESCRIPTION
Current code just moves one byte left without swapping http://coliru.stacked-crooked.com/a/87be408dc4c14d6b because it doesn’t increment by two inside `while (p < end) { uint8_t *const q = p + 1; const uint8_t tmp = *p; *p = *q; *q = tmp; p = q; }`, it swaps 0th byte with 1st then instead of swapping 2nd and 3rd it swaps 1st and 2nd

This is how does fixed code work http://coliru.stacked-crooked.com/a/196d759192422012

Plus, aqueue driver needs to be fixed to play samples on big endian without multiplying gain by 0.089(9) https://developer.apple.com/documentation/coreaudio/klinearpcmformatflagisbigendian