### PR TITLE
utf8: fix al_utf8_width argument type mismatch on platforms where sizeof(int) != 4

### DIFF
--- a/src/utf8.c
+++ b/src/utf8.c
@@ -985,7 +985,7 @@ bool al_ustr_has_suffix_cstr(const ALLEGRO_USTR *us1, const char *s2)
 
 /* Function: al_utf8_width
  */
-size_t al_utf8_width(int c)
+size_t al_utf8_width(int32_t c)
 {
    /* So we don't need to check for negative values nor use unsigned ints
     * in the interface, which are a pain.


### PR DESCRIPTION
The function prototype already specified int32_t, it just doesn't produce any warnings, cause usually int == int32_t.