### PR TITLE
Fix for window resizing on Windows when a menubar is visible

### DIFF
--- a/src/win/d3d_disp.cpp
+++ b/src/win/d3d_disp.cpp
@@ -2287,7 +2287,7 @@ static bool d3d_resize_helper(ALLEGRO_DISPLAY *d, int width, int height)
       wi.cbSize = sizeof(WINDOWINFO);
       GetWindowInfo(win_display->window, &wi);
 
-      AdjustWindowRectEx(&win_size, wi.dwStyle, false, wi.dwExStyle);
+      AdjustWindowRectEx(&win_size, wi.dwStyle, GetMenu(win_display->window) ? TRUE : FALSE, wi.dwExStyle);
 
       // FIXME: Handle failure (for example if window constraints are active?)
       SetWindowPos(win_display->window, HWND_TOP,

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -1406,7 +1406,7 @@ static bool wgl_resize_helper(ALLEGRO_DISPLAY *d, int width, int height)
       wi.cbSize = sizeof(WINDOWINFO);
       GetWindowInfo(win_disp->window, &wi);
 
-      AdjustWindowRectEx(&win_size, wi.dwStyle, false, wi.dwExStyle);
+      AdjustWindowRectEx(&win_size, wi.dwStyle, GetMenu(win_disp->window) ? TRUE : FALSE, wi.dwExStyle);
 
       if (!SetWindowPos(win_disp->window, HWND_TOP,
          0, 0,

--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -1173,7 +1173,7 @@ void _al_win_set_window_frameless(ALLEGRO_DISPLAY *display, HWND hWnd,
       style |= WS_VISIBLE;
 
       GetWindowRect(hWnd, &r);
-      AdjustWindowRectEx(&r, style, false, exStyle);
+      AdjustWindowRectEx(&r, style, GetMenu(hWnd) ? TRUE : FALSE, exStyle);
 
       w = r.right - r.left;
       h = r.bottom - r.top;


### PR DESCRIPTION
This fix enables AdjustWindowRectEx to correctly calculate the window's client area. I have tested this fix since 5.2.2 without any issues.