### PR TITLE
[4.4] Remove f* variants of fixed math functions

### DIFF
--- a/include/allegro/alcompat.h
+++ b/include/allegro/alcompat.h
@@ -40,24 +40,6 @@
       #endif
    #endif
 
-   #ifndef ALLEGRO_NO_FIX_ALIASES
-      AL_ALIAS(fixed fadd(fixed x, fixed y), fixadd(x, y))
-      AL_ALIAS(fixed fsub(fixed x, fixed y), fixsub(x, y))
-      AL_ALIAS(fixed fmul(fixed x, fixed y), fixmul(x, y))
-      AL_ALIAS(fixed fdiv(fixed x, fixed y), fixdiv(x, y))
-      AL_ALIAS(int fceil(fixed x), fixceil(x))
-      AL_ALIAS(int ffloor(fixed x), fixfloor(x))
-      AL_ALIAS(fixed fcos(fixed x), fixcos(x))
-      AL_ALIAS(fixed fsin(fixed x), fixsin(x))
-      AL_ALIAS(fixed ftan(fixed x), fixtan(x))
-      AL_ALIAS(fixed facos(fixed x), fixacos(x))
-      AL_ALIAS(fixed fasin(fixed x), fixasin(x))
-      AL_ALIAS(fixed fatan(fixed x), fixatan(x))
-      AL_ALIAS(fixed fatan2(fixed y, fixed x), fixatan2(y, x))
-      AL_ALIAS(fixed fsqrt(fixed x), fixsqrt(x))
-      AL_ALIAS(fixed fhypot(fixed x, fixed y), fixhypot(x, y))
-   #endif
-
 #endif  /* !defined ALLEGRO_SRC */
 
 


### PR DESCRIPTION
Removing functions that conflicts with later glibc implementations,
people should use fix* variants instead.
(Simply use fixadd instead of fadd).
 