### PR TITLE
Fix _al_kcm_refill_stream in cases where stream speed caused spl->pos to overshoot.

### DIFF
--- a/addons/audio/kcm_mixer.c
+++ b/addons/audio/kcm_mixer.c
@@ -224,17 +224,16 @@ static bool fix_looped_position(ALLEGRO_SAMPLE_INSTANCE *spl)
 
       case _ALLEGRO_PLAYMODE_STREAM_ONCE:
       case _ALLEGRO_PLAYMODE_STREAM_ONEDIR:
-         if (spl->pos < spl->spl_data.len) {
-            return true;
-         }
          stream = (ALLEGRO_AUDIO_STREAM *)spl;
-         is_empty = !_al_kcm_refill_stream(stream);
-         if (is_empty && stream->is_draining) {
-            stream->spl.is_playing = false;
+         is_empty = false;
+         while (spl->pos >= spl->spl_data.len && stream->spl.is_playing && !is_empty) {
+            is_empty = !_al_kcm_refill_stream(stream);
+            if (is_empty && stream->is_draining) {
+               stream->spl.is_playing = false;
+            }
+
+            _al_kcm_emit_stream_events(stream);
          }
-
-         _al_kcm_emit_stream_events(stream);
-
          return !(is_empty);
    }
 

--- a/addons/audio/kcm_voice.c
+++ b/addons/audio/kcm_voice.c
@@ -213,6 +213,8 @@ static void stream_read(void *source, void **vbuf, unsigned int *samples,
       *samples = len;
 
    if (pos >= len) {
+      /* XXX: Handle the case where we need to call _al_kcm_refill_stream
+       * multiple times due to ludicrous playback speed. */
       _al_kcm_refill_stream(stream);
       if (!stream->pending_bufs[0]) {
          if (stream->is_draining) {


### PR DESCRIPTION
Previously, this would result in us copying some garbage to the
beginning of the new buffer, since the logic was sourcing samples
relative to the overshot spl->pos, rather than the real end of the
buffer.

While I was at it, I fixed a super-rare situation where the speed is so
high that multiple buffers need to be updated. I only fixes it in the
mixer code, not the voice code. The latter is essentially deprecated
anyway, one should always use a mixer before a voice.

Fix #1051.