### PR TITLE
Include limits.h for PTHREAD_STACK_MIN

### DIFF
--- a/include/allegro5/platform/aintuthr.h
+++ b/include/allegro5/platform/aintuthr.h
@@ -5,6 +5,7 @@
 #define __al_included_allegro5_aintuthr_h
 
 #include <pthread.h>
+#include <limits.h>
 #include "allegro5/internal/aintern_thread.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
We get a build error on hurd in Debian, see 
https://buildd.debian.org/status/fetch.php?pkg=allegro5&arch=hurd-i386&ver=2%3A5.2.5.0-1&stamp=1566474705&raw=0

for full build log.