### PR TITLE
ALSA/PulseAudio crash and memory leak fixes

### DIFF
--- a/addons/audio/alsa.c
+++ b/addons/audio/alsa.c
@@ -144,6 +144,7 @@ static void alsa_close(void)
    
    alsa_device = NULL;
    
+   snd_output_close(snd_output);
    snd_config_update_free_global();
 }
 

--- a/addons/audio/alsa.c
+++ b/addons/audio/alsa.c
@@ -286,6 +286,7 @@ static void *alsa_update_mmap(ALLEGRO_THREAD *self, void *arg)
    const snd_pcm_channel_area_t *areas;
    snd_pcm_uframes_t offset;
    char *mmap;
+   snd_pcm_sframes_t commitres;
    int ret;
 
    ALLEGRO_INFO("ALSA update_mmap thread started\n");
@@ -347,7 +348,10 @@ static void *alsa_update_mmap(ALLEGRO_THREAD *self, void *arg)
          break;
       }
 
-      ASSERT(frames);
+      if (frames == 0) {
+         al_rest(0.005); /* TODO: Why not use an event or condition variable? */
+         goto commit;
+      }
 
       /* mmaped driver's memory. Interleaved channels format. */
       mmap = (char *) areas[0].addr
@@ -388,7 +392,8 @@ silence:
          al_fill_silence(mmap, frames, voice->depth, voice->chan_conf);
       }
 
-      snd_pcm_sframes_t commitres = snd_pcm_mmap_commit(alsa_voice->pcm_handle, offset, frames);
+commit:
+      commitres = snd_pcm_mmap_commit(alsa_voice->pcm_handle, offset, frames);
       if (commitres < 0 || (snd_pcm_uframes_t)commitres != frames) {
          if ((ret = xrun_recovery(alsa_voice->pcm_handle, commitres >= 0 ? -EPIPE : commitres)) < 0) {
             ALLEGRO_ERROR("MMAP commit error: %s\n", snd_strerror(ret));

--- a/addons/audio/pulseaudio.c
+++ b/addons/audio/pulseaudio.c
@@ -115,8 +115,9 @@ static int pulseaudio_open(void)
       if (pa_mainloop_iterate(mainloop, blocking, NULL) < 0) {
          ALLEGRO_ERROR("pa_mainloop_iterate failed\n");
          pa_context_disconnect(c);
+         pa_context_unref(c);
          pa_mainloop_free(mainloop);
-         break;
+         return 1;
       }
       pa_context_state_t s = pa_context_get_state(c);
       if (s == PA_CONTEXT_READY) {
@@ -126,6 +127,7 @@ static int pulseaudio_open(void)
       if (s == PA_CONTEXT_FAILED) {
          ALLEGRO_ERROR("PA_CONTEXT_FAILED\n");
          pa_context_disconnect(c);
+         pa_context_unref(c);
          pa_mainloop_free(mainloop);
          return 1;
       }
@@ -138,6 +140,7 @@ static int pulseaudio_open(void)
    }
    /*if (state == PA_SINK_SUSPENDED) {
       pa_context_disconnect(c);
+      pa_context_unref(c);
       pa_mainloop_free(mainloop);
       return 1;
    }*/


### PR DESCRIPTION
Fixes a large memory leak in al_install_audio() if PulseAudio is compiled in but not available, and a smaller memory leak in ALSA after uninstalling audio.

Also comes with a small fix for what appears to be an obvious use-after-free / double-free bug for the "pa_mainloop_iterate failed" case in PulseAudio initialization.

I'm not sure if the ALSA fix (issue #944) is the best it could be -- it just waits and re-tries as the existing under-run handler does -- but it should be a pretty rare case anyway.