### PR TITLE
Fix: Race Condition & Add Static Runtime Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ option(WANT_EMBED
 set(FRAMEWORK_INSTALL_PREFIX "/Library/Frameworks" CACHE STRING
     "Directory in which to install Mac OS X frameworks")
 
+if(MSVC)
+    option(STATIC_RUNTIME "Use the static MSVC runtime" on)
+endif(MSVC)
+
 #-----------------------------------------------------------------------------#
 #
 # Unix platform checks
@@ -335,6 +339,7 @@ if(COMPILER_GCC)
     set(CMAKE_SHARED_LINKER_FLAGS_PROFILE "-pg"
         CACHE STRING "profiling flags")
 endif(COMPILER_GCC)
+
 if(COMPILER_MSVC)
     set(CMAKE_C_FLAGS_PROFILE "-Gd -Ox"
         CACHE STRING "profiling flags")
@@ -342,6 +347,23 @@ if(COMPILER_MSVC)
         CACHE STRING "profiling flags")
     set(CMAKE_EXE_LINKER_FLAGS_PROFILE "-profile"
         CACHE STRING "profiling flags")
+
+    if(STATIC_RUNTIME)
+        set(CompilerFlags
+        	CMAKE_CXX_FLAGS
+	        CMAKE_CXX_FLAGS_DEBUG
+	        CMAKE_CXX_FLAGS_RELEASE
+		CMAKE_CXX_FLAGS_RELWITHDEBINFO
+        	CMAKE_C_FLAGS
+	        CMAKE_C_FLAGS_DEBUG
+        	CMAKE_C_FLAGS_RELEASE
+		CMAKE_C_FLAGS_RELWITHDEBINFO
+        	)
+	foreach(CompilerFlag ${CompilerFlags})
+	  string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+          string(REPLACE "/MDd" "/MTd" ${CompilerFlag} "${${CompilerFlag}}")
+	endforeach()
+    endif(STATIC_RUNTIME)
 endif(COMPILER_MSVC)
 
 #-----------------------------------------------------------------------------#

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -143,6 +143,7 @@ typedef struct KEY_BUFFER
 static volatile KEY_BUFFER key_buffer;
 static volatile KEY_BUFFER _key_buffer;
 
+static void *key_mutex;
 
 
 /* add_key:
@@ -172,12 +173,7 @@ static INLINE void add_key(volatile KEY_BUFFER *buffer, int key, int scancode)
       }
    }
 
-   buffer->lock++;
-
-   if (buffer->lock != 1) {
-      buffer->lock--;
-      return;
-   }
+   system_driver->lock_mutex(key_mutex);
 
    if ((waiting_for_input) && (keyboard_driver) && (keyboard_driver->stop_waiting_for_input))
       keyboard_driver->stop_waiting_for_input();
@@ -193,7 +189,7 @@ static INLINE void add_key(volatile KEY_BUFFER *buffer, int key, int scancode)
       buffer->end = c;
    }
 
-   buffer->lock--;
+   system_driver->unlock_mutex(key_mutex);
 }
 
 
@@ -206,14 +202,12 @@ void clear_keybuf(void)
    if (keyboard_polled)
       poll_keyboard();
 
-   key_buffer.lock++;
-   _key_buffer.lock++;
+   system_driver->lock_mutex(key_mutex);
 
    key_buffer.start = key_buffer.end = 0;
    _key_buffer.start = _key_buffer.end = 0;
 
-   key_buffer.lock--;
-   _key_buffer.lock--;
+   system_driver->unlock_mutex(key_mutex);
 
    if ((keypressed_hook) && (readkey_hook))
       while (keypressed_hook())
@@ -403,11 +397,18 @@ END_OF_STATIC_FUNCTION(repeat_timer);
  *  which will be used by the main keypressed() and readkey() functions. This
  *  can be useful if you want to use Allegro's GUI code with a custom
  *  keyboard handler, as it provides a way for the GUI to access keyboard
- *  input from your own code.
+ *  input from your own code. 
  */
 void install_keyboard_hooks(int (*keypressed)(void), int (*readkey)(void))
 {
    key_buffer.lock = _key_buffer.lock = 0;
+
+   // since this mode of using the keyboard handler does not have a removal
+   // function, it leaks memory---but at least we can limit the leak to only
+   // a single mutex even if the user calls this function a bunch of times
+   // for some reason.
+   if(!key_mutex)
+      key_mutex = system_driver->create_mutex();
 
    clear_keybuf();
    clear_key();
@@ -661,6 +662,9 @@ int install_keyboard(void)
    LOCK_FUNCTION(repeat_timer);
 
    key_buffer.lock = _key_buffer.lock = 0;
+   
+   if(!key_mutex)
+      key_mutex = system_driver->create_mutex();
 
    clear_keybuf();
    clear_key();
@@ -730,6 +734,12 @@ void remove_keyboard(void)
 
    clear_keybuf();
    clear_key();
+   
+   if(key_mutex)
+   {
+      system_driver->destroy_mutex(key_mutex);
+	  key_mutex = NULL;
+   }
 
    key_shifts = _key_shifts = 0;
 

--- a/src/win/wwnd.c
+++ b/src/win/wwnd.c
@@ -19,6 +19,7 @@
 #include "allegro.h"
 #include "allegro/internal/aintern.h"
 #include "allegro/platform/aintwin.h"
+#include "wddraw.h"
 
 #ifndef SCAN_DEPEND
    #include <string.h>


### PR DESCRIPTION

Changelog:
Fix: The keyboard handler has a race condition that can cause Allegro programs to stop accepting any keyboard input (usually manifests itself after the program has been running a considerable length of time). Replaced the old attempt at protecting the critical section with a mutex.
( evouga, 12th August, 2017 )

Feat: Added option to compile Allegro with a static runtime library.  (ZC needs this.)
( evouga, 19th August, 2017 )

FixL Added a missing #include directive.
( evouga, 10th August, 2017 )
