### PR TITLE
Add instructions to install Allegro using vcpkg

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -72,6 +72,16 @@ The addons, too, may require additional libraries.  Since the addons are
 strictly optional, they are not required to build Allegro, but a lot of
 functionality may be disabled if they are not present.
 
+If you're using the vcpkg dependency manager, you may install Allegro and its
+dependencies using a single command:
+
+`vcpkg install allegro5`
+
+Vcpkg will build Allegro and its dependencies from source in your computer and 
+provide CMake integration for your projects.
+
+See <https://github.com/Microsoft/vcpkg> for more information.
+
 Windows users may find some precompiled binaries for the additional libraries
 from <http://gnuwin32.sourceforge.net/>.  You need to get the `bin` and `lib`
 packages.  The `bin` packages contain DLLs, and the `lib` packages contain the


### PR DESCRIPTION
Vcpkg is a C++ library manager that is able to build and install Allegro and its dependencies using a single line command:

`vcpkg install allegro5`

This PR adds instructions on how to acquire Allegro using vcpkg with the purpose of making it easier for users to install and use Allegro.