### PR TITLE
fix python wrapper generation after the al_get_system_id patch

### DIFF
--- a/python/generate_python_ctypes.py
+++ b/python/generate_python_ctypes.py
@@ -237,6 +237,9 @@ class Allegro:
                     if "=" in field:
                         fname, val = field.split("=", 1)
                         fname = fname.strip()
+                        # replace any 'X' (an integer value in C) with
+                        # ord('X') to match up in Python
+                        val = re.sub("('.')", "ord(\\1)", val)
                         try:
                             i = int(eval(val, globals(), self.constants))
                         except NameError:


### PR DESCRIPTION
It would fail on things like ALLEGRO_SYSTEM_ID_XGLX otherwise which is AL_ID('X', 'G', 'L', 'X').