### PR TITLE
Fix implicit fallthrough compiler warnings

### DIFF
--- a/addons/audio/kcm_mixer.c
+++ b/addons/audio/kcm_mixer.c
@@ -310,15 +310,22 @@ static void NAME(void *source, void **vbuf, unsigned int *samples,            \
       for (c = 0; c < dest_maxc; c++) {                                       \
          ALLEGRO_STATIC_ASSERT(kcm_mixer, ALLEGRO_MAX_CHANNELS == 8);         \
          switch (maxc) {                                                      \
-            /* Each case falls through. */                                    \
             case 8: *buf += s[7] * spl->matrix[c*maxc + 7];                   \
+            /* fall through */                                                \
             case 7: *buf += s[6] * spl->matrix[c*maxc + 6];                   \
+            /* fall through */                                                \
             case 6: *buf += s[5] * spl->matrix[c*maxc + 5];                   \
+            /* fall through */                                                \
             case 5: *buf += s[4] * spl->matrix[c*maxc + 4];                   \
+            /* fall through */                                                \
             case 4: *buf += s[3] * spl->matrix[c*maxc + 3];                   \
+            /* fall through */                                                \
             case 3: *buf += s[2] * spl->matrix[c*maxc + 2];                   \
+            /* fall through */                                                \
             case 2: *buf += s[1] * spl->matrix[c*maxc + 1];                   \
+            /* fall through */                                                \
             case 1: *buf += s[0] * spl->matrix[c*maxc + 0];                   \
+            /* fall through */                                                \
             default: break;                                                   \
          }                                                                    \
          buf++;                                                               \


### PR DESCRIPTION
Compilers scan for comment markers that let you explicitly state that you really want a fall through.