### PR TITLE
cmake: fix HarfBuzz detection script and clean up

### DIFF
--- a/cmake/FindHarfBuzz.cmake
+++ b/cmake/FindHarfBuzz.cmake
@@ -34,10 +34,6 @@
 set(HARFBUZZ_FIND_ARGS
   HINTS
     ENV HARFBUZZ_DIR
-  PATHS
-    ENV GTKMM_BASEPATH
-    [HKEY_CURRENT_USER\\SOFTWARE\\gtkmm\\2.4;Path]
-    [HKEY_LOCAL_MACHINE\\SOFTWARE\\gtkmm\\2.4;Path]
 )
 
 find_path(
@@ -58,8 +54,6 @@ if(NOT HARFBUZZ_LIBRARY)
     PATH_SUFFIXES
       lib
   )
-  include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
-  select_library_configurations(HARFBUZZ)
 else()
   # on Windows, ensure paths are in canonical format (forward slahes):
   file(TO_CMAKE_PATH "${HARFBUZZ_LIBRARY}" HARFBUZZ_LIBRARY)


### PR DESCRIPTION
For starters,
  include(${CMAKE_CURRENT_LIST_DIR}/SelectLibraryConfigurations.cmake)
is wrong and should be changed to
  include(SelectLibraryConfigurations)

However, judging from both the docs and the actual output, this function
shouldn't be used at all if earlier detection doesn't set _RELEASE and
_DEBUG variants of its variables. Otherwise, a path already found gets
replaced with "HARFBUZZ_LIBRARY-NOTFOUND".

Fixes #979