### PR TITLE
Fix building for GNU/Linux without GNU extensions enabled

### DIFF
--- a/addons/audio/alsa.c
+++ b/addons/audio/alsa.c
@@ -23,6 +23,7 @@
 #include "allegro5/allegro.h"
 #include "allegro5/internal/aintern_audio.h"
 
+#include <alloca.h>
 #include <alsa/asoundlib.h>
 
 ALLEGRO_DEBUG_CHANNEL("alsa")

--- a/src/linux/lhaptic.c
+++ b/src/linux/lhaptic.c
@@ -16,6 +16,10 @@
  */
 
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <math.h>
 #include <stdio.h>
 #include <sys/time.h>


### PR DESCRIPTION
GCC doesn't define alloca, and timerclear isn't defined when compiling in standards mode that disables GNU extensions.