### PR TITLE
Windows - use UNICODE mechanism throughout

### DIFF
--- a/addons/native_dialog/win_dialog.c
+++ b/addons/native_dialog/win_dialog.c
@@ -245,7 +245,6 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
          wpath = _twin_ustr_to_tchar(path);
       }
       else {
-         //al_ustr_encode_utf16(path, buf, sizeof(buf));
          /* Extract the directory from the path. */
          initial_dir_path = al_clone_path(fd->fc_initial_path);
          if (initial_dir_path) {

--- a/addons/native_dialog/win_dialog.c
+++ b/addons/native_dialog/win_dialog.c
@@ -14,6 +14,7 @@
 #include "allegro5/internal/aintern_native_dialog.h"
 
 #include "allegro5/platform/aintwin.h"
+#include "allegro5/internal/aintern_wunicode.h"
 
 #include "allegro5/allegro_windows.h"
 
@@ -36,7 +37,7 @@ static int wlog_count = 0;
 static void *wlog_rich_edit_module = 0;
 
 /* Name of the edit control. Depend on system resources. */
-static wchar_t* wlog_edit_control = L"EDIT";
+static TCHAR* wlog_edit_control = TEXT("EDIT");
 
 /* True if output support unicode */
 static bool wlog_unicode = false;
@@ -46,6 +47,31 @@ static ALLEGRO_MUTEX* global_mutex;
 static ALLEGRO_COND* wm_size_cond;
 static bool got_wm_size_event = false;
 
+/* For Unicode support, define some helper functions
+ * which work with either UTF-16 or ANSI code pages
+ * depending on whether UNICODE is defined or not.
+ */ 
+
+/* tcreate_path:
+ * Create path from TCHARs
+ */
+static ALLEGRO_PATH* _tcreate_path(const TCHAR* ts) 
+{
+   char* tmp = _twin_tchar_to_utf8(ts);
+   ALLEGRO_PATH* path = al_create_path(tmp);
+   al_free(tmp);
+   return path;
+}
+/* tcreate_path:
+ * Create directory path from TCHARs
+ */
+static ALLEGRO_PATH* _tcreate_path_for_directory(const TCHAR* ts) 
+{
+   char* tmp = _twin_tchar_to_utf8(ts);
+   ALLEGRO_PATH* path = al_create_path_for_directory(tmp);
+   al_free(tmp);
+   return path;
+}
 
 bool _al_init_native_dialog_addon(void)
 {
@@ -67,27 +93,33 @@ void _al_shutdown_native_dialog_addon(void)
    wm_size_cond = NULL;
 }
 
+
 static bool select_folder(ALLEGRO_DISPLAY_WIN *win_display,
    ALLEGRO_NATIVE_DIALOG *fd)
 {
    BROWSEINFO folderinfo;
    LPCITEMIDLIST pidl;
-   char buf[MAX_PATH] = "";
-   char dbuf[MAX_PATH] = "";
+   /* Selected path */
+   TCHAR buf[MAX_PATH] = TEXT("");
+   /* Display name */
+   TCHAR dbuf[MAX_PATH] = TEXT("");
 
    folderinfo.hwndOwner = win_display ? win_display->window : NULL;
    folderinfo.pidlRoot = NULL;
    folderinfo.pszDisplayName = dbuf;
-   folderinfo.lpszTitle = al_cstr(fd->title);
+   folderinfo.lpszTitle = _twin_ustr_to_tchar(fd->title);
    folderinfo.ulFlags = 0;
    folderinfo.lpfn = NULL;
 
    pidl = SHBrowseForFolder(&folderinfo);
+
+   al_free((void*) folderinfo.lpszTitle);
+
    if (pidl) {
       SHGetPathFromIDList(pidl, buf);
       fd->fc_path_count = 1;
       fd->fc_paths = al_malloc(sizeof(void *));
-      fd->fc_paths[0] = al_create_path(buf);
+      fd->fc_paths[0] = _tcreate_path(buf);
       return true;
    }
    return false;
@@ -143,7 +175,7 @@ static ALLEGRO_USTR *create_filter_string(const ALLEGRO_USTR *patterns)
    return filter;
 }
 
-static int skip_nul_terminated_string(char *s)
+static int skip_nul_terminated_string(TCHAR *s)
 {
    int i = 0;
 
@@ -160,8 +192,10 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
    ALLEGRO_DISPLAY_WIN *win_display;
    int flags = 0;
    bool ret;
-   char buf[4096];
-   const int BUFSIZE = sizeof(buf);
+   TCHAR buf[4096];
+   const int BUFSIZE = sizeof(buf) / sizeof(TCHAR);
+   TCHAR* wfilter = NULL;
+   TCHAR* wpath = NULL;
    ALLEGRO_USTR *filter_string = NULL;
    ALLEGRO_PATH* initial_dir_path = NULL;
 
@@ -181,24 +215,25 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
    /* Create filter string. */
    if (fd->fc_patterns) {
       filter_string = create_filter_string(fd->fc_patterns);
-      ofn.lpstrFilter = al_cstr(filter_string);
+      wfilter = _twin_ustr_to_tchar(filter_string);
+      ofn.lpstrFilter = wfilter;
    }
    else {
       /* List all files by default. */
-      ofn.lpstrFilter = "All Files\0*.*\0\0";
+      ofn.lpstrFilter = TEXT("All Files\0*.*\0\0");
    }
 
    /* Provide buffer for file chosen by dialog. */
    ofn.lpstrFile = buf;
-   ofn.nMaxFile = sizeof(buf);
+   ofn.nMaxFile = BUFSIZE;
 
    /* Initialize file name buffer and starting directory. */
    if (fd->fc_initial_path) {
       bool is_dir;
-      const char *path = al_path_cstr(fd->fc_initial_path, ALLEGRO_NATIVE_PATH_SEP);
+      const ALLEGRO_USTR *path = al_path_ustr(fd->fc_initial_path, ALLEGRO_NATIVE_PATH_SEP);
 
-      if (al_filename_exists(path)) {
-         ALLEGRO_FS_ENTRY *fs = al_create_fs_entry(path);
+      if (al_filename_exists(al_cstr(path))) {
+         ALLEGRO_FS_ENTRY *fs = al_create_fs_entry(al_cstr(path));
          is_dir = al_get_fs_entry_mode(fs) & ALLEGRO_FILEMODE_ISDIR;
          al_destroy_fs_entry(fs);
       }
@@ -207,21 +242,22 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
       }
 
       if (is_dir) {
-         ofn.lpstrInitialDir = path;
+         wpath = _twin_ustr_to_tchar(path);
       }
       else {
-         strncpy(buf, path, BUFSIZE - 1);
+         //al_ustr_encode_utf16(path, buf, sizeof(buf));
          /* Extract the directory from the path. */
          initial_dir_path = al_clone_path(fd->fc_initial_path);
          if (initial_dir_path) {
             al_set_path_filename(initial_dir_path, NULL);
-            ofn.lpstrInitialDir = al_path_cstr(initial_dir_path, ALLEGRO_NATIVE_PATH_SEP);
+            wpath = _twin_utf8_to_tchar(al_path_cstr(initial_dir_path, ALLEGRO_NATIVE_PATH_SEP));
          }
       }
+      ofn.lpstrInitialDir = wpath;
    }
 
    if (fd->title)
-      ofn.lpstrTitle = al_cstr(fd->title);
+      ofn.lpstrTitle = _twin_ustr_to_tchar(fd->title);
 
    flags |= OFN_NOCHANGEDIR | OFN_EXPLORER;
    if (fd->flags & ALLEGRO_FILECHOOSER_SAVE) {
@@ -244,7 +280,9 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
    if (initial_dir_path) {
       al_destroy_path(initial_dir_path);
    }
-
+   al_free((void*) ofn.lpstrTitle);
+   al_free(wfilter);
+   al_free(wpath);
    al_ustr_free(filter_string);
 
    if (!ret) {
@@ -273,7 +311,7 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
 
    if (fd->fc_path_count == 1) {
       fd->fc_paths = al_malloc(sizeof(void *));
-      fd->fc_paths[0] = al_create_path(buf);
+      fd->fc_paths[0] = _tcreate_path(buf);
    }
    else {
       int i, p;
@@ -284,8 +322,10 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
       fd->fc_paths = al_malloc(fd->fc_path_count * sizeof(void *));
       i = skip_nul_terminated_string(buf);
       for (p = 0; p < (int)fd->fc_path_count; p++) {
-         fd->fc_paths[p] = al_create_path_for_directory(buf);
-         al_set_path_filename(fd->fc_paths[p], buf+i);
+         fd->fc_paths[p] = _tcreate_path_for_directory(buf);
+         char* tmp = _twin_tchar_to_utf8(buf + i);
+         al_set_path_filename(fd->fc_paths[p], tmp);
+         al_free(tmp);
          i += skip_nul_terminated_string(buf+i);
       }
    }
@@ -298,9 +338,7 @@ int _al_show_native_message_box(ALLEGRO_DISPLAY *display,
 {
    UINT type = MB_SETFOREGROUND;
    int result;
-
-   uint16_t *wide_text, *wide_title;
-   size_t text_len, title_len;
+   TCHAR *text, *title;
 
    /* Note: the message box code cannot assume that Allegro is installed. */
 
@@ -325,27 +363,20 @@ int _al_show_native_message_box(ALLEGRO_DISPLAY *display,
 
    al_ustr_append(fd->mb_heading, fd->mb_text);
 
-   text_len = al_ustr_size_utf16(fd->mb_heading);
-   title_len = al_ustr_size_utf16(fd->title);
-
-   wide_text = al_malloc(text_len + 1);
-   if (!wide_text)
-      return 0;
-
-   wide_title = al_malloc(title_len + 1);
-   if (!wide_title) {
-      al_free(wide_text);
+   text = _twin_ustr_to_tchar(fd->mb_heading);
+   if (!text) {
       return 0;
    }
+   title = _twin_ustr_to_tchar(fd->title);
+   if (!title) {
+      al_free(text);
+      return 0;
+   }
+   result = MessageBox(al_get_win_window_handle(display),
+      text, title, type);
 
-   al_ustr_encode_utf16(fd->mb_heading, wide_text, text_len);
-   al_ustr_encode_utf16(fd->title, wide_title, title_len);
-
-   result = MessageBoxW(al_get_win_window_handle(display),
-      (LPCWSTR) wide_text, (LPCWSTR) wide_title, type);
-
-   al_free(wide_text);
-   al_free(wide_title);
+   al_free(text);
+   al_free(title);
 
    if (result == IDYES || result == IDOK)
       return 1;
@@ -365,64 +396,37 @@ static void wlog_emit_close_event(ALLEGRO_NATIVE_DIALOG *textlog, bool keypress)
    al_emit_user_event(&textlog->tl_events, &event, NULL);
 }
 
-/* Output message to ANSI log. */
-static void wlog_do_append_native_text_log_ansi(ALLEGRO_NATIVE_DIALOG *textlog)
-{
-   int index;
-   index = GetWindowTextLength(textlog->tl_textview);
-   SendMessageA(textlog->tl_textview, EM_SETSEL, (WPARAM)index, (LPARAM)index);
-   SendMessageA(textlog->tl_textview, EM_REPLACESEL, 0, (LPARAM)al_cstr(textlog->tl_pending_text));
-
-   al_ustr_truncate(textlog->tl_pending_text, 0);
-   textlog->tl_have_pending = false;
-}
-
-/* Output message to Unicode log. */
-static void wlog_do_append_native_text_log_unicode(ALLEGRO_NATIVE_DIALOG *textlog)
-{
-#define BUFFER_SIZE  512
-   bool flush;
-   int index, ch, next;
-   static WCHAR buffer[BUFFER_SIZE + 1] = { 0 };
-
-   index = GetWindowTextLength(textlog->tl_textview);
-   SendMessageW(textlog->tl_textview, EM_SETSEL, (WPARAM)index, (LPARAM)index);
-
-   next = 0;
-   index = 0;
-   flush = false;
-   while ((ch = al_ustr_get_next(textlog->tl_pending_text, &next)) >= 0) {
-      buffer[index] = (WCHAR)ch;
-      flush = true;
-
-      index++;
-
-      if ((index % BUFFER_SIZE) == 0) {
-         buffer[BUFFER_SIZE] = L'\0';
-         SendMessageW(textlog->tl_textview, EM_REPLACESEL, 0, (LPARAM)buffer);
-         flush = false;
-         index = 0;
+/* convert_crlf:
+ * Alter this string to change every LF to CRLF
+ */
+static ALLEGRO_USTR* convert_crlf(ALLEGRO_USTR* s) {
+   int pos = 0;
+   int ch, prev;
+   while ((pos = al_ustr_find_chr(s, pos, '\n')) >= 0) {
+      prev = pos;
+      ch = al_ustr_prev_get(s, &prev);
+      if (ch == -2) {
+         return s;
+      } else if (ch != '\r') {
+         al_ustr_insert_chr(s, pos, '\r');
+         al_ustr_next(s, &pos);
       }
+      al_ustr_next(s, &pos);
    }
-
-   if (flush) {
-      buffer[index] = L'\0';
-      SendMessageW(textlog->tl_textview, EM_REPLACESEL, 0, (LPARAM)buffer);
-   }
-
-   al_ustr_truncate(textlog->tl_pending_text, 0);
-   textlog->tl_have_pending = false;
+   return s;
 }
-
 /* General function to output log message. */
 static void wlog_do_append_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
 {
-   if (wlog_unicode) {
-      wlog_do_append_native_text_log_unicode(textlog);
-   }
-   else {
-      wlog_do_append_native_text_log_ansi(textlog);
-   }
+   int index;
+   index = GetWindowTextLength(textlog->tl_textview);
+   SendMessage(textlog->tl_textview, EM_SETSEL, (WPARAM)index, (LPARAM)index);
+   convert_crlf(textlog->tl_pending_text);
+   TCHAR* buf = _twin_utf8_to_tchar(al_cstr(textlog->tl_pending_text));   
+   SendMessage(textlog->tl_textview, EM_REPLACESEL, 0, (LPARAM) buf);
+   al_free(buf);
+   al_ustr_truncate(textlog->tl_pending_text, 0);
+   textlog->tl_have_pending = false;
 
    SendMessage(textlog->tl_textview, WM_VSCROLL, SB_BOTTOM, 0);
 }
@@ -436,7 +440,7 @@ static LRESULT CALLBACK wlog_text_log_callback(HWND hWnd, UINT uMsg, WPARAM wPar
 
    switch (uMsg) {
       case WM_CREATE:
-         /* Set user data for window, so we will be able to retieve text log structure any time */
+         /* Set user data for window, so we will be able to retrieve text log structure any time */
          create_struct = (CREATESTRUCT*)lParam;
          SetWindowLongPtr(hWnd, GWLP_USERDATA, (LONG_PTR)create_struct->lpCreateParams);
          break;
@@ -489,21 +493,24 @@ static LRESULT CALLBACK wlog_text_log_callback(HWND hWnd, UINT uMsg, WPARAM wPar
 /* We hold textlog->tl_text_mutex. */
 static bool open_native_text_log_inner(ALLEGRO_NATIVE_DIALOG *textlog)
 {
-   LPCSTR font_name;
+   LPCTSTR font_name;
    HWND hWnd;
    HWND hLog;
    RECT client_rect;
    HFONT hFont;
    MSG msg;
    BOOL ret;
+   TCHAR* title;
 
    /* Create text log window. */
-   hWnd = CreateWindowA("Allegro Text Log", al_cstr(textlog->title),
+   title = _twin_ustr_to_tchar(textlog->title);
+   hWnd = CreateWindow(TEXT("Allegro Text Log"), title,
       WS_CAPTION | WS_SIZEBOX | WS_MINIMIZEBOX | WS_MAXIMIZEBOX | WS_SYSMENU,
       CW_USEDEFAULT, CW_USEDEFAULT, 640, 480, NULL, NULL,
       (HINSTANCE)GetModuleHandle(NULL), textlog);
+   al_free(title);
    if (!hWnd) {
-      ALLEGRO_ERROR("CreateWindowA failed\n");
+      ALLEGRO_ERROR("CreateWindow failed\n");
       return false;
    }
 
@@ -511,12 +518,12 @@ static bool open_native_text_log_inner(ALLEGRO_NATIVE_DIALOG *textlog)
    GetClientRect(hWnd, &client_rect);
 
    /* Create edit control. */
-   hLog = CreateWindowW(wlog_edit_control, NULL,
+   hLog = CreateWindow(wlog_edit_control, NULL,
       WS_CHILD | WS_VISIBLE | WS_VSCROLL | ES_MULTILINE | ES_WANTRETURN | ES_AUTOVSCROLL | ES_READONLY,
       client_rect.left, client_rect.top, client_rect.right - client_rect.left, client_rect.bottom - client_rect.top,
       hWnd, NULL, (HINSTANCE)GetModuleHandle(NULL), NULL);
    if (!hLog) {
-      ALLEGRO_ERROR("CreateWindowW failed\n");
+      ALLEGRO_ERROR("CreateWindow failed\n");
       DestroyWindow(hWnd);
       return false;
    }
@@ -526,9 +533,9 @@ static bool open_native_text_log_inner(ALLEGRO_NATIVE_DIALOG *textlog)
 
    /* Select font name. */
    if (textlog->flags & ALLEGRO_TEXTLOG_MONOSPACE)
-      font_name = "Courier New";
+      font_name = TEXT("Courier New");
    else
-      font_name = "Arial";
+      font_name = TEXT("Arial");
 
    /* Create font and set font. */
    hFont = CreateFont(-11, 0, 0, 0, FW_LIGHT, 0, 0,
@@ -586,7 +593,7 @@ static bool open_native_text_log_inner(ALLEGRO_NATIVE_DIALOG *textlog)
 
 bool _al_open_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
 {
-   WNDCLASSA text_log_class;
+   WNDCLASS text_log_class;
    bool rc;
 
    al_lock_mutex(textlog->tl_text_mutex);
@@ -601,16 +608,16 @@ bool _al_open_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
 
       memset(&text_log_class, 0, sizeof(text_log_class));
       text_log_class.hInstance      = (HINSTANCE)GetModuleHandle(NULL);
-      text_log_class.lpszClassName  = "Allegro Text Log";
+      text_log_class.lpszClassName  = TEXT("Allegro Text Log");
       text_log_class.lpfnWndProc    = wlog_text_log_callback;
       text_log_class.hIcon          = NULL;
       text_log_class.hCursor        = NULL;
       text_log_class.lpszMenuName   = NULL;
       text_log_class.hbrBackground  = (HBRUSH)GetStockObject(GRAY_BRUSH);
 
-      if (RegisterClassA(&text_log_class) == 0) {
+      if (RegisterClass(&text_log_class) == 0) {
          /* Failure, window class is a basis and we do not have one. */
-         ALLEGRO_ERROR("RegisterClassA failed\n");
+         ALLEGRO_ERROR("RegisterClass failed\n");
          al_unlock_mutex(textlog->tl_text_mutex);
          return false;
       }
@@ -623,21 +630,21 @@ bool _al_open_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
 
       if ((wlog_rich_edit_module = _al_open_library("msftedit.dll"))) {
          /* 4.1 and emulation of 3.0, 2.0, 1.0 */
-         wlog_edit_control = L"RICHEDIT50W"; /*MSFTEDIT_CLASS*/
+         wlog_edit_control = TEXT("RICHEDIT50W"); /*MSFTEDIT_CLASS*/
          wlog_unicode      = true;
       }
       else if ((wlog_rich_edit_module = _al_open_library("riched20.dll"))) {
          /* 3.0, 2.0 */
-         wlog_edit_control = L"RichEdit20W"; /*RICHEDIT_CLASS*/
+         wlog_edit_control = TEXT("RichEdit20W"); /*RICHEDIT_CLASS*/
          wlog_unicode      = true;
       }
       else if ((wlog_rich_edit_module = _al_open_library("riched32.dll"))) {
          /* 1.0 */
-         wlog_edit_control = L"RichEdit"; /*RICHEDIT_CLASS*/
+         wlog_edit_control = TEXT("RichEdit"); /*RICHEDIT_CLASS*/
          wlog_unicode      = false;
       }
       else {
-         wlog_edit_control = L"EDIT";
+         wlog_edit_control = TEXT("EDIT");
          wlog_unicode      = false;
       }
    }
@@ -660,7 +667,7 @@ bool _al_open_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
    /* Unregister window class. */
    if (wlog_count == 0) {
       ALLEGRO_DEBUG("Unregister text log class\n");
-      UnregisterClassA("Allegro Text Log", (HINSTANCE)GetModuleHandle(NULL));
+      UnregisterClass(TEXT("Allegro Text Log"), (HINSTANCE)GetModuleHandle(NULL));
    }
 
    al_unlock_mutex(textlog->tl_text_mutex);
@@ -765,7 +772,7 @@ static void init_menu_info(MENUITEMINFO *info, ALLEGRO_MENU_ITEM *menu)
    }
    else {
       info->fType = MFT_STRING;
-      info->dwTypeData = (LPSTR) al_cstr(menu->caption);
+      info->dwTypeData = _twin_ustr_to_tchar(menu->caption);
       info->cch = al_ustr_size(menu->caption);
    }
 
@@ -813,7 +820,11 @@ static void init_menu_info(MENUITEMINFO *info, ALLEGRO_MENU_ITEM *menu)
    }
 
 }
-
+static void destroy_menu_info(MENUITEMINFO *info) {
+   if (info->dwTypeData) {
+      al_free(info->dwTypeData);
+   }
+}
 bool _al_init_menu(ALLEGRO_MENU *menu)
 {
    menu->extra1 = CreateMenu();
@@ -832,7 +843,7 @@ bool _al_insert_menu_item_at(ALLEGRO_MENU_ITEM *item, int i)
    init_menu_info(&info, item);
   
    InsertMenuItem((HMENU) item->parent->extra1, i, TRUE, &info);
-
+   destroy_menu_info(&info);
    return true;
 }
 
@@ -845,7 +856,7 @@ bool _al_update_menu_item_at(ALLEGRO_MENU_ITEM *item, int i)
 
    if (item->parent->display)
       DrawMenuBar(al_get_win_window_handle(item->parent->display));
-
+   destroy_menu_info(&info);
    return true;
 }
 
@@ -929,5 +940,6 @@ int _al_get_menu_display_height(void)
 {
    return GetSystemMetrics(SM_CYMENU);
 }
+
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/native_dialog/win_dialog.c
+++ b/addons/native_dialog/win_dialog.c
@@ -250,9 +250,7 @@ bool _al_show_native_file_dialog(ALLEGRO_DISPLAY *display,
    if (!ret) {
       DWORD err = GetLastError();
       if (err != ERROR_SUCCESS) {
-         char buf[1000];
-         FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, NULL, err, 0, buf, sizeof(buf), NULL);
-         ALLEGRO_ERROR("al_show_native_file_dialog failed: %s\n", buf);
+         ALLEGRO_ERROR("al_show_native_file_dialog failed: %s\n", _al_win_error(err));
       }
       return false;
    }

--- a/include/allegro5/internal/aintern_wjoydxnu.h
+++ b/include/allegro5/internal/aintern_wjoydxnu.h
@@ -42,15 +42,15 @@ typedef enum
 
 typedef struct
 {
-   bool have_x;      char name_x[NAME_LEN];
-   bool have_y;      char name_y[NAME_LEN];
-   bool have_z;      char name_z[NAME_LEN];
-   bool have_rx;     char name_rx[NAME_LEN];
-   bool have_ry;     char name_ry[NAME_LEN];
-   bool have_rz;     char name_rz[NAME_LEN];
-   int num_sliders;  char name_slider[MAX_SLIDERS][NAME_LEN];
-   int num_povs;     char name_pov[MAX_POVS][NAME_LEN];
-   int num_buttons;  char name_button[MAX_BUTTONS][NAME_LEN];
+   bool have_x;      TCHAR name_x[NAME_LEN];
+   bool have_y;      TCHAR name_y[NAME_LEN];
+   bool have_z;      TCHAR name_z[NAME_LEN];
+   bool have_rx;     TCHAR name_rx[NAME_LEN];
+   bool have_ry;     TCHAR name_ry[NAME_LEN];
+   bool have_rz;     TCHAR name_rz[NAME_LEN];
+   int num_sliders;  TCHAR name_slider[MAX_SLIDERS][NAME_LEN];
+   int num_povs;     TCHAR name_pov[MAX_POVS][NAME_LEN];
+   int num_buttons;  TCHAR name_button[MAX_BUTTONS][NAME_LEN];
 } CAPS_AND_NAMES;
 
 

--- a/include/allegro5/internal/aintern_wunicode.h
+++ b/include/allegro5/internal/aintern_wunicode.h
@@ -3,14 +3,35 @@
 
 #ifdef ALLEGRO_WINDOWS
 
+#include <tchar.h>
+
 #ifdef __cplusplus
    extern "C" {
 #endif
 
 
-AL_FUNC(wchar_t *, _al_win_utf16, (const char *s));
-AL_FUNC(char *, _al_win_utf8, (const wchar_t *ws));
+AL_FUNC(wchar_t*, _al_win_utf8_to_utf16, (const char *s));
+AL_FUNC(char *, _al_win_utf16_to_utf8, (const wchar_t *ws));
+AL_FUNC(char*, _al_win_utf8_to_ansi, (const char* u));
+AL_FUNC(char*, _al_win_ansi_to_utf8, (const char *u));
+AL_FUNC(char *, _al_win_copy_utf16_to_utf8, (char* u, const wchar_t* ws, size_t size));
+AL_FUNC(char *, _al_win_copy_utf8_to_utf16, (wchar_t* ws, const char *u, size_t size));
+AL_FUNC(char *, _al_win_copy_ansi_to_utf8, (char* u, const char *s, size_t size));
+AL_FUNC(char *, _al_win_copy_utf8_to_ansi, (char* s, const char *u, size_t size));
 
+#ifdef UNICODE
+#define _twin_ustr_to_tchar(str) _al_win_utf8_to_utf16(al_cstr(str))
+#define _twin_utf8_to_tchar _al_win_utf8_to_utf16
+#define _twin_tchar_to_utf8 _al_win_utf16_to_utf8
+#define _twin_copy_tchar_to_utf8 _al_win_copy_utf16_to_utf8
+#define _twin_copy_utf8_to_tchar _al_win_copy_utf8_to_utf16
+#else
+#define _twin_ustr_to_tchar(str) _al_win_utf8_to_ansi(al_cstr(str))
+#define _twin_utf8_to_tchar _al_win_utf8_to_ansi
+#define _twin_tchar_to_utf8 _al_win_ansi_to_utf8
+#define _twin_copy_tchar_to_utf8 _al_win_copy_ansi_to_utf8
+#define _twin_copy_utf8_to_tchar _al_win_copy_utf8_to_ansi
+#endif
 
 #ifdef __cplusplus
    }

--- a/include/allegro5/platform/aintwin.h
+++ b/include/allegro5/platform/aintwin.h
@@ -283,6 +283,11 @@ void _al_win_touch_input_handle_end(int id, size_t timestamp, float x, float y, 
 void _al_win_touch_input_handle_move(int id, size_t timestamp, float x, float y, bool primary, ALLEGRO_DISPLAY_WIN *win_disp);
 void _al_win_touch_input_handle_cancel(int id, size_t timestamp, float x, float y, bool primary, ALLEGRO_DISPLAY_WIN *win_disp);
 
+/* Helpers for getting Windows system errors 
+ * May be called from addons 
+ */
+AL_FUNC(const char*, _al_win_error, (DWORD));
+AL_FUNC(const char*, _al_win_last_error, ());
 
 #ifdef __cplusplus
    }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -41,7 +41,6 @@
 #ifndef WINVER
 #define WINVER 0x0500
 #endif
-#define UNICODE
 #include <windows.h>
 #endif
 

--- a/src/file_stdio.c
+++ b/src/file_stdio.c
@@ -111,8 +111,8 @@ static void *file_stdio_fopen(const char *path, const char *mode)
 
 #ifdef ALLEGRO_WINDOWS
    {
-      wchar_t *wpath = _al_win_utf16(path);
-      wchar_t *wmode = _al_win_utf16(mode);
+      wchar_t *wpath = _al_win_utf8_to_utf16(path);
+      wchar_t *wmode = _al_win_utf8_to_utf16(mode);
       fp = _wfopen(wpath, wmode);
       al_free(wpath);
       al_free(wmode);

--- a/src/fshook_stdio.c
+++ b/src/fshook_stdio.c
@@ -20,8 +20,10 @@
 /* Eventually we will make Allegro use the Unicode (UTF-16) Windows API
  * globally but not yet.
  */
+#ifndef UNICODE
 #define UNICODE
 #define _UNICODE
+#endif
 
 #include "allegro5/allegro.h"
 #include "allegro5/internal/aintern.h"
@@ -216,7 +218,7 @@ static WRAP_CHAR *make_absolute_path(const char *tail)
 {
    WRAP_CHAR *abs_path = NULL;
 #ifdef ALLEGRO_WINDOWS
-   wchar_t *wtail = _al_win_utf16(tail);
+   wchar_t *wtail = _al_win_utf8_to_utf16(tail);
    if (wtail) {
       abs_path = make_absolute_path_inner(wtail);
       al_free(wtail);
@@ -250,7 +252,7 @@ static ALLEGRO_FS_ENTRY *create_abs_path_entry(const WRAP_CHAR *abs_path)
    memcpy(fh->abs_path, abs_path, len * sizeof(WRAP_CHAR));
 
 #ifdef ALLEGRO_WINDOWS
-   fh->abs_path_utf8 = _al_win_utf8(fh->abs_path);
+   fh->abs_path_utf8 = _al_win_utf16_to_utf8(fh->abs_path);
    if (!fh->abs_path_utf8) {
       al_free(fh->abs_path);
       al_free(fh);
@@ -530,7 +532,7 @@ static char *fs_stdio_get_current_directory(void)
       al_set_errno(errno);
       return NULL;
    }
-   cwd = _al_win_utf8(wcwd);
+   cwd = _al_win_utf16_to_utf8(wcwd);
    free(wcwd);
    return cwd;
 #else
@@ -557,7 +559,7 @@ static bool fs_stdio_change_directory(const char *path)
    int ret = -1;
 
 #ifdef ALLEGRO_WINDOWS
-   wchar_t *wpath = _al_win_utf16(path);
+   wchar_t *wpath = _al_win_utf8_to_utf16(path);
    if (wpath) {
       ret = _wchdir(wpath);
       al_free(wpath);

--- a/src/win/d3d_disp.cpp
+++ b/src/win/d3d_disp.cpp
@@ -14,8 +14,6 @@
  *
  */
 
-#define UNICODE
-
 #include <windows.h>
 
 #include <string.h>

--- a/src/win/wclipboard.c
+++ b/src/win/wclipboard.c
@@ -21,8 +21,6 @@
 #define WINVER 0x0501
 #endif
 
-#define UNICODE
-
 #include <windows.h>
 #include <windowsx.h>
 

--- a/src/win/wclipboard.c
+++ b/src/win/wclipboard.c
@@ -71,7 +71,7 @@ static bool win_set_clipboard_text(ALLEGRO_DISPLAY *display, const char *text)
    }
 
    /* Convert the text from UTF-8 to Windows Unicode */
-   tstr = _al_win_utf16(text);
+   tstr = _al_win_utf8_to_utf16(text);
    len  = wcslen(tstr);
    size = (len+1) * sizeof(wchar_t);
    /* Save the data to the clipboard */
@@ -113,7 +113,7 @@ static char *win_get_clipboard_text(ALLEGRO_DISPLAY *display)
       hMem = GetClipboardData(TEXT_FORMAT);
       if (hMem) {
          tstr = (LPTSTR)GlobalLock(hMem);
-         text = _al_win_utf8(tstr);
+         text = _twin_tchar_to_utf8(tstr);
          GlobalUnlock(hMem);
       } else {
          ALLEGRO_DEBUG("Couldn't get clipboard data");

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -99,7 +99,7 @@ static HGLRC init_temp_context(HWND wnd)
    memset(&pfd, 0, sizeof(pfd));
    pfd.nSize = sizeof(pfd);
    pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL
-	           | PFD_DOUBLEBUFFER_DONTCARE | PFD_STEREO_DONTCARE;
+              | PFD_DOUBLEBUFFER_DONTCARE | PFD_STEREO_DONTCARE;
    pfd.iPixelType = PFD_TYPE_RGBA;
    pfd.iLayerType = PFD_MAIN_PLANE;
    pfd.cColorBits = 32;
@@ -107,27 +107,27 @@ static HGLRC init_temp_context(HWND wnd)
    pf = ChoosePixelFormat(dc, &pfd);
    if (!pf) {
       ALLEGRO_ERROR("Unable to chose a temporary pixel format. %s\n",
-		  _al_win_last_error());
+        _al_win_last_error());
       return NULL;
    }
 
    memset(&pfd, 0, sizeof(pfd));
    if (!SetPixelFormat(dc, pf, &pfd)) {
       ALLEGRO_ERROR("Unable to set a temporary pixel format. %s\n",
-		  _al_win_last_error());
+        _al_win_last_error());
       return NULL;
    }
 
    glrc = wglCreateContext(dc);
    if (!glrc) {
       ALLEGRO_ERROR("Unable to create a render context. %s\n",
-		  _al_win_last_error());
+        _al_win_last_error());
       return NULL;
    }
 
    if (!wglMakeCurrent(dc, glrc)) {
       ALLEGRO_ERROR("Unable to set the render context as current. %s\n",
-		  _al_win_last_error());
+        _al_win_last_error());
       wglDeleteContext(glrc);
       return NULL;
    }

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -23,8 +23,6 @@
 #endif
 #endif
 
-#define UNICODE
-
 #include <windows.h>
 
 #include "allegro5/allegro.h"
@@ -36,6 +34,7 @@
 #include "allegro5/internal/aintern_vector.h"
 #include "allegro5/internal/aintern_wclipboard.h"
 #include "allegro5/platform/aintwin.h"
+#include "allegro5/internal/aintern_wunicode.h"
 
 #include "wgl.h"
 
@@ -208,7 +207,7 @@ static int get_pixel_formats_count_ext(HDC dc)
 
 static void display_pixel_format(ALLEGRO_EXTRA_DISPLAY_SETTINGS *eds)
 {
-   ALLEGRO_INFO("Accelarated: %s\n", eds->settings[ALLEGRO_RENDER_METHOD] ? "yes" : "no");
+   ALLEGRO_INFO("Accelerated: %s\n", eds->settings[ALLEGRO_RENDER_METHOD] ? "yes" : "no");
    ALLEGRO_INFO("Single-buffer: %s\n", eds->settings[ALLEGRO_SINGLE_BUFFER] ? "yes" : "no");
    if (eds->settings[ALLEGRO_SWAP_METHOD] > 0)
       ALLEGRO_INFO("Swap method: %s\n", eds->settings[ALLEGRO_SWAP_METHOD] == 2 ? "flip" : "copy");

--- a/src/win/wjoydxnu.cpp
+++ b/src/win/wjoydxnu.cpp
@@ -575,7 +575,8 @@ static void fill_joystick_info_using_caps_and_names(ALLEGRO_JOYSTICK_DIRECTX *jo
 
 #define N_STICK         (info->num_sticks)
 #define N_AXIS          (info->stick[N_STICK].num_axes)
-#define ADD_STRING(A, dfl)        (add_string(joy->all_names, (A), &pos, \
+#define ADD_STRING(A, dfl) \
+                        (add_string(joy->all_names, (A), &pos, \
                            sizeof(joy->all_names), (dfl)))
 
    /* the X, Y, Z axes make up the first stick */
@@ -699,7 +700,6 @@ static void fill_joystick_info_using_caps_and_names(ALLEGRO_JOYSTICK_DIRECTX *jo
 
 #undef N_AXIS
 #undef N_STICK
-#undef ADD_STRING
 #undef ADD_STRING
 }
 

--- a/src/win/wsystem.c
+++ b/src/win/wsystem.c
@@ -26,6 +26,7 @@
 #include "allegro5/internal/aintern_bitmap.h"
 #include "allegro5/internal/aintern_system.h"
 #include "allegro5/platform/aintwin.h"
+#include "allegro5/internal/aintern_wunicode.h"
 
 #if defined ALLEGRO_CFG_OPENGL
    #include "allegro5/allegro_opengl.h"
@@ -921,4 +922,26 @@ void _al_register_system_interfaces()
    *add = _al_system_win_driver();
 }
 
+const char* _al_win_error(DWORD err) {
+	LPTSTR msg = NULL;
+	int len;
+	static char buf[2048];
+
+	len = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER, NULL, err, 0, (LPTSTR)&msg, 0, NULL);
+	if (len == 0) {
+		_al_sane_strncpy(buf, "(Unable to decode the error code)", sizeof(buf));
+	}
+	else {
+		/* Truncate trailing CRLF if it has one */
+		if (len >= 2 && _tcscmp(msg + len - 2, TEXT("\r\n")) == 0) {
+			msg[len - 2] = (TCHAR)0;
+		}
+		_twin_copy_tchar_to_utf8(buf, msg, sizeof(buf));
+		LocalFree(msg);
+	}
+	return buf;
+}
+const char* _al_win_last_error() {
+	return _al_win_error(GetLastError());
+}
 /* vim: set sts=3 sw=3 et: */

--- a/src/win/wthread.c
+++ b/src/win/wthread.c
@@ -52,7 +52,7 @@ void _al_win_thread_init(void)
    if (first_call) {
       first_call = 0;
 
-      ole32 = GetModuleHandle("OLE32.DLL");
+      ole32 = GetModuleHandle(TEXT("OLE32.DLL"));
       if (ole32 != NULL) {
 	 _CoInitializeEx = (_CoInitializeEx_ptr) GetProcAddress(
 						ole32, "CoInitializeEx");

--- a/src/win/wtouch_input.c
+++ b/src/win/wtouch_input.c
@@ -185,34 +185,6 @@ static void generate_touch_input_event(int type, double timestamp, int id, float
    }
 }
 
-
-static char* get_error_desc(DWORD err)
-{
-   #define MSGLEN 2048
-   static char err_msg[MSGLEN];
-   memset(err_msg, 0, MSGLEN);
-
-   /* Get the formatting error string from Windows. Note that only the
-    * bottom 14 bits matter - the rest are reserved for various library
-    * IDs and type of error.
-    */
-   if (!FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM
-                    | FORMAT_MESSAGE_IGNORE_INSERTS,
-                      NULL, err & 0x3FFF,
-                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-                     (LPTSTR) &err_msg, MSGLEN, NULL)) {
-      strcpy(err_msg, "(Unable to decode the error code)");
-   }
-   else {
-      /* Remove two trailing characters */
-      if (strlen(err_msg) > 1)
-         *(err_msg + strlen(err_msg) - 2) = '\0';
-   }
-
-   return err_msg;
-}
-
-
 static bool init_touch_input(void)
 {
    unsigned i;
@@ -240,7 +212,7 @@ static bool init_touch_input(void)
       r = _al_win_register_touch_window(win_display->window, 0);
 	  ALLEGRO_INFO("registering touch window %p: %d\n", win_display, r);
 	  if (!r) {
-		 ALLEGRO_ERROR("RegisterTouchWindow failed: %s\n", get_error_desc(GetLastError()));
+		 ALLEGRO_ERROR("RegisterTouchWindow failed: %s\n", _al_win_last_error());
 	     return false;
 	  }
    }

--- a/src/win/wunicode.c
+++ b/src/win/wunicode.c
@@ -13,7 +13,6 @@
  *      See LICENSE.txt for copyright information.
  */
 
-
 #include "allegro5/allegro.h"
 #include "allegro5/internal/aintern_wunicode.h"
 
@@ -21,8 +20,10 @@
 
 ALLEGRO_DEBUG_CHANNEL("wunicode")
 
-
-wchar_t *_al_win_utf16(const char *s)
+/* _al_win_utf8_to_utf16:
+ * Convert UTF-8 to newly-allocated UTF-16 buffer
+ */
+wchar_t *_al_win_utf8_to_utf16(const char *s)
 {
    int wslen;
    wchar_t *ws;
@@ -45,12 +46,17 @@ wchar_t *_al_win_utf16(const char *s)
    return ws;
 }
 
-
-char *_al_win_utf8(const wchar_t *ws)
+/* _al_win_utf16_to_utf8:
+ * Convert UTF-16 to newly-allocated UTF-8 buffer
+ */
+char *_al_win_utf16_to_utf8(const wchar_t *ws)
 {
    int slen;
    char *s;
 
+   if (ws == NULL) {
+      return NULL;
+   }
    slen = WideCharToMultiByte(CP_UTF8, 0, ws, -1, NULL, 0, NULL, NULL);
    if (slen == 0) {
        ALLEGRO_ERROR("WideCharToMultiByte failed\n");
@@ -68,6 +74,166 @@ char *_al_win_utf8(const wchar_t *ws)
    }
    return s;
 }
+/* _al_win_utf8_to_ansi:
+ * Convert UTF-8 to newly-allocated ansi buffer
+ */
+char* _al_win_utf8_to_ansi(const char *u) {
+   int wslen;
+   wchar_t *ws;
+   int slen;
+   char *s;
+
+   if (u == NULL) {
+      return NULL;
+   }
+   wslen = MultiByteToWideChar(CP_UTF8, 0, u, -1, NULL, 0);
+   if (wslen == 0) {
+       ALLEGRO_ERROR("MultiByteToWideChar failed\n");
+       return NULL;
+   }
+   ws = al_malloc(sizeof(wchar_t) * wslen);
+   if (!ws) {
+       ALLEGRO_ERROR("Out of memory\n");
+       return NULL;
+   }
+   if (0 == MultiByteToWideChar(CP_UTF8, 0, u, -1, ws, wslen)) {
+       al_free(ws);
+       ALLEGRO_ERROR("MultiByteToWideChar failed\n");
+       return NULL;
+   }
+   slen = WideCharToMultiByte(CP_ACP, 0, ws, -1, NULL, 0, NULL, NULL);
+   if (slen == 0) {
+       ALLEGRO_ERROR("WideCharToMultiByte failed\n");
+       al_free(ws);
+       return NULL;
+   }
+   s = al_malloc(sizeof(char) * slen);
+   if (!s) {
+       ALLEGRO_ERROR("Out of memory\n");
+       al_free(ws);
+       return NULL;
+   }
+   if (0 == WideCharToMultiByte(CP_ACP, 0, ws, -1, s, slen, NULL, NULL)) {
+       al_free(ws);
+       al_free(s);
+       ALLEGRO_ERROR("WideCharToMultiByte failed\n");
+       return NULL;
+   }
+   al_free(ws);
+   return s;
+}
+
+/* _al_win_ansi_to_utf8:
+ * Convert UTF-8 to newly-allocated ansi buffer
+ */
+char* _al_win_ansi_to_utf8(const char *u) {
+   int wslen;
+   wchar_t *ws;
+   int slen;
+   char *s;
+
+   if (u == NULL) {
+      return NULL;
+   }
+   wslen = MultiByteToWideChar(CP_ACP, 0, u, -1, NULL, 0);
+   if (wslen == 0) {
+      ALLEGRO_ERROR("MultiByteToWideChar failed\n");
+      return NULL;
+   }
+   ws = al_malloc(sizeof(wchar_t) * wslen);
+   if (!ws) {
+      ALLEGRO_ERROR("Out of memory\n");
+      return NULL;
+   }
+   if (0 == MultiByteToWideChar(CP_ACP, 0, u, -1, ws, wslen)) {
+      al_free(ws);
+      ALLEGRO_ERROR("MultiByteToWideChar failed\n");
+      return NULL;
+   }
+   slen = WideCharToMultiByte(CP_UTF8, 0, ws, -1, NULL, 0, NULL, NULL);
+   if (slen == 0) {
+      ALLEGRO_ERROR("WideCharToMultiByte failed\n");
+      al_free(ws);
+      return NULL;
+   }
+   s = al_malloc(sizeof(char) * slen);
+   if (!s) {
+      ALLEGRO_ERROR("Out of memory\n");
+      al_free(ws);
+      return NULL;
+   }
+   if (0 == WideCharToMultiByte(CP_UTF8, 0, ws, -1, s, slen, NULL, NULL)) {
+      al_free(ws);
+      al_free(s);
+      ALLEGRO_ERROR("WideCharToMultiByte failed\n");
+      return NULL;
+   }
+   al_free(ws);
+   return s;
+}
+
+/* _al_win_copy_utf16_to_utf8: Copy string and convert to UTF-8.
+ * This takes a string and copies a UTF-8 version of it to
+ * a buffer of fixed size.
+ * If successful, the string will be zero-terminated and is 
+ * the return value of the function.
+ * If unsuccesful, NULL will be returned.
+ * If the representation would overflow the buffer, nothing
+ * is copied and the return value is NULL.
+ */ 
+char *_al_win_copy_utf16_to_utf8(char* u, const wchar_t *ws, size_t size)
+{
+   int rc = WideCharToMultiByte(CP_UTF8, 0, ws, -1, u, (int) size, NULL, NULL);
+   if (rc == 0) {
+       ALLEGRO_ERROR("WideCharToMultiByte failed\n");
+       return NULL;
+   }
+   return u;
+}
+char *_al_win_copy_utf8_to_ansi(char* s, const char *u, size_t size)
+{
+   int slen = MultiByteToWideChar(CP_UTF8, 0, u, -1, NULL, 0);
+    if (slen == 0) {
+       ALLEGRO_ERROR("MultiByteToWideChar failed\n");
+       return NULL;
+    }
+    wchar_t* ws = al_malloc(slen * sizeof(wchar_t));
+    if (!ws) {
+       ALLEGRO_ERROR("Out of memory\n");
+       return NULL;
+    }
+    MultiByteToWideChar(CP_UTF8, 0, u, -1, ws, slen);
+    int rc = WideCharToMultiByte(CP_ACP, 0, ws, slen, s, (int) size, NULL, NULL);
+    al_free(ws);
+    if (rc == 0) {
+       ALLEGRO_ERROR("WideCharToMultiByte failed\n");
+       return NULL;
+    }
+    return s;
+}
+
+char *_al_win_copy_ansi_to_utf8(char* u, const char *s, size_t size)
+{
+    int slen = MultiByteToWideChar(CP_ACP, 0, s, -1, NULL, 0);
+    if (slen == 0) {
+       ALLEGRO_ERROR("MultiByteToWideChar failed\n");
+       return NULL;
+    }
+    wchar_t* ws = al_malloc(slen * sizeof(wchar_t));
+    if (!ws) {
+       ALLEGRO_ERROR("Out of memory\n");
+       return NULL;
+    }
+    MultiByteToWideChar(CP_ACP, 0, s, -1, ws, slen);
+    int rc = WideCharToMultiByte(CP_UTF8, 0, ws, slen, u, (int) size, NULL, NULL);
+    al_free(ws);
+    if (rc == 0) {
+       ALLEGRO_ERROR("WideCharToMultiByte failed\n");
+       return NULL;
+    }
+    return u;
+}
+
 
 
 /* vim: set sts=3 sw=3 et: */

--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -1300,9 +1300,9 @@ bool _al_win_set_display_flag(ALLEGRO_DISPLAY *display, int flag, bool onoff)
 void _al_win_set_window_title(ALLEGRO_DISPLAY *display, const char *title)
 {
    ALLEGRO_DISPLAY_WIN *win_display = (ALLEGRO_DISPLAY_WIN *)display;
-   wchar_t *utf16 = _al_win_utf16(title);
-   SetWindowText(win_display->window, utf16);
-   al_free(utf16);
+   TCHAR *ttitle = _twin_utf8_to_tchar(title);
+   SetWindowText(win_display->window, ttitle);
+   al_free(ttitle);
 }
 
 bool _al_win_set_window_constraints(ALLEGRO_DISPLAY *display,

--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -20,8 +20,6 @@
 #define WINVER 0x0501
 #endif
 
-#define UNICODE
-
 #include <windows.h>
 #include <windowsx.h>
 
@@ -97,7 +95,7 @@ static void clear_window(HWND window, int w, int h)
 HWND _al_win_create_hidden_window()
 {
    HWND window = CreateWindowEx(0,
-      L"ALEX", L"hidden", WS_POPUP,
+      TEXT("ALEX"), TEXT("hidden"), WS_POPUP,
       -5000, -5000, 0, 0,
       NULL,NULL,window_class.hInstance,0);
    return window;
@@ -155,7 +153,7 @@ HWND _al_win_create_window(ALLEGRO_DISPLAY *display, int width, int height, int 
    ALLEGRO_DISPLAY_WIN *win_display = (ALLEGRO_DISPLAY_WIN *)display;
    WINDOWINFO wi;
    int lsize, rsize, tsize, bsize; // left, right, top, bottom border sizes
-   wchar_t* window_title;
+   TCHAR* window_title;
 
    wi.cbSize = sizeof(WINDOWINFO);
 
@@ -174,9 +172,9 @@ HWND _al_win_create_window(ALLEGRO_DISPLAY *display, int width, int height, int 
       _al_win_get_window_center(win_display, width, height, &pos_x, &pos_y);
    }
 
-   window_title = _al_win_utf16(al_get_new_window_title());
+   window_title = _twin_utf8_to_tchar(al_get_new_window_title());
    my_window = CreateWindowEx(ex_style,
-      L"ALEX", window_title, style,
+      TEXT("ALEX"), window_title, style,
       pos_x, pos_y, width, height,
       NULL,NULL,window_class.hInstance,0);
    al_free(window_title);
@@ -232,7 +230,7 @@ HWND _al_win_create_faux_fullscreen_window(LPCTSTR devname, ALLEGRO_DISPLAY *dis
    DWORD ex_style;
    DEVMODE mode;
    LONG temp;
-   wchar_t* window_title;
+   TCHAR* window_title;
 
    ALLEGRO_DISPLAY_WIN *win_display = (ALLEGRO_DISPLAY_WIN *)display;
    (void)flags;
@@ -242,9 +240,9 @@ HWND _al_win_create_faux_fullscreen_window(LPCTSTR devname, ALLEGRO_DISPLAY *dis
    style = WS_VISIBLE;
    ex_style = WS_EX_TOPMOST;
 
-   window_title = _al_win_utf16(al_get_new_window_title());
+   window_title = _twin_utf8_to_tchar(al_get_new_window_title());
    my_window = CreateWindowEx(ex_style,
-      L"ALEX", window_title, style,
+      TEXT("ALEX"), window_title, style,
       x1, y1, width, height,
       NULL,NULL,window_class.hInstance,0);
    al_free(window_title);
@@ -999,15 +997,15 @@ int _al_win_init_window()
    window_class.hIcon = NULL;
    window_class.hInstance = GetModuleHandle(NULL);
    window_class.lpfnWndProc = window_callback;
-   window_class.lpszClassName = L"ALEX";
+   window_class.lpszClassName = TEXT("ALEX");
    window_class.lpszMenuName = NULL;
    window_class.style = CS_VREDRAW|CS_HREDRAW|CS_OWNDC;
 
    RegisterClass(&window_class);
 
    if (_al_win_msg_call_proc == 0 && _al_win_msg_suicide == 0) {
-      _al_win_msg_call_proc = RegisterWindowMessage(L"Allegro call proc");
-      _al_win_msg_suicide = RegisterWindowMessage(L"Allegro window suicide");
+      _al_win_msg_call_proc = RegisterWindowMessage(TEXT("Allegro call proc"));
+      _al_win_msg_suicide = RegisterWindowMessage(TEXT("Allegro window suicide"));
    }
 
    return true;


### PR DESCRIPTION
This is quite an extensive change to the Windows code only. It allows Allegro to be compiled in wide-char (i.e. UTF-16) mode by defining UNICODE and _UNICODE in the config, or in Ansi mode if they are not defined. This affects mostly the Joystick and Native Dialog code.
In several places there was an implicit assumption that Ansi strings could be freely interchanged with `char*` in Allegro. This is not the case because Allegro assumes a `char*` to be UTF-8 (or the 7-bit ASCII subset) and Ansi strings can contain characters in the range 0x80-0xFF which are decoded according to the system code page.
This lead to https://www.allegro.cc/forums/thread/617652 and https://www.allegro.cc/forums/thread/617697
There is also code in fshooks which uses  the wide-char functions exclusively and this has not been changed.
Co-incidentally it fixes a bug in the native 'text log' where line breaks did not show up (LF -> CRLF conversion)

Fixes #397 