### PR TITLE
Fix lost precision warning

### DIFF
--- a/include/allegro5/inline/fmaths.inl
+++ b/include/allegro5/inline/fmaths.inl
@@ -131,8 +131,7 @@ AL_INLINE(al_fixed, al_fixsub, (al_fixed x, al_fixed y),
          return 0x80000000;
       }
       else {
-         int res = lres >> 16;
-         return res;
+         return (al_fixed) (lres >> 16);
       }
    })
 #endif	    /* al_fixmul() C implementations */


### PR DESCRIPTION
This wasn't causing errors but has been bugging me for a while.
````
In file included from /usr/local/include/allegro5/allegro.h:45:
In file included from /usr/local/include/allegro5/fmaths.h:42:
/usr/local/include/allegro5/inline/fmaths.inl:134:25: warning: implicit conversion loses integer precision: 'int64_t' (aka 'long long') to 'int' [-Wshorten-64-to-32]
         int res = lres >> 16;
             ~~~   ~~~~~^~~~~
````
Also, it's not guaranteed that `int` and `al_fixed` (a.k.a `int32_t`) are the same type.