### PR TITLE
Added ifdef to prevent hard ref to glXCreateContextAttribsARB

### DIFF
--- a/src/x/xglx_config.c
+++ b/src/x/xglx_config.c
@@ -491,8 +491,12 @@ static GLXContext create_context_new(int ver, Display *dpy, GLXFBConfig fb,
    GCCA_PROC _xglx_glXCreateContextAttribsARB = NULL;
 
    if (ver >= 140) {
-      /* GLX 1.4 should have this */
+      /* GLX 1.4 should have this, if it's defined, use it directly. */
+      /* OTOH it *could* be there but only available through dynamic loading. */
+      /* In that case, fallback to calling glxXGetProcAddress. */
+#ifdef glXCreateContextAttribsARB
       _xglx_glXCreateContextAttribsARB = glXCreateContextAttribsARB;
+#endif // glXCreateContextAttribsARB
    }
    if (!_xglx_glXCreateContextAttribsARB) {
       /* Load the extension manually. */


### PR DESCRIPTION
Master branch would not compile on my box, had to use this `#ifdef` trick.

This [stack overflow ling](https://stackoverflow.com/questions/9459652/glxcreatecontextattribsarb-not-found-on-opengl-4-2-driver-glx-1-4) suggests it's not a bad practice to use `glXGetProcAddress`, generally speaking. I think it would work in all cases, and that hard-linking on  `glXCreateContextAttribsARB` is, to some extent, an unneeded optimization. But I'm not the expert here.

What I know is that with this patch, on my box having following properties:
```
$ uname -a
Linux pat 4.18.0-3-amd64 #1 SMP Debian 4.18.20-2 (2018-11-23) x86_64 GNU/Linux
$ dpkg --list | grep -i glx
ii  libgl1-mesa-dev:amd64                                            18.2.6-1                               amd64        free implementation of the OpenGL API -- GLX development files
ii  libgl1-mesa-glx:amd64                                            18.2.6-1                               amd64        transitional dummy package
ii  libgl1-mesa-glx:i386                                             18.2.6-1                               i386         transitional dummy package
ii  libglx-mesa0:amd64                                               18.2.6-1                               amd64        free implementation of the OpenGL API -- GLX vendor library
ii  libglx-mesa0:i386                                                18.2.6-1                               i386         free implementation of the OpenGL API -- GLX vendor library
ii  libglx0:amd64                                                    1.1.0-1                                amd64        Vendor neutral GL dispatch library -- GLX support
ii  libglx0:i386                                                     1.1.0-1                                i386         Vendor neutral GL dispatch library -- GLX support
ii  libswt-glx-gtk-3-jni                                             3.8.2-5                                amd64        Standard Widget Toolkit for GTK+ GLX JNI library
ii  libva-glx1:amd64                                                 1.7.3-2                                amd64        Video Acceleration (VA) API for Linux -- GLX runtime
ii  libva-glx2:amd64                                                 2.3.0-2                                amd64        Video Acceleration (VA) API for Linux -- GLX runtime
ii  libxcb-glx0:amd64                                                1.13.1-2                               amd64        X C Binding, glx extension
ii  libxcb-glx0:i386                                                 1.13.1-2                               i386         X C Binding, glx extension
ii  libxcb-glx0-dev:amd64                                            1.13.1-2                               amd64        X C Binding, glx extension, development files
```
I  was able to build Allegro and run the `ex_opengl_pixel_shader` example successfully. For some reason `ex_opengl` crashes but I think it's unrelated, really. Again, without that patch, I can't even compile, so hard to compare.