### PR TITLE
SDL: don't create SDL_Renderer

### DIFF
--- a/include/allegro5/platform/allegro_internal_sdl.h
+++ b/include/allegro5/platform/allegro_internal_sdl.h
@@ -18,7 +18,6 @@ typedef struct ALLEGRO_DISPLAY_SDL
 
    int x, y;
    SDL_Window *window;
-   SDL_Renderer *renderer;
    SDL_GLContext context;
 } ALLEGRO_DISPLAY_SDL;
 


### PR DESCRIPTION
As we do all GL drawing by ourselves, SDL_Renderer is completely unnecessary.

It actually even triggers a bug in current SDL master :D