### PR TITLE
Fix regex on line 65 of generate_python_ctypes.py

### DIFF
--- a/python/generate_python_ctypes.py
+++ b/python/generate_python_ctypes.py
@@ -62,7 +62,7 @@ class Allegro:
             "postprocess_callback_t": c_void_p,
             }
 
-        ptype = re.sub(r"\bstruct|union\b", "", ptype)
+        ptype = re.sub(r"\b(struct|union)\b", "", ptype)
         ptype = re.sub(r"\bconst\b", "", ptype)
         ptype = re.sub(r"\bextern\b", "", ptype)
         ptype = re.sub(r"\b__inline__\b", "", ptype)


### PR DESCRIPTION
The previous regex on line 65 r"\bstruct|union\b" matches "struct" at the beginning of a word or "union" at the end of a word (e.g. it matches twice on "structured reunion" and re.sub will give "ured re").
The proposed regex r"\b(struct|union)\b" matches "struct" or "union" as a whole word only.