### PR TITLE
MacOS: make sure all relevant code runs on the main thread.

### DIFF
--- a/src/macosx/hidman.m
+++ b/src/macosx/hidman.m
@@ -364,7 +364,6 @@ HID_DEVICE_COLLECTION *_al_osx_hid_scan(int type, HID_DEVICE_COLLECTION* col)
 	mach_port_t master_port = 0;
 	io_iterator_t hid_object_iterator = 0;
 	io_object_t hid_device = 0;
-	CFMutableDictionaryRef class_dictionary = NULL;
 	int usage, usage_page;
 	CFTypeRef type_ref;
 	CFMutableDictionaryRef properties = NULL, usb_properties = NULL;
@@ -390,7 +389,7 @@ HID_DEVICE_COLLECTION *_al_osx_hid_scan(int type, HID_DEVICE_COLLECTION* col)
 	result = IOMasterPort(bootstrap_port, &master_port);
 	if (result == kIOReturnSuccess) {
 		result = _get_matching_services(master_port, usage_page, usage, &hid_object_iterator);
-		if ((type == HID_MOUSE) && (hid_object_iterator == NULL)) {
+		if ((type == HID_MOUSE) && (hid_object_iterator == IO_OBJECT_NULL)) {
 			/* in case of a mouse, GD_Mouse must not be true but can also be a pointing device */
 			result = _get_matching_services(master_port, usage_page, kHIDUsage_GD_Pointer, &hid_object_iterator);
 		}

--- a/src/macosx/system.m
+++ b/src/macosx/system.m
@@ -435,9 +435,10 @@ static int osx_get_monitor_dpi(int adapter)
 static bool osx_inhibit_screensaver(bool inhibit)
 {
    // Send a message to the App's delegate always on the main thread
-   [[NSApp delegate] performSelectorOnMainThread: @selector(setInhibitScreenSaver:)
-      withObject: [NSNumber numberWithBool:inhibit ? YES : NO]
-      waitUntilDone: NO];
+   NSObject* delegate = [NSApp delegate];
+   [delegate performSelectorOnMainThread: @selector(setInhibitScreenSaver:)
+                              withObject: [NSNumber numberWithBool:inhibit ? YES : NO]
+                           waitUntilDone: NO];
    ALLEGRO_INFO("Stop screensaver\n");
    return true;
 }


### PR DESCRIPTION
Recent versions of MacOS are stricter about always running certain functions on the main thread (particularly, functions to create Cocoa objects.) Xcode includes a method to detect calls made on the 'wrong' thread. This patch fixes all reported instances.
Note that it uses `dispatch_sync`, as recommended by Apple, instead of `performSelectorOnMainThread:withObject:waitUntilDone:` on a helper object. This simplified the code. I kept uses of the latter when it was just calling a single method on a Cocoa object.
There is also a small modification to `ex_native_dialog` to demonstrate the Save dialog as well as the Open dialog.
Closes #876 