### PR TITLE
Fix Unicode/Non-Unicode path appearing on Output Console.

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -21,6 +21,10 @@
 #include "allegro5/internal/aintern_thread.h"
 #include "allegro5/internal/aintern_vector.h"
 
+#ifdef ALLEGRO_WINDOWS
+#include "allegro5/internal/aintern_wunicode.h"
+#endif
+
 #ifdef ALLEGRO_ANDROID
 #include <unistd.h>
 #include <android/log.h>
@@ -329,7 +333,9 @@ void _al_trace_suffix(const char *msg, ...)
       }
       #endif
       #ifdef ALLEGRO_WINDOWS
-         (void) OutputDebugString((LPCTSTR) static_trace_buffer);
+         TCHAR *windows_output = _twin_utf8_to_tchar(static_trace_buffer);
+         OutputDebugString(windows_output);
+         al_free(windows_output);
       #endif
       static_trace_buffer[0] = '\0';
    }


### PR DESCRIPTION
When debugging with Windows today, I noticed that sometimes the Output messages are unreadable, at least for me :(

![Old](https://user-images.githubusercontent.com/195178/57012074-853d0000-6bb9-11e9-804e-bca2529ee878.PNG)

I didn't understand why Windows messes this up, but long story short, I decided to make it output through the Non-UNICODE version of a function.

![New-Fixed](https://user-images.githubusercontent.com/195178/57012073-853d0000-6bb9-11e9-98e7-773a480b8fba.PNG)