### PR TITLE
Add al_get_system_id function

### DIFF
--- a/docs/src/refman/system.txt
+++ b/docs/src/refman/system.txt
@@ -223,6 +223,22 @@ place it next to your executable!
 __ALLEGRO_5_CFG
 ~~~~
 
+## API: al_get_system_id
+
+Returns the platform that Allegro is running on, which can be one of the following:
+
+-  ALLEGRO_SYSTEM_ID_UNKNOWN
+-  ALLEGRO_SYSTEM_ID_XGLX
+-  ALLEGRO_SYSTEM_ID_WINDOWS
+-  ALLEGRO_SYSTEM_ID_MACOSX
+-  ALLEGRO_SYSTEM_ID_ANDROID
+-  ALLEGRO_SYSTEM_ID_IPHONE
+-  ALLEGRO_SYSTEM_ID_GP2XWIZ
+-  ALLEGRO_SYSTEM_ID_RASPBERRYPI
+-  ALLEGRO_SYSTEM_ID_SDL
+
+Since: 5.2.5
+
 ## API: al_register_assert_handler
 
 Register a function to be called when an internal Allegro assertion fails.

--- a/include/allegro5/internal/aintern_system.h
+++ b/include/allegro5/internal/aintern_system.h
@@ -20,7 +20,7 @@ typedef struct ALLEGRO_SYSTEM_INTERFACE ALLEGRO_SYSTEM_INTERFACE;
 
 struct ALLEGRO_SYSTEM_INTERFACE
 {
-   int id;
+   ALLEGRO_SYSTEM_ID id;
    ALLEGRO_SYSTEM *(*initialize)(int flags);
    ALLEGRO_DISPLAY_INTERFACE *(*get_display_driver)(void);
    ALLEGRO_KEYBOARD_DRIVER *(*get_keyboard_driver)(void);

--- a/include/allegro5/system.h
+++ b/include/allegro5/system.h
@@ -10,6 +10,19 @@
 
 typedef struct ALLEGRO_SYSTEM ALLEGRO_SYSTEM;
 
+enum ALLEGRO_SYSTEM_ID {
+  ALLEGRO_SYSTEM_ID_UNKNOWN = 0,
+  ALLEGRO_SYSTEM_ID_XGLX = AL_ID('X', 'G', 'L', 'X'),
+  ALLEGRO_SYSTEM_ID_WINDOWS = AL_ID('W', 'I', 'N', 'D'),
+  ALLEGRO_SYSTEM_ID_MACOSX = AL_ID('O', 'S', 'X', ' '),
+  ALLEGRO_SYSTEM_ID_ANDROID = AL_ID('A', 'N', 'D', 'R'),
+  ALLEGRO_SYSTEM_ID_IPHONE = AL_ID('I', 'P', 'H', 'O'),
+  ALLEGRO_SYSTEM_ID_GP2XWIZ = AL_ID('W', 'I', 'Z', ' '),
+  ALLEGRO_SYSTEM_ID_RASPBERRYPI = AL_ID('R', 'A', 'S', 'P'),
+  ALLEGRO_SYSTEM_ID_SDL = AL_ID('S', 'D', 'L', '2')
+};
+typedef enum ALLEGRO_SYSTEM_ID ALLEGRO_SYSTEM_ID;
+
 /* Function: al_init
  */
 #define al_init()    (al_install_system(ALLEGRO_VERSION_INT, atexit))
@@ -19,6 +32,7 @@ AL_FUNC(void, al_uninstall_system, (void));
 AL_FUNC(bool, al_is_system_installed, (void));
 AL_FUNC(ALLEGRO_SYSTEM *, al_get_system_driver, (void));
 AL_FUNC(ALLEGRO_CONFIG *, al_get_system_config, (void));
+AL_FUNC(ALLEGRO_SYSTEM_ID, al_get_system_id, (void));
 
 enum {
    ALLEGRO_RESOURCES_PATH = 0,

--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -533,6 +533,7 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_android_interface()
    android_vt = al_malloc(sizeof *android_vt);
    memset(android_vt, 0, sizeof *android_vt);
 
+   android_vt->id = ALLEGRO_SYSTEM_ID_ANDROID;
    android_vt->initialize = android_initialize;
    android_vt->get_display_driver = _al_get_android_display_driver;
    android_vt->get_keyboard_driver = _al_get_android_keyboard_driver;

--- a/src/gp2xwiz/wiz_system.c
+++ b/src/gp2xwiz/wiz_system.c
@@ -141,6 +141,7 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_gp2xwiz_driver(void)
 
    gp2xwiz_vt = al_calloc(1, sizeof *gp2xwiz_vt);
 
+   gp2xwiz_vt->id = ALLEGRO_SYSTEM_ID_GP2XWIZ;
    gp2xwiz_vt->initialize = gp2xwiz_initialize;
    gp2xwiz_vt->get_display_driver = gp2xwiz_get_display_driver;
    gp2xwiz_vt->get_keyboard_driver = gp2xwiz_get_keyboard_driver;

--- a/src/iphone/iphone_system.c
+++ b/src/iphone/iphone_system.c
@@ -82,6 +82,7 @@ ALLEGRO_SYSTEM_INTERFACE *_al_get_iphone_system_interface(void)
     
     vt = al_calloc(1, sizeof *vt);
     
+    vt->id = ALLEGRO_SYSTEM_ID_IPHONE;
     vt->initialize = iphone_initialize;
     vt->get_display_driver = iphone_get_display_driver;
     vt->get_keyboard_driver = _al_get_iphone_keyboard_driver;

--- a/src/macosx/system.m
+++ b/src/macosx/system.m
@@ -522,6 +522,7 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_osx_driver(void)
    if (vt == NULL) {
       vt = al_malloc(sizeof(*vt));
       memset(vt, 0, sizeof(*vt));
+      vt->id = ALLEGRO_SYSTEM_ID_MACOSX;
       vt->initialize = osx_sys_init;
       vt->get_display_driver = _al_osx_get_display_driver;
       vt->get_keyboard_driver = _al_osx_get_keyboard_driver;

--- a/src/raspberrypi/pisystem.c
+++ b/src/raspberrypi/pisystem.c
@@ -179,6 +179,7 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_raspberrypi_driver(void)
 
    pi_vt = al_calloc(1, sizeof *pi_vt);
 
+   pi_vt->id = ALLEGRO_SYSTEM_ID_RASPBERRYPI;
    pi_vt->initialize = pi_initialize;
    pi_vt->get_display_driver = _al_get_raspberrypi_display_interface;
    pi_vt->get_keyboard_driver = pi_get_keyboard_driver;

--- a/src/sdl/sdl_system.c
+++ b/src/sdl/sdl_system.c
@@ -315,7 +315,7 @@ ALLEGRO_SYSTEM_INTERFACE *_al_sdl_system_driver(void)
       return vt;
 
    vt = al_calloc(1, sizeof *vt);
-   vt->id = AL_ID('S', 'D', 'L', '2');
+   vt->id = ALLEGRO_SYSTEM_ID_SDL;
    vt->initialize = sdl_initialize;
    vt->get_display_driver = sdl_get_display_driver;
    vt->get_keyboard_driver = sdl_get_keyboard_driver;

--- a/src/system.c
+++ b/src/system.c
@@ -355,6 +355,12 @@ ALLEGRO_SYSTEM *al_get_system_driver(void)
    return active_sysdrv;
 }
 
+/* Function: al_get_system_id
+ */
+ALLEGRO_SYSTEM_ID al_get_system_id(void)
+{
+   return active_sysdrv->vt->id;
+}
 
 /* Function: al_get_system_config
  */

--- a/src/win/wsystem.c
+++ b/src/win/wsystem.c
@@ -885,6 +885,7 @@ static ALLEGRO_SYSTEM_INTERFACE *_al_system_win_driver(void)
 
    vt = al_calloc(1, sizeof *vt);
 
+   vt->id = ALLEGRO_SYSTEM_ID_WINDOWS;
    vt->initialize = win_initialize;
    vt->get_display_driver = win_get_display_driver;
    vt->get_keyboard_driver = win_get_keyboard_driver;

--- a/src/x/xsystem.c
+++ b/src/x/xsystem.c
@@ -405,6 +405,7 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_xglx_driver(void)
 
    xglx_vt = al_calloc(1, sizeof *xglx_vt);
 
+   xglx_vt->id = ALLEGRO_SYSTEM_ID_XGLX;
    xglx_vt->initialize = xglx_initialize;
    xglx_vt->get_display_driver = xglx_get_display_driver;
    xglx_vt->get_keyboard_driver = xglx_get_keyboard_driver;


### PR DESCRIPTION
Some systems, like SDL or Raspberry Pi, can be employed on a platform where a more generic system can also work.
In such case there's no way to differentiate between systems, as the usual way to handle things like that, preprocessor macros, by definition can't work at runtime.

BTW. I'll be more than happy to change those names if you come up with better ideas :D If you prefer strings to enum, that's fine too. I have added `ALLEGRO_SYSTEM_ID_UNKNOWN` as I see some support for custom systems in the code.