### PR TITLE
Move the time routines into the system driver.

### DIFF
--- a/include/allegro5/internal/aintern_system.h
+++ b/include/allegro5/internal/aintern_system.h
@@ -48,6 +48,9 @@ struct ALLEGRO_SYSTEM_INTERFACE
    void (*close_library)(void *handle);
    void (*heartbeat)(void);
    void (*heartbeat_init)(void);
+   double (*get_time)(void);
+   void (*rest)(double seconds);
+   void (*init_timeout)(ALLEGRO_TIMEOUT *timeout, double seconds);
 };
 
 struct ALLEGRO_SYSTEM

--- a/include/allegro5/platform/aintunix.h
+++ b/include/allegro5/platform/aintunix.h
@@ -18,6 +18,7 @@
 #ifndef __al_included_allegro5_aintunix_h
 #define __al_included_allegro5_aintunix_h
 
+#include "allegro5/altime.h"
 #include "allegro5/path.h"
 #include "allegro5/internal/aintern_driver.h"
 
@@ -30,7 +31,10 @@
 extern "C" {
 #endif
 
-   AL_FUNC(ALLEGRO_PATH *, _al_unix_get_path, (int id));
+ALLEGRO_PATH *_al_unix_get_path(int id);
+double _al_unix_get_time(void);
+void _al_unix_rest(double seconds);
+void _al_unix_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds);
 
 
 #ifdef __cplusplus
@@ -60,7 +64,7 @@ extern "C" {
 #endif
 
 /* time */
-AL_FUNC(void, _al_unix_init_time, (void));
+void _al_unix_init_time(void);
 
 /* fdwatch */
 void _al_unix_start_watching_fd(int fd, void (*callback)(void *), void *cb_data);

--- a/include/allegro5/platform/aintwin.h
+++ b/include/allegro5/platform/aintwin.h
@@ -289,6 +289,11 @@ void _al_win_touch_input_handle_cancel(int id, size_t timestamp, float x, float 
 AL_FUNC(const char*, _al_win_error, (DWORD));
 AL_FUNC(const char*, _al_win_last_error, (void));
 
+/* Time handling */
+double _al_win_get_time(void);
+void _al_win_rest(double seconds);
+void _al_win_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds);
+
 #ifdef __cplusplus
    }
 #endif

--- a/include/allegro5/platform/allegro_internal_sdl.h
+++ b/include/allegro5/platform/allegro_internal_sdl.h
@@ -1,5 +1,6 @@
 #include "SDL.h"
 
+#include "allegro5/altime.h"
 #include "allegro5/internal/aintern_display.h"
 #include "allegro5/internal/aintern_keyboard.h"
 #include "allegro5/internal/aintern_mouse.h"
@@ -46,3 +47,6 @@ float _al_sdl_get_display_pixel_ratio(ALLEGRO_DISPLAY *display);
 
 void _al_sdl_event_hack(void);
 
+double _al_sdl_get_time(void);
+void _al_sdl_rest(double seconds);
+void _al_sdl_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds);

--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -545,6 +545,9 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_android_interface()
    android_vt->get_path = _al_android_get_path;
    android_vt->shutdown_system = android_shutdown_system;
    android_vt->inhibit_screensaver = android_inhibit_screensaver;
+   android_vt->get_time = _al_unix_get_time;
+   android_vt->rest = _al_unix_rest;
+   android_vt->init_timeout = _al_unix_init_timeout;
 
    return android_vt;
 }

--- a/src/gp2xwiz/wiz_system.c
+++ b/src/gp2xwiz/wiz_system.c
@@ -156,6 +156,9 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_gp2xwiz_driver(void)
    gp2xwiz_vt->get_path = _al_unix_get_path;
    gp2xwiz_vt->inhibit_screensaver = gp2xwiz_inhibit_screensaver;
    gp2xwiz_vt->get_num_display_formats = gp2xwiz_get_num_display_formats;
+   gp2xwiz_vt->get_time = _al_unix_get_time;
+   gp2xwiz_vt->rest = _al_unix_rest;
+   gp2xwiz_vt->init_timeout = _al_unix_init_timeout;
 
    return gp2xwiz_vt;
 }

--- a/src/macosx/system.m
+++ b/src/macosx/system.m
@@ -542,6 +542,9 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_osx_driver(void)
       vt->inhibit_screensaver = osx_inhibit_screensaver;
       vt->thread_init = osx_thread_init;
       vt->thread_exit = osx_thread_exit;
+      vt->get_time = _al_unix_get_time;
+      vt->rest = _al_unix_rest;
+      vt->init_timeout = _al_unix_init_timeout;
 
    };
 

--- a/src/raspberrypi/pisystem.c
+++ b/src/raspberrypi/pisystem.c
@@ -195,6 +195,9 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_raspberrypi_driver(void)
    pi_vt->get_cursor_position = pi_get_cursor_position;
    pi_vt->get_path = _al_unix_get_path;
    pi_vt->inhibit_screensaver = pi_inhibit_screensaver;
+   pi_vt->get_time = _al_unix_get_time;
+   pi_vt->rest = _al_unix_rest;
+   pi_vt->init_timeout = _al_unix_init_timeout;
 
    return pi_vt;
 }

--- a/src/sdl/sdl_system.c
+++ b/src/sdl/sdl_system.c
@@ -342,6 +342,9 @@ ALLEGRO_SYSTEM_INTERFACE *_al_sdl_system_driver(void)
    vt->close_library = sdl_close_library;*/
    vt->heartbeat = sdl_heartbeat;
    vt->heartbeat_init = sdl_heartbeat_init;
+   vt->get_time = _al_sdl_get_time;
+   vt->rest = _al_sdl_rest;
+   vt->init_timeout = _al_sdl_init_timeout;
 
    return vt;
 }

--- a/src/sdl/sdl_time.c
+++ b/src/sdl/sdl_time.c
@@ -20,21 +20,21 @@
 
 ALLEGRO_DEBUG_CHANNEL("SDL")
 
-double al_get_time(void)
+double _al_sdl_get_time(void)
 {
    return 1.0 * SDL_GetPerformanceCounter() / SDL_GetPerformanceFrequency();
 }
 
 
 
-void al_rest(double seconds)
+void _al_sdl_rest(double seconds)
 {
    SDL_Delay(seconds * 1000);
 }
 
 
 
-void al_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
+void _al_sdl_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
 {
    ALLEGRO_TIMEOUT_SDL *timeout_sdl = (void *)timeout;
    timeout_sdl->ms = seconds * 1000;

--- a/src/system.c
+++ b/src/system.c
@@ -495,4 +495,38 @@ void _al_close_library(void *library)
       active_sysdrv->vt->close_library(library);
 }
 
+
+/* Function: al_get_time
+ */
+double al_get_time(void)
+{
+   ASSERT(active_sysdrv);
+
+   if (active_sysdrv->vt->get_time)
+      return active_sysdrv->vt->get_time();
+   return 0.0;
+}
+
+
+/* Function: al_rest
+ */
+void al_rest(double seconds)
+{
+   ASSERT(active_sysdrv);
+
+   if (active_sysdrv->vt->rest)
+      active_sysdrv->vt->rest(seconds);
+}
+
+
+/* Function: al_init_timeout
+ */
+void al_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
+{
+   ASSERT(active_sysdrv);
+
+   if (active_sysdrv->vt->init_timeout)
+      active_sysdrv->vt->init_timeout(timeout, seconds);
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/src/unix/utime.c
+++ b/src/unix/utime.c
@@ -43,9 +43,7 @@ void _al_unix_init_time(void)
 
 
 
-/* Function: al_get_time
- */
-double al_get_time(void)
+double _al_unix_get_time(void)
 {
    struct timeval now;
    double time;
@@ -58,9 +56,7 @@ double al_get_time(void)
 
 
 
-/* Function: al_rest
- */
-void al_rest(double seconds)
+void _al_unix_rest(double seconds)
 {
    struct timespec timeout;
    double fsecs = floor(seconds);
@@ -71,31 +67,29 @@ void al_rest(double seconds)
 
 
 
-/* Function: al_init_timeout
- */
-void al_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
+void _al_unix_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
 {
-    ALLEGRO_TIMEOUT_UNIX *ut = (ALLEGRO_TIMEOUT_UNIX *) timeout;
-    struct timeval now;
-    double integral;
-    double frac;
+   ALLEGRO_TIMEOUT_UNIX *ut = (ALLEGRO_TIMEOUT_UNIX *) timeout;
+   struct timeval now;
+   double integral;
+   double frac;
 
-    ASSERT(ut);
+   ASSERT(ut);
 
-    gettimeofday(&now, NULL);
+   gettimeofday(&now, NULL);
 
-    if (seconds <= 0.0) {
-	ut->abstime.tv_sec = now.tv_sec;
-	ut->abstime.tv_nsec = now.tv_usec * 1000;
-    }
-    else {
-	frac = modf(seconds, &integral);
+   if (seconds <= 0.0) {
+      ut->abstime.tv_sec = now.tv_sec;
+      ut->abstime.tv_nsec = now.tv_usec * 1000;
+   }
+   else {
+      frac = modf(seconds, &integral);
 
-	ut->abstime.tv_sec = now.tv_sec + integral;
-	ut->abstime.tv_nsec = (now.tv_usec * 1000) + (frac * 1000000000L);
-	ut->abstime.tv_sec += ut->abstime.tv_nsec / 1000000000L;
-	ut->abstime.tv_nsec = ut->abstime.tv_nsec % 1000000000L;
-    }
+      ut->abstime.tv_sec = now.tv_sec + integral;
+      ut->abstime.tv_nsec = (now.tv_usec * 1000) + (frac * 1000000000L);
+      ut->abstime.tv_sec += ut->abstime.tv_nsec / 1000000000L;
+      ut->abstime.tv_nsec = ut->abstime.tv_nsec % 1000000000L;
+   }
 }
 
 /* vim: set sts=3 sw=3 et */

--- a/src/win/wsystem.c
+++ b/src/win/wsystem.c
@@ -913,6 +913,9 @@ static ALLEGRO_SYSTEM_INTERFACE *_al_system_win_driver(void)
    vt->open_library = win_open_library;
    vt->import_symbol = win_import_symbol;
    vt->close_library = win_close_library;
+   vt->get_time = _al_win_get_time;
+   vt->rest = _al_win_rest;
+   vt->init_timeout = _al_win_init_timeout;
 
    return vt;
 }

--- a/src/win/wtime.c
+++ b/src/win/wtime.c
@@ -83,7 +83,7 @@ static double high_res_current_time(void)
 }
 
 
-double al_get_time(void)
+double _al_win_get_time(void)
 {
    return (*real_get_time_func)();
 }
@@ -117,11 +117,8 @@ void _al_win_shutdown_time(void)
 }
 
 
-/* al_rest:
- *  Rests the specified amount of milliseconds.
- *  Does nothing with values <= 0.
- */
-void al_rest(double seconds)
+
+void _al_win_rest(double seconds)
 {
    if (seconds <= 0)
       return;
@@ -130,10 +127,8 @@ void al_rest(double seconds)
 }
 
 
-/* al_init_timeout:
- *  Set a timeout value.
- */
-void al_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
+
+void _al_win_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
 {
    ALLEGRO_TIMEOUT_WIN *wt = (ALLEGRO_TIMEOUT_WIN *) timeout;
 

--- a/src/x/xsystem.c
+++ b/src/x/xsystem.c
@@ -454,6 +454,9 @@ ALLEGRO_SYSTEM_INTERFACE *_al_system_xglx_driver(void)
    xglx_vt->ungrab_mouse = _al_xwin_ungrab_mouse;
    xglx_vt->get_path = _al_unix_get_path;
    xglx_vt->inhibit_screensaver = xglx_inhibit_screensaver;
+   xglx_vt->get_time = _al_unix_get_time;
+   xglx_vt->rest = _al_unix_rest;
+   xglx_vt->init_timeout = _al_unix_init_timeout;
 
    return xglx_vt;
 }


### PR DESCRIPTION
This simplifies the implementation of new drivers, and fixes the
oddities with doc generation.

First steps towards fixing #996.