### PR TITLE
Fix reported bitshifts for ARGB_4444 and RGBA_4444 pixel formats

### DIFF
--- a/src/display_settings.c
+++ b/src/display_settings.c
@@ -883,14 +883,15 @@ void _al_set_color_components(int format, ALLEGRO_EXTRA_DISPLAY_SETTINGS *eds,
       break;
       case ALLEGRO_PIXEL_FORMAT_ARGB_4444:
          al_set_new_display_option(ALLEGRO_ALPHA_SHIFT, 12, importance);
-         al_set_new_display_option(ALLEGRO_BLUE_SHIFT,  8, importance);
+         al_set_new_display_option(ALLEGRO_BLUE_SHIFT,  0, importance);
          al_set_new_display_option(ALLEGRO_GREEN_SHIFT, 4, importance);
-         al_set_new_display_option(ALLEGRO_RED_SHIFT,   0, importance);      
+         al_set_new_display_option(ALLEGRO_RED_SHIFT,   8, importance);      
+      break;
       case ALLEGRO_PIXEL_FORMAT_RGBA_4444:
-         al_set_new_display_option(ALLEGRO_ALPHA_SHIFT, 12, importance);
-         al_set_new_display_option(ALLEGRO_BLUE_SHIFT,  8, importance);
-         al_set_new_display_option(ALLEGRO_GREEN_SHIFT, 4, importance);
-         al_set_new_display_option(ALLEGRO_RED_SHIFT,   0, importance);      
+         al_set_new_display_option(ALLEGRO_ALPHA_SHIFT, 0, importance);
+         al_set_new_display_option(ALLEGRO_BLUE_SHIFT,  4, importance);
+         al_set_new_display_option(ALLEGRO_GREEN_SHIFT, 8, importance);
+         al_set_new_display_option(ALLEGRO_RED_SHIFT,   12, importance);      
       break;
    }
 


### PR DESCRIPTION
Something went really wrong there (and the compiler was warning about fallthrough, but nobody cared :P )