### PR TITLE
fix mp3 files with multiple channels

### DIFF
--- a/addons/acodec/mp3.c
+++ b/addons/acodec/mp3.c
@@ -98,7 +98,7 @@ ALLEGRO_SAMPLE *_al_load_mp3_f(ALLEGRO_FILE *f)
    }
 
    /* Create sample from info variable. */
-   spl = al_create_sample(info.buffer, info.samples, info.hz,
+   spl = al_create_sample(info.buffer, info.samples / info.channels, info.hz,
       _al_word_size_to_depth_conf(sizeof(mp3d_sample_t)),
       _al_count_to_channel_conf(info.channels), true);
 


### PR DESCRIPTION
I tested adding some sounds from this pack to my game, and since we now support mp3 just used the mp3 files as is: https://opengameart.org/content/monster-and-creatures-sound-effects-pack-001

The files play fine, however once Allegro is done playing any of them it crashes. Turns out there is some kind of miscalculation for the sample length. This PR fixes it for me but someone who knows MiniMp3 should double check.