### PR TITLE
xwin.c: increase X_MAX_EVENTS to 50

### DIFF
--- a/src/x/xwin.c
+++ b/src/x/xwin.c
@@ -162,7 +162,7 @@ static int use_bgr_palette_hack = FALSE; /* use BGR hack for color conversion pa
 int _xwin_missed_input;
 #endif
 
-#define X_MAX_EVENTS   5
+#define X_MAX_EVENTS   50
 #define MOUSE_WARP_DELAY   200
 
 static char _xwin_driver_desc[256] = EMPTY_STRING;


### PR DESCRIPTION
this should fix mouse lag on Linux with hi-res devices.
( see https://github.com/aseprite/aseprite/issues/283 )