### PR TITLE
Fix vsync on OSX 10.14+.

### DIFF
--- a/src/macosx/osxgl.h
+++ b/src/macosx/osxgl.h
@@ -36,6 +36,11 @@ typedef struct ALLEGRO_DISPLAY_OSX_WIN {
    BOOL in_fullscreen;
    BOOL single_buffer;
    CGDisplayModeRef original_mode;
+   /* For new (10.14+) vsyncing. */
+   CVDisplayLinkRef display_link;
+   ALLEGRO_MUTEX *flip_mutex;
+   ALLEGRO_COND *flip_cond;
+   int num_flips;
 } ALLEGRO_DISPLAY_OSX_WIN;
 
 /* This is our version of ALLEGRO_MOUSE_CURSOR */


### PR DESCRIPTION
This follows the changeset from SDL and GLFW:

https://hg.libsdl.org/SDL/rev/73f3ca85ac0e
https://github.com/glfw/glfw/issues/1337

But with a few modifications based on my observations:

- <s>I think I do a better job at always waiting for a refresh</s>
- I keep the old way around because in my testing the new way (while limiting
  frames) did not prevent screen tearing.

Fixes #978