### PR TITLE
opengl: fix compilation with Mesa 18.2.5 and later

### DIFF
--- a/include/allegro5/allegro_opengl.h
+++ b/include/allegro5/allegro_opengl.h
@@ -103,10 +103,14 @@
 
 /* HACK: Prevent both Mesa and SGI's broken headers from screwing us */
 #define __glext_h_
+#define __gl_glext_h_
 #define __glxext_h_
+#define __glx_glxext_h_
 #include <GL/gl.h>
 #undef  __glext_h_
+#undef  __gl_glext_h_
 #undef  __glxext_h_
+#undef  __glx_glxext_h_
 
 #endif /* ALLEGRO_MACOSX */
 

--- a/include/allegro5/opengl/GLext/glx_ext_defs.h
+++ b/include/allegro5/opengl/GLext/glx_ext_defs.h
@@ -1,7 +1,9 @@
 /* HACK: Prevent both Mesa and SGI's broken headers from screwing us */
 #define __glxext_h_
+#define __glx_glxext_h_
 #include <GL/glx.h>
 #undef __glxext_h_
+#undef __glx_glxext_h_
 
 #ifndef GLX_VERSION_1_3
 #define _ALLEGRO_GLX_VERSION_1_3


### PR DESCRIPTION
Mesa headers have been updated and changed some defines that Allegro
is hackily relying on.

https://gitlab.freedesktop.org/mesa/mesa/commit/f7d42ee7d319256608ad60778f6787c140badada