### PR TITLE
4.4: Windows: fix TAB key getting stuck in "key" array when held before ALT

### DIFF
--- a/src/win/wkeybd.c
+++ b/src/win/wkeybd.c
@@ -325,8 +325,12 @@ static void key_dinput_handle_scancode(unsigned char scancode, int pressed)
    /* ignore special Windows keys (alt+tab, alt+space, (ctrl|alt)+esc) */
    if (((scancode == DIK_TAB) && (_key_shifts & KB_ALT_FLAG))
        || ((scancode == DIK_SPACE) && (_key_shifts & KB_ALT_FLAG))
-       || ((scancode == DIK_ESCAPE) && (_key_shifts & (KB_CTRL_FLAG | KB_ALT_FLAG))))
+       || ((scancode == DIK_ESCAPE) && (_key_shifts & (KB_CTRL_FLAG | KB_ALT_FLAG)))) {
+      /* force key release to make sure it does not get 'stuck' if held before ALT */
+      if (key[hw_to_mycode[scancode]])
+         handle_key_release(scancode);
       return;
+   }
 
    /* alt+F4 triggers a WM_CLOSE under Windows */
    if ((scancode == DIK_F4) && (_key_shifts & KB_ALT_FLAG)) {


### PR DESCRIPTION
This fixes an issue of certain key codes getting stuck in the "key" array after Alt+Tab, Ctrl+Esc and similar combinations until these keys are pressed again. I am not aware if this was reported properly here, but it seems to be a very old bug because it was reported by AGS engine users on numerous occasions in the past years.

### Demonstration
I've made a simple test program which demonstrates the issue, the source may be downloaded here (Dropbox):
https://www.dropbox.com/s/xlwrsmd9a6w0cde/winalleg-keystucktest-src.zip?dl=0
This program draws red rectangle whenever TAB key is found in the "key" array, and green rectangle otherwise (exit by ESC).

Steps to reproduce:
1. Hold TAB.
2. Hold ALT (dont let TAB yet).
3. Now release TAB first (this is essential).
4. Now release ALT.
5. Examine rectangle stays red until you press TAB again.

### On the problem
From my understanding of what Allegro is doing in **key_dinput_handle_scancode()**:
it receives key push and release events, and passes them further into **handle_key_press()** / **handle_key_release()**. It may skip these calls under certain conditions, including ALT + F4, ALT + TAB and some other combinations.

Skipping Alt+Tab instead of passing it further into program makes sense, but the ambivalent meaning of this function caused it to fail. Because when TAB key is released, if ALT key is still registered as pressed at that moment, the TAB release event will also be ignored:

1. you hold TAB; since ALT is not pressed yet, the *press event is registered*.
2. you hold ALT and then release TAB or ALT & TAB simultaneously, then *release event is skipped*, making program think that TAB is still pressed.

My knowledge of Allegro internals is limited, so quickest solution I found is to force release event for the scancode that is accompanied by Alt and Ctrl (TAB, space or Escape in this case). TBH I am not fully certain if that's optimal, therefore may try to find better way if necessary.