### PR TITLE
[android] updated Gradle to more recent versions

### DIFF
--- a/README_android.txt
+++ b/README_android.txt
@@ -65,7 +65,7 @@ command:
         --api=15 --install-dir=$ANDROID_NDK_TOOLCHAIN_ROOT --arch=arm
 
 You can use any api 9 or higher but 15 is the lowest this was tested
-with. 
+with.
 
 Use the --arch parameter according to the toolchain you are creating:
 
@@ -196,8 +196,8 @@ If you want to build just the .apk for an example, there are targets
 for that as well:
 
     make ex_draw_bitmap_apk
-    adb install -r examples/ex_draw_bitmap.project/bin/ex_draw_bitmap-debug.apk
-    adb -d shell 'am start -n org.liballeg.examples.ex_draw_bitmap/.Activity'
+    adb -d install -r ./examples/ex_draw_bitmap.project/app/build/outputs/apk/debug/app-debug.apk
+    adb -d shell 'am start -n org.liballeg.ex_draw_bitmap/org.liballeg.app.MainActivity'
 
 
 How startup works on Android
@@ -395,4 +395,3 @@ Run the app again. If it worked, congratulations! You just ran your
 first Allegro program on Android!
 
 (The sample code will just flash your screen yellow and red with no way to quit, so you will have to force quit it.)
-

--- a/android/gradle_project/build.gradle
+++ b/android/gradle_project/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.0.0-beta7"
+        classpath "com.android.tools.build:gradle:3.2.0"
     }
 }
 

--- a/android/gradle_project/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle_project/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
I was trying to build Allegro for android and kept bumping into that error :

```
> Configure project :allegro
The CompileOptions.bootClasspath property has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the CompileOptions.bootstrapClasspath property instead.


FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':allegro'.
> No toolchains found in the NDK toolchains folder for ABI with prefix: mips64el-linux-android

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
make[2]: *** [lib/allegro-debug.aar] Error 1
make[1]: *** [android/CMakeFiles/aar.dir/all] Error 2
make: *** [all] Error 2
```

Apparently it's due to the fact this platform has been deprecated in latest versions of Android NDK.

I'm not the only user experiencing this, and it's not strictly Allegro related, eg: -> https://github.com/flutter/flutter/issues/22031

I'm using:

```
export ANDROID_NDK_ROOT=$HOME/Home/android/android-ndk-r17c
export ANDROID_NDK_TOOLCHAIN_ROOT=$HOME/Home/android/allegro-android-toolchain
export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
export PATH=$ANDROID_NDK_TOOLCHAIN_ROOT/bin:$JAVA_HOME/bin:$PATH
```

I *think* I could just use even older versions of the NDK but I get a sense, at some point, it makes sense to upgrade to newer versions.

Note that this enabled me to compile Allegro, but I'm still not to the point I have something running on my phone. That being said, without this patch, it would not even compile...