### PR TITLE
Change allegro graphic to full screen in execution time

### DIFF
--- a/docs/src/changes-5.2.txt
+++ b/docs/src/changes-5.2.txt
@@ -2,6 +2,91 @@
 
 These lists serve as summaries; the full histories are in the git repository.
 
+Changes from 5.2.3 to 5.2.4 (February 2018)
+==========================================
+
+The main developers this time were: Sebastian Krzyszkowiak, Elias Pschernig,
+SiegeLord
+
+Core:
+
+  - Fix errors when reading/writing 0 byte buffers (Bruce Pascoe).
+
+  - Re-initialize TLS when Allegro is installed (Issue #865).
+
+  - Add `al_transform_coordinates_4d`.
+
+  - Don't initialize the trace mutex multiple times (Issue #874).
+
+  - Fix 3D (non-projection) transforms with `al_hold_bitmap_drawing`.
+
+Raspberry Pi port:
+
+  - Fix compilation on RPI.
+
+Android port:
+
+  - Remove limit on the working directory length.
+
+  - Fix `ALLEGRO_MAXIMIZED` flag.
+
+  - Fix build with older Android NDKs.
+
+  - Remove `glClear` hack for Android 2.1.
+
+Linux port:
+
+  - Make compositor bypass configurable in X11, and bypass only when fullscreen
+    by default.
+
+OSX port:
+
+  - Fix a few OSX retina scaling issues (Issue #851).
+
+Audio addon:
+
+  - Fix ALSA lag.
+
+  - Add an option to use the desktop window when initializing DirectSound
+    (Issue #877).
+
+Font addon:
+
+  - Add support for bmfont format.
+
+Native dialog addon:
+
+  - Resize the display on Windows when hiding/showing the menu (Issue #860).
+
+  - Detect when `al_popup_menu` fails to actually work under GTK (Issue #808).
+
+  - Don't clear the top-level menu when destroying the popup menu.
+
+Build system:
+
+  - Don't link in libm on MSVC for DUMB (Issue #847).
+
+  - Don't use the LOCATION property (Issue #847).
+
+  - Don't use SYSTEM for DirectX includes.
+
+  - Add hints for mingw-w64 path locations for DirectX includes/libs.
+
+Python binding:
+
+  - Fix the Python code-generation scripts to run under Python 2.
+
+Lua binding:
+
+  - Add script to generate LuaJIT C API for Allegro 5 (BQ).
+
+Documentation:
+
+  - Many improvements (Andreas Rönnquist, others)
+
+Examples:
+
+  - Add a texture to the skybox in `ex_camera`.
 
 Changes from 5.2.2 to 5.2.3 (October 2017)
 ==========================================

--- a/include/allegro5/base.h
+++ b/include/allegro5/base.h
@@ -71,11 +71,11 @@
  * Note x.y.z (= x.y.z.0) has release number 1, and x.y.z.1 has release
  * number 2, just to confuse you.
  */
-#define ALLEGRO_RELEASE_NUMBER   0
+#define ALLEGRO_RELEASE_NUMBER   1
 
-#define ALLEGRO_VERSION_STR      "5.2.4 (GIT)"
-#define ALLEGRO_DATE_STR         "2017"
-#define ALLEGRO_DATE             20171008    /* yyyymmdd */
+#define ALLEGRO_VERSION_STR      "5.2.4"
+#define ALLEGRO_DATE_STR         "2018"
+#define ALLEGRO_DATE             20180224    /* yyyymmdd */
 #define ALLEGRO_VERSION_INT \
     ((ALLEGRO_VERSION << 24) | (ALLEGRO_SUB_VERSION << 16) | \
     (ALLEGRO_WIP_VERSION << 8) | ALLEGRO_RELEASE_NUMBER | \


### PR DESCRIPTION
I am updating my engine while developing my game menu. I use two libraries to manipulate the engine. One of them is allegro 5.2.5. I am trying to change the graphic mode in execution time but until now I could not. I've tried to use al_toggle_display_flag, al_set_display_flag and other functions, but none of them is able to change from window screen to fullscreen and vice-versa.
It could be really good to have a function like al_set_window_fullscreen which could be able to change the window mode in execution time.
Thanks for the attention.

Lísias de Castro Martins

