### PR TITLE
the alpha test commit broke GLES, this fixes it

### DIFF
--- a/include/allegro5/internal/aintern_opengl.h
+++ b/include/allegro5/internal/aintern_opengl.h
@@ -119,6 +119,7 @@ typedef struct ALLEGRO_OGL_VARLOCS
    GLint tex_loc;
    GLint use_tex_matrix_loc;
    GLint tex_matrix_loc;
+   GLint alpha_test_loc;
    GLint alpha_func_loc;
    GLint alpha_test_val_loc;
    GLint user_attr_loc[_ALLEGRO_PRIM_MAX_USER_ATTR];

--- a/include/allegro5/shader.h
+++ b/include/allegro5/shader.h
@@ -42,6 +42,7 @@ typedef enum ALLEGRO_SHADER_PLATFORM ALLEGRO_SHADER_PLATFORM;
 #define ALLEGRO_SHADER_VAR_USER_ATTR         "al_user_attr_"
 #define ALLEGRO_SHADER_VAR_USE_TEX           "al_use_tex"
 #define ALLEGRO_SHADER_VAR_USE_TEX_MATRIX    "al_use_tex_matrix"
+#define ALLEGRO_SHADER_VAR_ALPHA_TEST        "al_alpha_test"
 #define ALLEGRO_SHADER_VAR_ALPHA_FUNCTION    "al_alpha_func"
 #define ALLEGRO_SHADER_VAR_ALPHA_TEST_VALUE  "al_alpha_test_val"
 

--- a/src/display.c
+++ b/src/display.c
@@ -107,10 +107,6 @@ ALLEGRO_DISPLAY *al_create_display(int w, int h)
          return NULL;
       }
       al_use_shader(display->default_shader);
-      // The call to update_render_state above inside of
-      // al_set_target_bitmap will have failed with programmable
-      // pipeline since there was no shader yet. Simply repeat it here.
-      display->vt->update_render_state(display);
    }
 
    /* Clear the screen */

--- a/src/display.c
+++ b/src/display.c
@@ -107,6 +107,10 @@ ALLEGRO_DISPLAY *al_create_display(int w, int h)
          return NULL;
       }
       al_use_shader(display->default_shader);
+      // The call to update_render_state above inside of
+      // al_set_target_bitmap will have failed with programmable
+      // pipeline since there was no shader yet. Simply repeat it here.
+      display->vt->update_render_state(display);
    }
 
    /* Clear the screen */

--- a/src/opengl/ogl_render_state.c
+++ b/src/opengl/ogl_render_state.c
@@ -27,11 +27,13 @@ void _al_ogl_update_render_state(ALLEGRO_DISPLAY *display)
 
    if (display->flags & ALLEGRO_PROGRAMMABLE_PIPELINE) {
 #ifdef ALLEGRO_CFG_SHADER_GLSL
+      GLint atloc = display->ogl_extras->varlocs.alpha_test_loc;
       GLint floc = display->ogl_extras->varlocs.alpha_func_loc;
       GLint tvloc = display->ogl_extras->varlocs.alpha_test_val_loc;
 
       if (display->ogl_extras->program_object > 0 && floc >= 0 && tvloc >= 0) {
-         glUniform1i(floc, r->alpha_test == 0 ? ALLEGRO_RENDER_ALWAYS : r->alpha_function);
+         glUniform1i(atloc, r->alpha_test);
+         glUniform1i(floc, r->alpha_function);
          glUniform1f(tvloc, (float)r->alpha_test_value / 255.0);
       }
 #endif

--- a/src/opengl/ogl_shader.c
+++ b/src/opengl/ogl_shader.c
@@ -230,6 +230,11 @@ static bool glsl_use_shader(ALLEGRO_SHADER *shader, ALLEGRO_DISPLAY *display,
          display->ogl_extras->varlocs.projview_matrix_loc, &display->projview_transform);
    }
 
+   /* Alpha testing may be done in the shader and so when a shader is
+    * set the uniforms need to be synchronized.
+    */
+   _al_ogl_update_render_state(display);
+
    return true;
 }
 

--- a/src/opengl/ogl_shader.c
+++ b/src/opengl/ogl_shader.c
@@ -441,6 +441,7 @@ static void lookup_varlocs(ALLEGRO_OGL_VARLOCS *varlocs, GLuint program)
    varlocs->tex_loc = glGetUniformLocation(program, ALLEGRO_SHADER_VAR_TEX);
    varlocs->use_tex_matrix_loc = glGetUniformLocation(program, ALLEGRO_SHADER_VAR_USE_TEX_MATRIX);
    varlocs->tex_matrix_loc = glGetUniformLocation(program, ALLEGRO_SHADER_VAR_TEX_MATRIX);
+   varlocs->alpha_test_loc = glGetUniformLocation(program, ALLEGRO_SHADER_VAR_ALPHA_TEST);
    varlocs->alpha_func_loc = glGetUniformLocation(program, ALLEGRO_SHADER_VAR_ALPHA_FUNCTION);
    varlocs->alpha_test_val_loc = glGetUniformLocation(program, ALLEGRO_SHADER_VAR_ALPHA_TEST_VALUE);
 

--- a/src/shader_source.inc
+++ b/src/shader_source.inc
@@ -43,6 +43,7 @@ static const char *default_glsl_pixel_source =
    "#endif\n"
    "uniform sampler2D " ALLEGRO_SHADER_VAR_TEX ";\n"
    "uniform bool " ALLEGRO_SHADER_VAR_USE_TEX ";\n"
+   "uniform bool " ALLEGRO_SHADER_VAR_ALPHA_TEST ";\n"
    "uniform int " ALLEGRO_SHADER_VAR_ALPHA_FUNCTION ";\n"
    "uniform float " ALLEGRO_SHADER_VAR_ALPHA_TEST_VALUE ";\n"
    "varying vec4 varying_color;\n"
@@ -57,7 +58,7 @@ static const char *default_glsl_pixel_source =
    "    c = varying_color * texture2D(" ALLEGRO_SHADER_VAR_TEX ", varying_texcoord);\n"
    "  else\n"
    "    c = varying_color;\n"
-   "  if (alpha_test_func(c.a, " ALLEGRO_SHADER_VAR_ALPHA_FUNCTION ", "
+   "  if (!" ALLEGRO_SHADER_VAR_ALPHA_TEST " || alpha_test_func(c.a, " ALLEGRO_SHADER_VAR_ALPHA_FUNCTION ", "
                           ALLEGRO_SHADER_VAR_ALPHA_TEST_VALUE "))\n"
    "    gl_FragColor = c;\n"
    "  else\n"
@@ -67,8 +68,8 @@ static const char *default_glsl_pixel_source =
    "bool alpha_test_func(float x, int op, float compare)\n"
    "{\n"
    // Note: These must be aligned with the ALLEGRO_RENDER_FUNCTION enum values.
-   "  if (op == 1) return true;\n" // ALLEGRO_RENDER_ALWAYS
-   "  else if (op == 0) return false;\n" // ALLEGRO_RENDER_NEVER
+   "  if (op == 0) return false;\n" // ALLEGRO_RENDER_NEVER
+   "  else if (op == 1) return true;\n" // ALLEGRO_RENDER_ALWAYS
    "  else if (op == 2) return x < compare;\n" // ALLEGRO_RENDER_LESS
    "  else if (op == 3) return x == compare;\n" // ALLEGRO_RENDER_EQUAL
    "  else if (op == 4) return x <= compare;\n" // ALLEGRO_RENDER_LESS_EQUAL


### PR DESCRIPTION
There is a bit of a chicken and egg problem - we need to call al_set_target_bitmap first because setting the shader requires the display. But we need to do the setup after setting the shader.