### PR TITLE
Report OpenGL version in display options on Android, iOS and Raspberry Pi

### DIFF
--- a/src/android/android_display.c
+++ b/src/android/android_display.c
@@ -568,6 +568,11 @@ static ALLEGRO_DISPLAY *android_create_display(int w, int h)
    android_set_display_option(display, ALLEGRO_SUPPORTED_ORIENTATIONS,
       al_get_new_display_option(ALLEGRO_SUPPORTED_ORIENTATIONS, NULL));
 
+   /* Fill in opengl version */
+   const int v = d->display.ogl_extras->ogl_info.version;
+   d->display.extra_settings.settings[ALLEGRO_OPENGL_MAJOR_VERSION] = (v >> 24) & 0xFF;
+   d->display.extra_settings.settings[ALLEGRO_OPENGL_MINOR_VERSION] = (v >> 16) & 0xFF;
+
    ALLEGRO_DEBUG("end");
    return display;
 }

--- a/src/iphone/iphone_display.m
+++ b/src/iphone/iphone_display.m
@@ -218,6 +218,11 @@ static ALLEGRO_DISPLAY *iphone_create_display(int w, int h)
    int ndisplays = system->system.displays._size;
    [[UIApplication sharedApplication] setIdleTimerDisabled:(ndisplays > 1)];
 
+   /* Fill in opengl version */
+   const int v = display->ogl_extras->ogl_info.version;
+   display->extra_settings.settings[ALLEGRO_OPENGL_MAJOR_VERSION] = (v >> 24) & 0xFF;
+   display->extra_settings.settings[ALLEGRO_OPENGL_MINOR_VERSION] = (v >> 16) & 0xFF;
+
    return display;
 }
 

--- a/src/raspberrypi/pidisplay.c
+++ b/src/raspberrypi/pidisplay.c
@@ -483,6 +483,11 @@ static ALLEGRO_DISPLAY *raspberrypi_create_display(int w, int h)
 
    set_cursor_data(d, default_cursor, DEFAULT_CURSOR_WIDTH, DEFAULT_CURSOR_HEIGHT);
 
+   /* Fill in opengl version */
+   const int v = display->ogl_extras->ogl_info.version;
+   display->extra_settings.settings[ALLEGRO_OPENGL_MAJOR_VERSION] = (v >> 24) & 0xFF;
+   display->extra_settings.settings[ALLEGRO_OPENGL_MINOR_VERSION] = (v >> 16) & 0xFF;
+
    return display;
 }
 


### PR DESCRIPTION
The only ones left now are macosx (I got lost in all its various context initializations) and gp2xwiz, with this lovely piece of code inside:
```
   // FIXME
   // We don't have this extra_settings stuff set up right
   //if (display->extra_settings.settings[ALLEGRO_COMPATIBLE_DISPLAY])
      setup_gl(display);
```
:D 