### PR TITLE
No PTHREAD_STACK_MIN on Hurd

### DIFF
--- a/include/allegro5/platform/aintuthr.h
+++ b/include/allegro5/platform/aintuthr.h
@@ -5,7 +5,6 @@
 #define __al_included_allegro5_aintuthr_h
 
 #include <pthread.h>
-#include <limits.h>
 #include "allegro5/internal/aintern_thread.h"
 
 #ifdef __cplusplus

--- a/src/unix/uxthread.c
+++ b/src/unix/uxthread.c
@@ -72,7 +72,9 @@ void _al_thread_create(_AL_THREAD *thread, void (*proc)(_AL_THREAD*, void*), voi
 
 void _al_thread_create_with_stacksize(_AL_THREAD* thread, void (*proc)(_AL_THREAD*, void*), void *arg, size_t stacksize) 
 {
+#ifndef __GNU__
    ASSERT(stacksize >= PTHREAD_STACK_MIN);
+#endif
    ASSERT(thread);
    ASSERT(proc);
    {


### PR DESCRIPTION
This patch also removes the #include <limits.h> which didn't
work - The proper fix is to simply not check for PTHREAD_STACK_MIN
on Hurd, since it's not defined, and the real minimum on Hurd
is much smaller than on Linux.

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=823049
for the same fix that was applied on xscreensaver.