### PR TITLE
Enable debug window for DEBUGMODE on Windows (XP and Higher).

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -180,7 +180,7 @@ static void open_trace_file(void)
          // stderr will be redirected to xcode's debug console though, so
          // it's as good to use as the NSLog stuff.
          trace_info.trace_file = stderr;
-#elif defined(ALLEGRO_WINDOWS)
+#elif defined(ALLEGRO_ANDROID)
          trace_info.trace_file = NULL;
 #else
          trace_info.trace_file = fopen("allegro.log", "w");
@@ -207,7 +207,7 @@ static void do_trace(const char *msg, ...)
          msg, ap);
       va_end(ap);
    }
-   else if (trace_info.trace_file) {
+   if (!_al_user_trace_handler && trace_info.trace_file) {
       va_start(ap, msg);
       vfprintf(trace_info.trace_file, msg, ap);
       va_end(ap);
@@ -333,7 +333,7 @@ void _al_trace_suffix(const char *msg, ...)
       #endif
       static_trace_buffer[0] = '\0';
    }
-   else if (trace_info.trace_file) {
+   if (!_al_user_trace_handler && trace_info.trace_file) {
       va_start(ap, msg);
       vfprintf(trace_info.trace_file, msg, ap);
       va_end(ap);

--- a/src/debug.c
+++ b/src/debug.c
@@ -174,12 +174,14 @@ static void open_trace_file(void)
       if (s)
          trace_info.trace_file = fopen(s, "w");
       else
-#ifdef ALLEGRO_IPHONE
+#if defined(ALLEGRO_IPHONE)
          // Remember, we have no (accessible) filesystem on (not jailbroken)
          // iphone.
          // stderr will be redirected to xcode's debug console though, so
          // it's as good to use as the NSLog stuff.
          trace_info.trace_file = stderr;
+#elif defined(ALLEGRO_WINDOWS)
+         trace_info.trace_file = NULL;
 #else
          trace_info.trace_file = fopen("allegro.log", "w");
 #endif
@@ -193,7 +195,7 @@ static void do_trace(const char *msg, ...)
 {
    va_list ap;
 
-#ifdef ALLEGRO_ANDROID
+#if defined(ALLEGRO_ANDROID) || defined(ALLEGRO_WINDOWS)
    if (true)
 #else
    if (_al_user_trace_handler)
@@ -305,7 +307,7 @@ void _al_trace_suffix(const char *msg, ...)
    int olderr = errno;
    va_list ap;
 
-#ifdef ALLEGRO_ANDROID
+#if defined(ALLEGRO_ANDROID) || defined(ALLEGRO_WINDOWS)
    if (true)
 #else
    if (_al_user_trace_handler)
@@ -325,6 +327,9 @@ void _al_trace_suffix(const char *msg, ...)
          (void)__android_log_print(ANDROID_LOG_INFO, "allegro", "%s",
             static_trace_buffer);
       }
+      #endif
+      #ifdef ALLEGRO_WINDOWS
+         (void) OutputDebugString((LPCTSTR) static_trace_buffer);
       #endif
       static_trace_buffer[0] = '\0';
    }


### PR DESCRIPTION
This patch enables easier debugging. It is easpecially useful for -mwindows / -SUBSYSTEM:windows applications.

We do not need to resort to allegro.log in Windows, so this patch does exactly that.

![DebugWindow](https://user-images.githubusercontent.com/195178/55674918-d7675b80-586f-11e9-8326-e5c02c4dc6d8.PNG)

