### PR TITLE
Add a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 3
+
+[CMakeLists.txt]
+indent_size = 4
+
+[*.cmake]
+indent_size = 4


### PR DESCRIPTION
Lots of editors and IDEs support the EditorConfig format, so adding it to the repository allows automatic format configuration regardless of used editor.