### PR TITLE
Fix for OpenGL version selection on Windows

### DIFF
--- a/src/opengl/extensions.c
+++ b/src/opengl/extensions.c
@@ -724,11 +724,14 @@ void _al_ogl_manage_extensions(ALLEGRO_DISPLAY *gl_disp)
    ALLEGRO_OGL_EXT_API *ext_api;
    ALLEGRO_OGL_EXT_LIST *ext_list;
 
+   /* Some functions depend on knowing the version of opengl in use */
+   fill_in_info_struct(glGetString(GL_RENDERER), &(gl_disp->ogl_extras->ogl_info));
+
    /* Print out OpenGL extensions
     * We should use glGetStringi(GL_EXTENSIONS, i) for OpenGL 3.0+
     * but it doesn't seem to work until later.
     */
-   if (!_al_ogl_version_3_only(gl_disp->flags)) {
+   if (gl_disp->ogl_extras->ogl_info.version < _ALLEGRO_OPENGL_VERSION_3_0) {
       ALLEGRO_DEBUG("OpenGL Extensions:\n");
       print_extensions((char const *)glGetString(GL_EXTENSIONS));
    }
@@ -787,8 +790,6 @@ void _al_ogl_manage_extensions(ALLEGRO_DISPLAY *gl_disp)
    print_extensions(ext);
 #endif
 
-   fill_in_info_struct(glGetString(GL_RENDERER), &(gl_disp->ogl_extras->ogl_info));
-
    /* Create & load extension API table */
    ext_api = create_extension_api_table();
    load_extensions(ext_api);
@@ -798,7 +799,7 @@ void _al_ogl_manage_extensions(ALLEGRO_DISPLAY *gl_disp)
    /* Need that symbol already so can't wait until it is assigned later. */
    glGetStringi = ext_api->GetStringi;
 
-   if (_al_ogl_version_3_only(gl_disp->flags)) {
+   if (gl_disp->ogl_extras->ogl_info.version >= _ALLEGRO_OPENGL_VERSION_3_0) {
       ALLEGRO_DEBUG("OpenGL Extensions:\n");
       print_extensions_3_0();
    }

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -1002,6 +1002,13 @@ static bool create_display_internals(ALLEGRO_DISPLAY_WGL *wgl_disp)
       disp->extra_settings.settings[ALLEGRO_COMPATIBLE_DISPLAY] = 0;
    }
 
+   /* Fill in the display settings for opengl major and minor versions...*/
+   int* s = disp->extra_settings.settings;
+   s[ALLEGRO_OPENGL_MAJOR_VERSION] = 
+      (disp->ogl_extras->ogl_info.version >> 24) & 0xFF;
+   s[ALLEGRO_OPENGL_MINOR_VERSION] = 
+      (disp->ogl_extras->ogl_info.version >> 16) & 0xFF;   
+
    /* Try to enable or disable vsync as requested */
    /* NOTE: my drivers claim I don't have WGL_EXT_swap_control
     * (according to al_have_opengl_extension), but wglSwapIntervalEXT

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -959,10 +959,8 @@ static bool create_display_internals(ALLEGRO_DISPLAY_WGL *wgl_disp)
       return false;
    }
 
-   major = _al_get_suggested_display_option(disp,
-      ALLEGRO_OPENGL_MAJOR_VERSION, 0);
-   minor = _al_get_suggested_display_option(disp,
-      ALLEGRO_OPENGL_MINOR_VERSION, 0);
+   major = al_get_new_display_option(ALLEGRO_OPENGL_MAJOR_VERSION , 0);
+   minor = al_get_new_display_option(ALLEGRO_OPENGL_MINOR_VERSION , 0);
 
    // TODO: request GLES context in GLES builds
    if ((disp->flags & ALLEGRO_OPENGL_3_0) || major != 0) {


### PR DESCRIPTION
This patch does a few things : 

1) Respect ALLEGRO_OPENGL_MAJOR and MINOR_VERSION on Windows
2) Fix for extension reporting based on inaccurate flag
3) Store the opengl version in the display options for retrieval by the user