### PR TITLE
Fix C4334 warning on VS2017

### DIFF
--- a/src/display_settings.c
+++ b/src/display_settings.c
@@ -53,7 +53,7 @@ int _al_get_suggested_display_option(ALLEGRO_DISPLAY *d,
 {
    ALLEGRO_EXTRA_DISPLAY_SETTINGS *s = &d->extra_settings;
    uint64_t flags = s->required | s->suggested;
-   if (flags & (1 << option))
+   if (flags & (UINT64_C(1) << option))
       return s->settings[option];
    return default_value;
 }


### PR DESCRIPTION
This is just a minor change to fix a warning for the windows code only. It comes from casting 32-bit shift to 64 bit.