### PR TITLE
Add "al_is_*_addon_initialized()" for acodec, image, font, and ttf addons

### DIFF
--- a/addons/acodec/acodec.c
+++ b/addons/acodec/acodec.c
@@ -3,6 +3,11 @@
 #include "allegro5/internal/aintern_acodec_cfg.h"
 #include "acodec.h"
 
+
+/* globals */
+static bool acodec_inited = false;
+
+
 /* Function: al_get_allegro_acodec_version
  */
 uint32_t al_get_allegro_acodec_version(void)
@@ -61,7 +66,17 @@ bool al_init_acodec_addon(void)
    ret &= al_register_audio_stream_loader_f(".mp3", _al_load_mp3_audio_stream_f);
 #endif
 
+   acodec_inited = ret;
+
    return ret;
+}
+
+
+/* Function: al_is_acodec_addon_initialized
+ */
+bool al_is_acodec_addon_initialized(void)
+{
+   return acodec_inited;
 }
 
 

--- a/addons/acodec/allegro5/allegro_acodec.h
+++ b/addons/acodec/allegro5/allegro_acodec.h
@@ -30,6 +30,7 @@ extern "C" {
 
 
 ALLEGRO_ACODEC_FUNC(bool, al_init_acodec_addon, (void));
+ALLEGRO_ACODEC_FUNC(bool, al_is_acodec_addon_initialized, (void));
 ALLEGRO_ACODEC_FUNC(uint32_t, al_get_allegro_acodec_version, (void));
 
 

--- a/addons/font/allegro5/allegro_font.h
+++ b/addons/font/allegro5/allegro_font.h
@@ -102,6 +102,7 @@ ALLEGRO_FONT_FUNC(void, al_get_text_dimensions, (const ALLEGRO_FONT *f,
    char const *text,
    int *bbx, int *bby, int *bbw, int *bbh));
 ALLEGRO_FONT_FUNC(bool, al_init_font_addon, (void));
+ALLEGRO_FONT_FUNC(bool, al_is_font_addon_initialized, (void));
 ALLEGRO_FONT_FUNC(void, al_shutdown_font_addon, (void));
 ALLEGRO_FONT_FUNC(uint32_t, al_get_allegro_font_version, (void));
 ALLEGRO_FONT_FUNC(int, al_get_font_ranges, (ALLEGRO_FONT *font,

--- a/addons/font/font.c
+++ b/addons/font/font.c
@@ -387,6 +387,16 @@ bool al_init_font_addon(void)
 }
 
 
+
+/* Function: al_is_font_addon_initialized
+ */
+bool al_is_font_addon_initialized(void)
+{
+   return font_inited;
+}
+
+
+
 /* Function: al_shutdown_font_addon
  */
 void al_shutdown_font_addon(void)

--- a/addons/image/allegro5/allegro_image.h
+++ b/addons/image/allegro5/allegro_image.h
@@ -32,6 +32,7 @@ extern "C" {
 
 
 ALLEGRO_IIO_FUNC(bool, al_init_image_addon, (void));
+ALLEGRO_IIO_FUNC(bool, al_is_image_addon_initialized, (void));
 ALLEGRO_IIO_FUNC(void, al_shutdown_image_addon, (void));
 ALLEGRO_IIO_FUNC(uint32_t, al_get_allegro_image_version, (void));
 

--- a/addons/image/iio.c
+++ b/addons/image/iio.c
@@ -164,6 +164,14 @@ bool al_init_image_addon(void)
 }
 
 
+/* Function: al_is_image_addon_initialized
+ */
+bool is_image_addon_initialized(void)
+{
+   return iio_inited;
+}
+
+
 /* Function: al_shutdown_image_addon
  */
 void al_shutdown_image_addon(void)

--- a/addons/native_dialog/allegro5/allegro_native_dialog.h
+++ b/addons/native_dialog/allegro5/allegro_native_dialog.h
@@ -59,6 +59,7 @@ typedef struct ALLEGRO_MENU_INFO {
 #define ALLEGRO_END_OF_MENU                { NULL,          0, 0, NULL }
 
 ALLEGRO_DIALOG_FUNC(bool, al_init_native_dialog_addon, (void));
+ALLEGRO_DIALOG_FUNC(bool, al_is_native_dialog_addon_initialized, (void));
 ALLEGRO_DIALOG_FUNC(void, al_shutdown_native_dialog_addon, (void));
 
 ALLEGRO_DIALOG_FUNC(ALLEGRO_FILECHOOSER *, al_create_native_file_dialog, (char const *initial_path,

--- a/addons/native_dialog/dialog.c
+++ b/addons/native_dialog/dialog.c
@@ -27,6 +27,13 @@ bool al_init_native_dialog_addon(void)
    return true;
 }
 
+/* Function: al_is_native_dialog_addon_initialized
+ */
+bool al_is_native_dialog_addon_initialized(void)
+{
+   return inited_addon;
+}
+
 /* Function: al_shutdown_native_dialog_addon
  */
 void al_shutdown_native_dialog_addon(void)

--- a/addons/primitives/allegro5/allegro_primitives.h
+++ b/addons/primitives/allegro5/allegro_primitives.h
@@ -165,6 +165,7 @@ ALLEGRO_PRIM_FUNC(uint32_t, al_get_allegro_primitives_version, (void));
 * Primary Functions
 */
 ALLEGRO_PRIM_FUNC(bool, al_init_primitives_addon, (void));
+ALLEGRO_PRIM_FUNC(bool, al_is_primitives_addon_initialized, (void));
 ALLEGRO_PRIM_FUNC(void, al_shutdown_primitives_addon, (void));
 ALLEGRO_PRIM_FUNC(int, al_draw_prim, (const void* vtxs, const ALLEGRO_VERTEX_DECL* decl, ALLEGRO_BITMAP* texture, int start, int end, int type));
 ALLEGRO_PRIM_FUNC(int, al_draw_indexed_prim, (const void* vtxs, const ALLEGRO_VERTEX_DECL* decl, ALLEGRO_BITMAP* texture, const int* indices, int num_vtx, int type));

--- a/addons/primitives/primitives.c
+++ b/addons/primitives/primitives.c
@@ -55,6 +55,13 @@ bool al_init_primitives_addon(void)
    return ret;
 }
 
+/* Function: al_is_primitives_addon_initialized
+ */
+bool al_is_primitives_addon_initialized(void)
+{
+   return addon_initialized;
+}
+
 /* Function: al_shutdown_primitives_addon
  */
 void al_shutdown_primitives_addon(void)

--- a/addons/ttf/allegro5/allegro_ttf.h
+++ b/addons/ttf/allegro5/allegro_ttf.h
@@ -39,6 +39,7 @@ ALLEGRO_TTF_FUNC(ALLEGRO_FONT *, al_load_ttf_font_f, (ALLEGRO_FILE *file, char c
 ALLEGRO_TTF_FUNC(ALLEGRO_FONT *, al_load_ttf_font_stretch, (char const *filename, int w, int h, int flags));
 ALLEGRO_TTF_FUNC(ALLEGRO_FONT *, al_load_ttf_font_stretch_f, (ALLEGRO_FILE *file, char const *filename, int w, int h, int flags));
 ALLEGRO_TTF_FUNC(bool, al_init_ttf_addon, (void));
+ALLEGRO_TTF_FUNC(bool, al_is_ttf_addon_initialized, (void));
 ALLEGRO_TTF_FUNC(void, al_shutdown_ttf_addon, (void));
 ALLEGRO_TTF_FUNC(uint32_t, al_get_allegro_ttf_version, (void));
 

--- a/addons/ttf/ttf.c
+++ b/addons/ttf/ttf.c
@@ -1134,6 +1134,14 @@ bool al_init_ttf_addon(void)
 }
 
 
+/* Function: al_is_ttf_addon_initialized
+ */
+bool al_is_ttf_addon_initialized(void)
+{
+   return ttf_inited;
+}
+
+
 /* Function: al_shutdown_ttf_addon
  */
 void al_shutdown_ttf_addon(void)

--- a/addons/video/allegro5/allegro_video.h
+++ b/addons/video/allegro5/allegro_video.h
@@ -67,6 +67,7 @@ ALLEGRO_VIDEO_FUNC(ALLEGRO_BITMAP *, al_get_video_frame, (ALLEGRO_VIDEO *video))
 ALLEGRO_VIDEO_FUNC(double, al_get_video_position, (ALLEGRO_VIDEO *video, ALLEGRO_VIDEO_POSITION_TYPE which));
 ALLEGRO_VIDEO_FUNC(bool, al_seek_video, (ALLEGRO_VIDEO *video, double pos_in_seconds));
 ALLEGRO_VIDEO_FUNC(bool, al_init_video_addon, (void));
+ALLEGRO_VIDEO_FUNC(bool, al_is_video_addon_initialized, (void));
 ALLEGRO_VIDEO_FUNC(void, al_shutdown_video_addon, (void));
 ALLEGRO_VIDEO_FUNC(uint32_t, al_get_allegro_video_version, (void));
 

--- a/addons/video/video.c
+++ b/addons/video/video.c
@@ -276,6 +276,14 @@ bool al_init_video_addon(void)
 }
 
 
+/* Function: al_is_video_addon_initialized
+ */
+bool al_is_video_addon_initialized(void)
+{
+   return video_inited;
+}
+
+
 /* Function: al_shutdown_video_addon
  */
 void al_shutdown_video_addon(void)

--- a/docs/src/refman/acodec.txt
+++ b/docs/src/refman/acodec.txt
@@ -32,6 +32,10 @@ streamed with [al_load_audio_stream] or [al_load_audio_stream_f].
 
 Return true on success.
 
+## API: al_is_acodec_addon_initialized
+
+Returns true if the acodec addon has been initialized, otherwise returns false.
+
 ## API: al_get_allegro_acodec_version
 
 Returns the (compiled) version of the addon, in the same format as

--- a/docs/src/refman/acodec.txt
+++ b/docs/src/refman/acodec.txt
@@ -34,7 +34,7 @@ Return true on success.
 
 ## API: al_is_acodec_addon_initialized
 
-Returns true if the acodec addon has been initialized, otherwise returns false.
+Returns true if the acodec addon is initialized, otherwise returns false.
 
 ## API: al_get_allegro_acodec_version
 

--- a/docs/src/refman/acodec.txt
+++ b/docs/src/refman/acodec.txt
@@ -36,6 +36,8 @@ Return true on success.
 
 Returns true if the acodec addon is initialized, otherwise returns false.
 
+Since: 5.2.6
+
 ## API: al_get_allegro_acodec_version
 
 Returns the (compiled) version of the addon, in the same format as

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -75,6 +75,8 @@ See also: [al_init_image_addon], [al_init_ttf_addon], [al_shutdown_font_addon]
 
 Returns true if the font addon is initialized, otherwise returns false.
 
+Since: 5.2.6
+
 See also: [al_init_image_addon], [al_shutdown_font_addon]
 
 ### API: al_shutdown_font_addon
@@ -705,6 +707,8 @@ Returns true on success, false on failure.
 ### API: al_is_ttf_addon_initialized
 
 Returns true if the TTF addon is initialized, otherwise returns false.
+
+Since: 5.2.6
 
 See also: [al_init_ttf_addon], [al_shutdown_ttf_addon]
 

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -73,7 +73,7 @@ See also: [al_init_image_addon], [al_init_ttf_addon], [al_shutdown_font_addon]
 
 ### API: al_is_font_addon_initialized
 
-Returns true if the font addon has been initialized, otherwise returns false.
+Returns true if the font addon is initialized, otherwise returns false.
 
 See also: [al_init_image_addon], [al_shutdown_font_addon]
 
@@ -704,7 +704,7 @@ Returns true on success, false on failure.
 
 ### API: al_is_ttf_addon_initialized
 
-Returns true if the TTF addon has been initialized, otherwise returns false.
+Returns true if the TTF addon is initialized, otherwise returns false.
 
 See also: [al_init_ttf_addon], [al_shutdown_ttf_addon]
 

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -702,6 +702,12 @@ Call this after [al_init_font_addon] to make [al_load_font] recognize
 
 Returns true on success, false on failure.
 
+### API: al_is_ttf_addon_initialized
+
+Returns true if the TTF addon has been initialized, otherwise returns false.
+
+See also: [al_init_ttf_addon], [al_shutdown_ttf_addon]
+
 ### API: al_shutdown_ttf_addon
 
 Unloads the ttf addon again. You normally don't need to call this.

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -71,6 +71,12 @@ checking the return value if your code needs to be compatible with Allegro
 
 See also: [al_init_image_addon], [al_init_ttf_addon], [al_shutdown_font_addon]
 
+### API: al_is_font_addon_initialized
+
+Returns true if the font addon has been initialized, otherwise returns false.
+
+See also: [al_init_image_addon], [al_shutdown_font_addon]
+
 ### API: al_shutdown_font_addon
 
 Shut down the font addon. This is done automatically at program exit,

--- a/docs/src/refman/font.txt
+++ b/docs/src/refman/font.txt
@@ -77,7 +77,7 @@ Returns true if the font addon is initialized, otherwise returns false.
 
 Since: 5.2.6
 
-See also: [al_init_image_addon], [al_shutdown_font_addon]
+See also: [al_init_font_addon], [al_shutdown_font_addon]
 
 ### API: al_shutdown_font_addon
 

--- a/docs/src/refman/image.txt
+++ b/docs/src/refman/image.txt
@@ -33,6 +33,8 @@ have the pixel format matching the format in the file.
 
 Returns true if the image addon is initialized, otherwise returns false.
 
+Since: 5.2.6
+
 ## API: al_shutdown_image_addon
 
 Shut down the image addon. This is done automatically at program exit,

--- a/docs/src/refman/image.txt
+++ b/docs/src/refman/image.txt
@@ -31,7 +31,7 @@ have the pixel format matching the format in the file.
 
 ## API: al_is_image_addon_initialized
 
-Returns true if the image addon has been initialized, otherwise returns false.
+Returns true if the image addon is initialized, otherwise returns false.
 
 ## API: al_shutdown_image_addon
 

--- a/docs/src/refman/image.txt
+++ b/docs/src/refman/image.txt
@@ -29,6 +29,10 @@ contains textures compressed in the DXT1, DXT3 and DXT5 formats. Note that when
 loading a DDS file, the created bitmap will always be a video bitmap and will
 have the pixel format matching the format in the file.
 
+## API: al_is_image_addon_initialized
+
+Returns true if the image addon has been initialized, otherwise returns false.
+
 ## API: al_shutdown_image_addon
 
 Shut down the image addon. This is done automatically at program exit,

--- a/docs/src/refman/native_dialog.txt
+++ b/docs/src/refman/native_dialog.txt
@@ -35,6 +35,8 @@ See also: [al_shutdown_native_dialog_addon]
 
 Returns true if the native dialog addon is initialized, otherwise returns false.
 
+Since: 5.2.6
+
 ## API: al_shutdown_native_dialog_addon
 
 Shut down the native dialog addon.

--- a/docs/src/refman/native_dialog.txt
+++ b/docs/src/refman/native_dialog.txt
@@ -31,6 +31,10 @@ an error message if Allegro fails to initialise.
 
 See also: [al_shutdown_native_dialog_addon]
 
+## API: al_is_native_dialog_addon_initialized
+
+Returns true if the native dialog addon is initialized, otherwise returns false.
+
 ## API: al_shutdown_native_dialog_addon
 
 Shut down the native dialog addon.

--- a/docs/src/refman/primitives.txt
+++ b/docs/src/refman/primitives.txt
@@ -23,6 +23,12 @@ True on success, false on failure.
 
 See also: [al_shutdown_primitives_addon]
 
+### API: al_is_primitives_addon_initialized
+
+Returns true if the primitives addon is initialized, otherwise returns false.
+
+See also: [al_init_primitives_addon], [al_shutdown_primitives_addon]
+
 ### API: al_shutdown_primitives_addon
 
 Shut down the primitives addon. This is done automatically at program exit,

--- a/docs/src/refman/primitives.txt
+++ b/docs/src/refman/primitives.txt
@@ -27,6 +27,8 @@ See also: [al_shutdown_primitives_addon]
 
 Returns true if the primitives addon is initialized, otherwise returns false.
 
+Since: 5.2.6
+
 See also: [al_init_primitives_addon], [al_shutdown_primitives_addon]
 
 ### API: al_shutdown_primitives_addon

--- a/docs/src/refman/video.txt
+++ b/docs/src/refman/video.txt
@@ -69,6 +69,8 @@ Since: 5.1.12
 
 Returns true if the video addon is initialized, otherwise returns false.
 
+Since: 5.2.6
+
 ## API: al_shutdown_video_addon
 
 Shut down the video addon. This is done automatically at program exit,

--- a/docs/src/refman/video.txt
+++ b/docs/src/refman/video.txt
@@ -65,6 +65,10 @@ Initializes the video addon.
 
 Since: 5.1.12
 
+## API: al_is_video_addon_initialized
+
+Returns true if the video addon is initialized, otherwise returns false.
+
 ## API: al_shutdown_video_addon
 
 Shut down the video addon. This is done automatically at program exit,


### PR DESCRIPTION
## Problem

Hello Allegro :)

I have some program components that require addons to be initialized, but there's no indication if initialization has been overlooked other than a segfault during runtime when calling the addon functions.

One possible solution is to trigger initialization inside my components themselves, but this is not a good idea and in some cases is dependent on allegro initialization as well.  Initialization as a side-effect is not great here, and should be handled outside the component regardless.

A better solution is to check for initialization of the dependent addon within the component, and output an error message or raise an exception, but Allegro currently doesn't have initialization checks for some addons.  One does exist for audio "install", however.

## Solution

Add functions `al_is_*_addon_initialized` for checking initialization.

I've also added doc listings.  I originally set out to only add it to the image addon, but just went ahead and added checks for all of them.  Acodec required the addition of a global static bool, while the others already had them.

The following addons require initialization and do not currently have checks in master:

- acodec
- font
- ttf
- image i/o
- native dialog
- primitives
- video streaming

## Tests

I'm not sure if there are any test, are there places for tests for these?