### PR TITLE
Adds floating point coordinate mouse events.

### DIFF
--- a/docs/src/refman/events.txt
+++ b/docs/src/refman/events.txt
@@ -201,6 +201,13 @@ events instead which are identical except for their type.
 > *Note:* currently mouse.display may be NULL if an event is generated in
 response to [al_set_mouse_axis].
 
+### ALLEGRO_EVENT_MOUSE_AXES_FLOAT
+
+Like `ALLEGRO_EVENT_MOUSE_AXES`, but with floating point coordinates.
+Both event types are always generated, so you should only handle one type.
+
+Since: 5.2.6
+
 ### ALLEGRO_EVENT_MOUSE_BUTTON_DOWN
 
 A mouse button was pressed.
@@ -225,6 +232,13 @@ mouse.pressure (float)
 
 mouse.display (ALLEGRO_DISPLAY *)
 :   The display which had mouse focus.
+
+### ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT
+
+Like `ALLEGRO_EVENT_MOUSE_BUTTON_DOWN`, but with floating point coordinates.
+Both event types are always generated, so you should only handle one type.
+
+Since: 5.2.6
 
 ### ALLEGRO_EVENT_MOUSE_BUTTON_UP
 
@@ -251,10 +265,24 @@ mouse.pressure (float)
 mouse.display (ALLEGRO_DISPLAY *)
 :   The display which had mouse focus.
 
+### ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT
+
+Like `ALLEGRO_EVENT_MOUSE_BUTTON_UP`, but with floating point coordinates.
+Both event types are always generated, so you should only handle one type.
+
+Since: 5.2.6
+
 ### ALLEGRO_EVENT_MOUSE_WARPED
 
 [al_set_mouse_xy] was called to move the mouse.
 This event is identical to ALLEGRO_EVENT_MOUSE_AXES otherwise.
+
+### ALLEGRO_EVENT_MOUSE_WARPED_FLOAT
+
+Like `ALLEGRO_EVENT_MOUSE_WARPED`, but with floating point coordinates.
+Both event types are always generated, so you should only handle one type.
+
+Since: 5.2.6
 
 ### ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY
 
@@ -275,6 +303,13 @@ mouse.w (int)
 mouse.display (ALLEGRO_DISPLAY *)
 :   The display which had mouse focus.
 
+### ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY_FLOAT
+
+Like `ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY`, but with floating point coordinates.
+Both event types are always generated, so you should only handle one type.
+
+Since: 5.2.6
+
 ### ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY
 
 The mouse cursor left the boundaries of a window opened by the program.
@@ -293,6 +328,13 @@ mouse.w (int)
 
 mouse.display (ALLEGRO_DISPLAY *)
 :   The display which had mouse focus.
+
+### ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY_FLOAT
+
+Like `ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY`, but with floating point coordinates.
+Both event types are always generated, so you should only handle one type.
+
+Since: 5.2.6
 
 ### ALLEGRO_EVENT_TOUCH_BEGIN
 

--- a/docs/src/refman/mouse.txt
+++ b/docs/src/refman/mouse.txt
@@ -144,6 +144,10 @@ Returns NULL if the mouse subsystem was not installed.
 
 ## API: al_set_mouse_wheel_precision
 
+> *Note:* this function is soft-deprecated. The same functionality can be 
+obtained by handling the `*_FLOAT` mouse events, which naturally 
+capture all of the precision the input devices have to offer.
+
 Sets the precision of the mouse wheel (the z and w coordinates). This precision
 manifests itself as a multiplier on the `dz` and `dw` fields in mouse events.
 It also affects the `z` and `w` fields of events and [ALLEGRO_MOUSE_STATE], but

--- a/examples/ex_mouse_events.c
+++ b/examples/ex_mouse_events.c
@@ -36,14 +36,14 @@ int main(int argc, char **argv)
    ALLEGRO_EVENT_QUEUE *queue;
    ALLEGRO_EVENT event;
    ALLEGRO_FONT *font;
-   int mx = 0;
-   int my = 0;
-   int mz = 0;
-   int mw = 0;
-   int mmx = 0;
-   int mmy = 0;
-   int mmz = 0;
-   int mmw = 0;
+   float mx = 0;
+   float my = 0;
+   float mz = 0;
+   float mw = 0;
+   float mmx = 0;
+   float mmy = 0;
+   float mmz = 0;
+   float mmw = 0;
    int precision = 1;
    bool in = true;
    bool buttons[NUM_BUTTONS] = {false};
@@ -102,8 +102,8 @@ int main(int argc, char **argv)
          }
          al_draw_bitmap(cursor, mx, my, 0);
          al_set_blender(ALLEGRO_ADD, ALLEGRO_ONE, ALLEGRO_INVERSE_ALPHA);
-         al_draw_textf(font, black, 5, 5, 0, "dx %i, dy %i, dz %i, dw %i", mmx, mmy, mmz, mmw);
-         al_draw_textf(font, black, 5, 25, 0, "x %i, y %i, z %i, w %i", mx, my, mz, mw);
+         al_draw_textf(font, black, 5, 5, 0, "dx %g, dy %g, dz %g, dw %g", mmx, mmy, mmz, mmw);
+         al_draw_textf(font, black, 5, 25, 0, "x %g, y %g, z %g, w %g", mx, my, mz, mw);
          al_draw_textf(font, black, 5, 45, 0, "p = %g", p);
          al_draw_textf(font, black, 5, 65, 0, "%s", in ? "in" : "out");
          al_draw_textf(font, black, 5, 85, 0, "wheel precision (PgUp/PgDn) %d", precision);
@@ -114,37 +114,37 @@ int main(int argc, char **argv)
 
       al_wait_for_event(queue, &event);
       switch (event.type) {
-         case ALLEGRO_EVENT_MOUSE_AXES:
-            mx = event.mouse.x;
-            my = event.mouse.y;
-            mz = event.mouse.z;
-            mw = event.mouse.w;
-            mmx = event.mouse.dx;
-            mmy = event.mouse.dy;
-            mmz = event.mouse.dz;
-            mmw = event.mouse.dw;
-            p = event.mouse.pressure;
+         case ALLEGRO_EVENT_MOUSE_AXES_FLOAT:
+            mx = event.mouse_float.x;
+            my = event.mouse_float.y;
+            mz = event.mouse_float.z;
+            mw = event.mouse_float.w;
+            mmx = event.mouse_float.dx;
+            mmy = event.mouse_float.dy;
+            mmz = event.mouse_float.dz;
+            mmw = event.mouse_float.dw;
+            p = event.mouse_float.pressure;
             break;
 
-         case ALLEGRO_EVENT_MOUSE_BUTTON_DOWN:
-            if (event.mouse.button-1 < NUM_BUTTONS) {
-               buttons[event.mouse.button-1] = true;
+         case ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT:
+            if (event.mouse_float.button-1 < NUM_BUTTONS) {
+               buttons[event.mouse_float.button-1] = true;
             }
             p = event.mouse.pressure;
             break;
 
-         case ALLEGRO_EVENT_MOUSE_BUTTON_UP:
-            if (event.mouse.button-1 < NUM_BUTTONS) {
-               buttons[event.mouse.button-1] = false;
+         case ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT:
+            if (event.mouse_float.button-1 < NUM_BUTTONS) {
+               buttons[event.mouse_float.button-1] = false;
             }
-            p = event.mouse.pressure;
+            p = event.mouse_float.pressure;
             break;
 
-         case ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY:
+         case ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY_FLOAT:
             in = true;
             break;
 
-         case ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY:
+         case ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY_FLOAT:
             in = false;
             break;
 

--- a/include/allegro5/events.h
+++ b/include/allegro5/events.h
@@ -49,7 +49,14 @@ enum
    ALLEGRO_EVENT_TOUCH_CANCEL                = 53,
    
    ALLEGRO_EVENT_DISPLAY_CONNECTED           = 60,
-   ALLEGRO_EVENT_DISPLAY_DISCONNECTED        = 61
+   ALLEGRO_EVENT_DISPLAY_DISCONNECTED        = 61,
+
+   ALLEGRO_EVENT_MOUSE_AXES_FLOAT            = 62,
+   ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT     = 63,
+   ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT       = 64,
+   ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY_FLOAT   = 65,
+   ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY_FLOAT   = 66,
+   ALLEGRO_EVENT_MOUSE_WARPED_FLOAT          = 67
 };
 
 
@@ -155,6 +162,24 @@ typedef struct ALLEGRO_MOUSE_EVENT
 
 
 
+typedef struct ALLEGRO_MOUSE_FLOAT_EVENT
+{
+   _AL_EVENT_HEADER(struct ALLEGRO_MOUSE)
+   struct ALLEGRO_DISPLAY *display;
+   /* (display) Window the event originate from
+    * (x, y) Primary mouse position
+    * (z) Mouse wheel position (1D 'wheel'), or,
+    * (w, z) Mouse wheel position (2D 'ball')
+    * (pressure) The pressure applied, for stylus (0 or 1 for normal mouse)
+    */
+   float x,  y,  z, w;
+   float dx, dy, dz, dw;
+   unsigned int button;
+   float pressure;
+} ALLEGRO_MOUSE_FLOAT_EVENT;
+
+
+
 typedef struct ALLEGRO_TIMER_EVENT
 {
    _AL_EVENT_HEADER(struct ALLEGRO_TIMER)
@@ -209,14 +234,15 @@ union ALLEGRO_EVENT
     * common to all event types, without using some specific type
     * structure.
     */
-   ALLEGRO_ANY_EVENT      any;
-   ALLEGRO_DISPLAY_EVENT  display;
-   ALLEGRO_JOYSTICK_EVENT joystick;
-   ALLEGRO_KEYBOARD_EVENT keyboard;
-   ALLEGRO_MOUSE_EVENT    mouse;
-   ALLEGRO_TIMER_EVENT    timer;
-   ALLEGRO_TOUCH_EVENT    touch;
-   ALLEGRO_USER_EVENT     user;
+   ALLEGRO_ANY_EVENT         any;
+   ALLEGRO_DISPLAY_EVENT     display;
+   ALLEGRO_JOYSTICK_EVENT    joystick;
+   ALLEGRO_KEYBOARD_EVENT    keyboard;
+   ALLEGRO_MOUSE_EVENT       mouse;
+   ALLEGRO_MOUSE_FLOAT_EVENT mouse_float;
+   ALLEGRO_TIMER_EVENT       timer;
+   ALLEGRO_TOUCH_EVENT       touch;
+   ALLEGRO_USER_EVENT        user;
 };
 
 

--- a/include/allegro5/internal/aintern_android.h
+++ b/include/allegro5/internal/aintern_android.h
@@ -155,9 +155,7 @@ jclass _al_android_image_loader_class(void);
 jclass _al_android_clipboard_class(void);
 jclass _al_android_apk_fs_class(void);
 
-void _al_android_generate_mouse_event(unsigned int type, int x, int y,
-   unsigned int button, ALLEGRO_DISPLAY *d);
-void _al_android_mouse_get_state(ALLEGRO_MOUSE_STATE *ret_state);
+void _al_android_mouse_get_state(ALLEGRO_MOUSE_FLOAT_STATE *ret_state);
 
 void _al_android_generate_accelerometer_event(float x, float y, float z);
 void _al_android_generate_joystick_axis_event(int index, int stick, int axis, float value);

--- a/include/allegro5/internal/aintern_iphone.h
+++ b/include/allegro5/internal/aintern_iphone.h
@@ -38,8 +38,6 @@ ALLEGRO_MOUSE_DRIVER *_al_get_iphone_mouse_driver(void);
 ALLEGRO_TOUCH_INPUT_DRIVER *_al_get_iphone_touch_input_driver(void);
 ALLEGRO_JOYSTICK_DRIVER *_al_get_iphone_joystick_driver(void);
 void _al_iphone_setup_opengl_view(ALLEGRO_DISPLAY *d, bool manage_backbuffer);
-//void _al_iphone_generate_mouse_event(unsigned int type,
-//   int x, int y, unsigned int button, ALLEGRO_DISPLAY *d);
 //void _al_iphone_generate_touch_event(unsigned int type, double timestamp, float x, float y, bool primary, ALLEGRO_DISPLAY *d);
 void _al_iphone_update_visuals(void);
 void _al_iphone_accelerometer_control(int frequency);

--- a/include/allegro5/internal/aintern_mouse.h
+++ b/include/allegro5/internal/aintern_mouse.h
@@ -9,6 +9,21 @@
 #endif
 
 
+
+typedef struct ALLEGRO_MOUSE_FLOAT_STATE
+{
+   /* Like ALLEGRO_MOUSE_STATE, but using floats. */
+   float x;
+   float y;
+   float z;
+   float w;
+   float more_axes[ALLEGRO_MOUSE_MAX_EXTRA_AXES];
+   int buttons;
+   float pressure;
+   struct ALLEGRO_DISPLAY *display;
+} ALLEGRO_MOUSE_FLOAT_STATE;
+
+
 typedef struct ALLEGRO_MOUSE_DRIVER
 {
    int  msedrv_id;
@@ -20,9 +35,9 @@ typedef struct ALLEGRO_MOUSE_DRIVER
    AL_METHOD(ALLEGRO_MOUSE*, get_mouse, (void));
    AL_METHOD(unsigned int, get_mouse_num_buttons, (void));
    AL_METHOD(unsigned int, get_mouse_num_axes, (void));
-   AL_METHOD(bool, set_mouse_xy, (ALLEGRO_DISPLAY *display, int x, int y));
-   AL_METHOD(bool, set_mouse_axis, (int which, int value));
-   AL_METHOD(void, get_mouse_state, (ALLEGRO_MOUSE_STATE *ret_state));
+   AL_METHOD(bool, set_mouse_xy, (ALLEGRO_DISPLAY *display, float x, float y));
+   AL_METHOD(bool, set_mouse_axis, (int which, float value));
+   AL_METHOD(void, get_mouse_state, (ALLEGRO_MOUSE_FLOAT_STATE *ret_state));
 } ALLEGRO_MOUSE_DRIVER;
 
 
@@ -33,6 +48,8 @@ struct ALLEGRO_MOUSE
 {
    ALLEGRO_EVENT_SOURCE es;
 };
+
+extern void _al_make_int_mouse_event(ALLEGRO_EVENT *event);
 
 
 #ifdef __cplusplus

--- a/src/android/android_mouse.c
+++ b/src/android/android_mouse.c
@@ -5,56 +5,12 @@
 
 typedef struct ALLEGRO_MOUSE_ANDROID {
     ALLEGRO_MOUSE parent;
-    ALLEGRO_MOUSE_STATE state;
+    ALLEGRO_MOUSE_FLOAT_STATE state;
 } ALLEGRO_MOUSE_ANDROID;
 
 static ALLEGRO_MOUSE_ANDROID the_mouse;
 
 static bool amouse_installed;
-
-/*
- *  Helper to generate a mouse event.
- */
-void _al_android_generate_mouse_event(unsigned int type, int x, int y,
-   unsigned int button, ALLEGRO_DISPLAY *d)
-{
-   ALLEGRO_EVENT event;
-   
-   _al_event_source_lock(&the_mouse.parent.es);
-
-   //_al_android_translate_from_screen(d, &x, &y);
-
-   the_mouse.state.x = x;
-   the_mouse.state.y = y;
-
-   if (type == ALLEGRO_EVENT_MOUSE_BUTTON_DOWN) {
-      the_mouse.state.buttons |= (1 << button);
-   }
-   else if (type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
-      the_mouse.state.buttons &= ~(1 << button);
-   }
-
-   the_mouse.state.pressure = the_mouse.state.buttons ? 1.0 : 0.0; // TODO
-
-   if (_al_event_source_needs_to_generate_event(&the_mouse.parent.es)) {
-      event.mouse.type = type;
-      event.mouse.timestamp = al_get_time();
-      event.mouse.display = d;
-      event.mouse.x = x;
-      event.mouse.y = y;
-      event.mouse.z = 0;
-      event.mouse.w = 0;
-      event.mouse.dx = 0; // TODO
-      event.mouse.dy = 0; // TODO
-      event.mouse.dz = 0; // TODO
-      event.mouse.dw = 0; // TODO
-      event.mouse.button = button;
-      event.mouse.pressure = the_mouse.state.pressure;
-      _al_event_source_emit_event(&the_mouse.parent.es, &event);
-   }
-
-   _al_event_source_unlock(&the_mouse.parent.es);
-}
 
 static void amouse_exit(void);
 static bool amouse_init(void)
@@ -93,7 +49,7 @@ static unsigned int amouse_get_mouse_num_axes(void)
 }
 
 /* Hard to accomplish on a touch screen. */
-static bool amouse_set_mouse_xy(ALLEGRO_DISPLAY *display, int x, int y)
+static bool amouse_set_mouse_xy(ALLEGRO_DISPLAY *display, float x, float y)
 {
     (void)display;
     (void)x;
@@ -101,7 +57,7 @@ static bool amouse_set_mouse_xy(ALLEGRO_DISPLAY *display, int x, int y)
     return false;
 }
 
-static bool amouse_set_mouse_axis(int which, int z)
+static bool amouse_set_mouse_axis(int which, float z)
 {
     (void)which;
     (void)z;

--- a/src/android/android_touch.c
+++ b/src/android/android_touch.c
@@ -31,7 +31,7 @@ static void android_touch_input_handle_cancel(int id, double timestamp,
 
 
 static ALLEGRO_TOUCH_INPUT_STATE touch_input_state;
-static ALLEGRO_MOUSE_STATE mouse_state;
+static ALLEGRO_MOUSE_FLOAT_STATE mouse_state;
 static ALLEGRO_TOUCH_INPUT touch_input;
 static bool installed = false;
 
@@ -91,8 +91,8 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
    }
 
    if (touch_input.mouse_emulation_mode != ALLEGRO_MOUSE_EMULATION_NONE) {
-      mouse_state.x = (int)x;
-      mouse_state.y = (int)y;
+      mouse_state.x = x;
+      mouse_state.y = y;
       if (type == ALLEGRO_EVENT_TOUCH_BEGIN)
          mouse_state.buttons++;
       else if (type == ALLEGRO_EVENT_TOUCH_END)
@@ -104,19 +104,19 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
       if (want_mouse_emulation_event) {
 
          switch (type) {
-            case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN; break;
+            case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT; break;
             case ALLEGRO_EVENT_TOUCH_CANCEL:
-            case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP;   break;
-            case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES;        break;
+            case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT;   break;
+            case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES_FLOAT;        break;
          }
    
          event.mouse.type      = type;
          event.mouse.timestamp = timestamp;
          event.mouse.display   = (ALLEGRO_DISPLAY*)disp;
-         event.mouse.x         = (int)x;
-         event.mouse.y         = (int)y;
-         event.mouse.dx        = (int)dx;
-         event.mouse.dy        = (int)dy;
+         event.mouse.x         = x;
+         event.mouse.y         = y;
+         event.mouse.dx        = dx;
+         event.mouse.dy        = dy;
          event.mouse.dz        = 0;
          event.mouse.dw        = 0;
          if (touch_input.mouse_emulation_mode != ALLEGRO_MOUSE_EMULATION_5_0_x) {
@@ -131,6 +131,8 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
             al_set_mouse_xy(event.mouse.display, event.mouse.x, event.mouse.y);
          }
    
+         _al_event_source_emit_event(&touch_input.mouse_emulation_es, &event);
+         _al_make_int_mouse_event(&event);
          _al_event_source_emit_event(&touch_input.mouse_emulation_es, &event);
       }
       _al_event_source_unlock(&touch_input.mouse_emulation_es);
@@ -390,7 +392,7 @@ ALLEGRO_TOUCH_INPUT_DRIVER *_al_get_android_touch_input_driver(void)
 }
 
 
-void _al_android_mouse_get_state(ALLEGRO_MOUSE_STATE *ret_state)
+void _al_android_mouse_get_state(ALLEGRO_MOUSE_FLOAT_STATE *ret_state)
 {
    _al_event_source_lock(&touch_input.es);
    *ret_state = mouse_state;

--- a/src/iphone/iphone_mouse.m
+++ b/src/iphone/iphone_mouse.m
@@ -5,56 +5,12 @@
 
 typedef struct ALLEGRO_MOUSE_IPHONE {
     ALLEGRO_MOUSE parent;
-    ALLEGRO_MOUSE_STATE state;
+    ALLEGRO_MOUSE_FLOAT_STATE state;
 } ALLEGRO_MOUSE_IPHONE;
 
 static ALLEGRO_MOUSE_IPHONE the_mouse;
 
 static bool imouse_installed;
-
-/*
- *  Helper to generate a mouse event.
- */
-void _al_iphone_generate_mouse_event(unsigned int type, int x, int y,
-   unsigned int button, ALLEGRO_DISPLAY *d)
-{
-   ALLEGRO_EVENT event;
-   
-   _al_event_source_lock(&the_mouse.parent.es);
-
-   _al_iphone_translate_from_screen(d, &x, &y);
-
-   the_mouse.state.x = x;
-   the_mouse.state.y = y;
-
-   if (type == ALLEGRO_EVENT_MOUSE_BUTTON_DOWN) {
-      the_mouse.state.buttons |= (1 << button);
-   }
-   else if (type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
-      the_mouse.state.buttons &= ~(1 << button);
-   }
-
-   the_mouse.state.pressure = the_mouse.state.buttons ? 1.0 : 0.0; // TODO
-
-   if (_al_event_source_needs_to_generate_event(&the_mouse.parent.es)) {
-      event.mouse.type = type;
-      event.mouse.timestamp = al_get_time();
-      event.mouse.display = d;
-      event.mouse.x = x;
-      event.mouse.y = y;
-      event.mouse.z = 0;
-      event.mouse.w = 0;
-      event.mouse.dx = 0; // TODO
-      event.mouse.dy = 0; // TODO
-      event.mouse.dz = 0; // TODO
-      event.mouse.dw = 0; // TODO
-      event.mouse.button = button;
-      event.mouse.pressure = the_mouse.state.pressure;
-      _al_event_source_emit_event(&the_mouse.parent.es, &event);
-   }
-
-   _al_event_source_unlock(&the_mouse.parent.es);
-}
 
 static void imouse_exit(void);
 static bool imouse_init(void)
@@ -93,7 +49,7 @@ static unsigned int imouse_get_mouse_num_axes(void)
 }
 
 /* Hard to accomplish on a touch screen. */
-static bool imouse_set_mouse_xy(ALLEGRO_DISPLAY *display, int x, int y)
+static bool imouse_set_mouse_xy(ALLEGRO_DISPLAY *display, float x, float y)
 {
     (void)display;
     (void)x;
@@ -101,26 +57,14 @@ static bool imouse_set_mouse_xy(ALLEGRO_DISPLAY *display, int x, int y)
     return false;
 }
 
-static bool imouse_set_mouse_axis(int which, int z)
+static bool imouse_set_mouse_axis(int which, float z)
 {
     (void)which;
     (void)z;
     return false;
 }
 
-/*
-static void imouse_get_state(ALLEGRO_MOUSE_STATE *ret_state)
-{
-    ASSERT(imouse_installed);
-    
-    _al_event_source_lock(&the_mouse.parent.es);
-    {
-        *ret_state = the_mouse.state;
-    }
-    _al_event_source_unlock(&the_mouse.parent.es);
-}
-*/
-void imouse_get_state(ALLEGRO_MOUSE_STATE *ret_state);
+void imouse_get_state(ALLEGRO_MOUSE_FLOAT_STATE *ret_state);
 
 static ALLEGRO_MOUSE_DRIVER iphone_mouse_driver = {
     AL_ID('I', 'P', 'H', 'O'),

--- a/src/iphone/iphone_touch_input.m
+++ b/src/iphone/iphone_touch_input.m
@@ -21,7 +21,7 @@
 
 
 static ALLEGRO_TOUCH_INPUT_STATE touch_input_state;
-static ALLEGRO_MOUSE_STATE mouse_state;
+static ALLEGRO_MOUSE_FLOAT_STATE mouse_state;
 static ALLEGRO_TOUCH_INPUT touch_input;
 static bool installed = false;
 
@@ -72,19 +72,19 @@ static void generate_touch_input_event(unsigned int type, double timestamp, int 
       if (want_mouse_emulation_event) {
 
          switch (type) {
-            case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN; break;
+            case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT; break;
             case ALLEGRO_EVENT_TOUCH_CANCEL:
-            case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP;   break;
-            case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES;        break;
+            case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT;   break;
+            case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES_FLOAT;        break;
          }
    
          event.mouse.type      = type;
          event.mouse.timestamp = timestamp;
          event.mouse.display   = (ALLEGRO_DISPLAY*)disp;
-         event.mouse.x         = (int)x;
-         event.mouse.y         = (int)y;
-         event.mouse.dx        = (int)dx;
-         event.mouse.dy        = (int)dy;
+         event.mouse.x         = x;
+         event.mouse.y         = y;
+         event.mouse.dx        = dx;
+         event.mouse.dy        = dy;
          event.mouse.dz        = 0;
          event.mouse.dw        = 0;
          if (touch_input.mouse_emulation_mode != ALLEGRO_MOUSE_EMULATION_5_0_x) {
@@ -100,13 +100,15 @@ static void generate_touch_input_event(unsigned int type, double timestamp, int 
          }
    
          _al_event_source_emit_event(&touch_input.mouse_emulation_es, &event);
+         _al_make_int_mouse_event(&event);
+         _al_event_source_emit_event(&touch_input.mouse_emulation_es, &event);
       }
 
-      mouse_state.x = (int)x;
-      mouse_state.y = (int)y;
-      if (type == ALLEGRO_EVENT_MOUSE_BUTTON_DOWN)
+      mouse_state.x = x;
+      mouse_state.y = y;
+      if (type == ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT)
          mouse_state.buttons |= id;
-      else if (type == ALLEGRO_EVENT_MOUSE_BUTTON_UP)
+      else if (type == ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT)
          mouse_state.buttons &= ~id;
 
       _al_event_source_unlock(&touch_input.mouse_emulation_es);
@@ -317,7 +319,7 @@ ALLEGRO_TOUCH_INPUT_DRIVER *_al_get_iphone_touch_input_driver(void)
     return &touch_input_driver;
 }
 
-void imouse_get_state(ALLEGRO_MOUSE_STATE *ret_state)
+void imouse_get_state(ALLEGRO_MOUSE_FLOAT_STATE *ret_state)
 {
    _al_event_source_lock(&touch_input.es);
    *ret_state = mouse_state;

--- a/src/mousenu.c
+++ b/src/mousenu.c
@@ -208,10 +208,22 @@ bool al_set_mouse_axis(int which, int value)
  */
 void al_get_mouse_state(ALLEGRO_MOUSE_STATE *ret_state)
 {
+   ALLEGRO_MOUSE_FLOAT_STATE ret_state_float;
+   int i;
    ASSERT(new_mouse_driver);
    ASSERT(ret_state);
 
-   new_mouse_driver->get_mouse_state(ret_state);
+   new_mouse_driver->get_mouse_state(&ret_state_float);
+
+   ret_state->x = (int)ret_state_float.x;
+   ret_state->y = (int)ret_state_float.y;
+   ret_state->z = (int)ret_state_float.z;
+   ret_state->w = (int)ret_state_float.w;
+   ret_state->buttons = ret_state_float.buttons;
+   ret_state->pressure = ret_state_float.pressure;
+   ret_state->display = ret_state_float.display;
+   for (i = 0; i < ALLEGRO_MOUSE_MAX_EXTRA_AXES; i++)
+      ret_state->more_axes[i] = (int)ret_state_float.more_axes[i];
 }
 
 
@@ -331,6 +343,53 @@ int al_get_mouse_wheel_precision(void)
    ALLEGRO_SYSTEM *alsys = al_get_system_driver();
    ASSERT(alsys);
    return alsys->mouse_wheel_precision;
+}
+
+
+
+void _al_make_int_mouse_event(ALLEGRO_EVENT *event)
+{
+   ALLEGRO_EVENT_TYPE new_type = 0;
+   ALLEGRO_EVENT old_event;
+   ASSERT(event);
+   old_event = *event;
+
+   switch (event->type) {
+      case ALLEGRO_EVENT_MOUSE_AXES_FLOAT:
+         new_type = ALLEGRO_EVENT_MOUSE_AXES;
+         break;
+      case ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT:
+         new_type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN;
+         break;
+      case ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT:
+         new_type = ALLEGRO_EVENT_MOUSE_BUTTON_UP;
+         break;
+      case ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY_FLOAT:
+         new_type = ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY;
+         break;
+      case ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY_FLOAT:
+         new_type = ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY;
+         break;
+      case ALLEGRO_EVENT_MOUSE_WARPED_FLOAT:
+         new_type = ALLEGRO_EVENT_MOUSE_WARPED;
+         break;
+      default:
+         ASSERT(0);
+   }
+
+   event->type = new_type;
+   event->mouse.x = (int)old_event.mouse_float.x;
+   event->mouse.y = (int)old_event.mouse_float.y;
+   event->mouse.z = (int)old_event.mouse_float.z;
+   event->mouse.w = (int)old_event.mouse_float.w;
+
+   event->mouse.dx = (int)old_event.mouse_float.dx;
+   event->mouse.dy = (int)old_event.mouse_float.dy;
+   event->mouse.dz = (int)old_event.mouse_float.dz;
+   event->mouse.dw = (int)old_event.mouse_float.dw;
+
+   event->mouse.button = old_event.mouse_float.button;
+   event->mouse.pressure = old_event.mouse_float.pressure;
 }
 
 /* vim: set sts=3 sw=3 et: */

--- a/src/sdl/sdl_mouse.c
+++ b/src/sdl/sdl_mouse.c
@@ -21,7 +21,7 @@ ALLEGRO_DEBUG_CHANNEL("SDL")
 typedef struct ALLEGRO_MOUSE_SDL
 {
    ALLEGRO_MOUSE mouse;
-   ALLEGRO_MOUSE_STATE state;
+   ALLEGRO_MOUSE_FLOAT_STATE state;
    ALLEGRO_DISPLAY *display;
 } ALLEGRO_MOUSE_SDL;
 
@@ -65,17 +65,17 @@ void _al_sdl_mouse_event(SDL_Event *e)
       d = find_display(e->window.windowID);
       float ratio = _al_sdl_get_display_pixel_ratio(d);
       if (e->window.event == SDL_WINDOWEVENT_ENTER) {
-         event.mouse.type = ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY;
-         SDL_GetMouseState(&event.mouse.x, &event.mouse.y);
-         event.mouse.x *= ratio;
-         event.mouse.y *= ratio;
+         event.mouse_float.type = ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY_FLOAT;
+         SDL_GetMouseState(&event.mouse_float.x, &event.mouse_float.y);
+         event.mouse_float.x *= ratio;
+         event.mouse_float.y *= ratio;
       }
       else {
-         event.mouse.type = ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY;
-         event.mouse.x = mouse->state.x;
-         event.mouse.y = mouse->state.y;
-         event.mouse.z = mouse->state.z;
-         event.mouse.w = mouse->state.w;
+         event.mouse_float.type = ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY_FLOAT;
+         event.mouse_float.x = mouse->state.x;
+         event.mouse_float.y = mouse->state.y;
+         event.mouse_float.z = mouse->state.z;
+         event.mouse_float.w = mouse->state.w;
       }
       mouse->display = e->window.event == SDL_WINDOWEVENT_ENTER ? d : NULL;
    }
@@ -86,15 +86,15 @@ void _al_sdl_mouse_event(SDL_Event *e)
       }
       d = find_display(e->motion.windowID);
       float ratio = d ? _al_sdl_get_display_pixel_ratio(d) : 1.0;
-      event.mouse.type = ALLEGRO_EVENT_MOUSE_AXES;
-      event.mouse.x = e->motion.x * ratio;
-      event.mouse.y = e->motion.y * ratio;
-      event.mouse.z = mouse->state.z;
-      event.mouse.w = mouse->state.w;
-      event.mouse.dx = e->motion.xrel * ratio;
-      event.mouse.dy = e->motion.yrel * ratio;
-      event.mouse.dz = 0;
-      event.mouse.dw = 0;
+      event.mouse_float.type = ALLEGRO_EVENT_MOUSE_AXES_FLOAT;
+      event.mouse_float.x = e->motion.x * ratio;
+      event.mouse_float.y = e->motion.y * ratio;
+      event.mouse_float.z = mouse->state.z;
+      event.mouse_float.w = mouse->state.w;
+      event.mouse_float.dx = e->motion.xrel * ratio;
+      event.mouse_float.dy = e->motion.yrel * ratio;
+      event.mouse_float.dz = 0;
+      event.mouse_float.dw = 0;
       mouse->state.x = e->motion.x * ratio;
       mouse->state.y = e->motion.y * ratio;
    }
@@ -104,17 +104,17 @@ void _al_sdl_mouse_event(SDL_Event *e)
          return;
       }
       d = find_display(e->wheel.windowID);
-      event.mouse.type = ALLEGRO_EVENT_MOUSE_AXES;
+      event.mouse_float.type = ALLEGRO_EVENT_MOUSE_AXES_FLOAT;
       mouse->state.z += al_get_mouse_wheel_precision() * e->wheel.y;
       mouse->state.w += al_get_mouse_wheel_precision() * e->wheel.x;
-      event.mouse.x = mouse->state.x;
-      event.mouse.y = mouse->state.y;
-      event.mouse.z = mouse->state.z;
-      event.mouse.w = mouse->state.w;
-      event.mouse.dx = 0;
-      event.mouse.dy = 0;
-      event.mouse.dz = al_get_mouse_wheel_precision() * e->wheel.y;
-      event.mouse.dw = al_get_mouse_wheel_precision() * e->wheel.x;
+      event.mouse_float.x = mouse->state.x;
+      event.mouse_float.y = mouse->state.y;
+      event.mouse_float.z = mouse->state.z;
+      event.mouse_float.w = mouse->state.w;
+      event.mouse_float.dx = 0;
+      event.mouse_float.dy = 0;
+      event.mouse_float.dz = al_get_mouse_wheel_precision() * e->wheel.y;
+      event.mouse_float.dw = al_get_mouse_wheel_precision() * e->wheel.x;
    }
    else {
       if (e->button.which == SDL_TOUCH_MOUSEID) {
@@ -124,29 +124,31 @@ void _al_sdl_mouse_event(SDL_Event *e)
       d = find_display(e->button.windowID);
       float ratio = d ? _al_sdl_get_display_pixel_ratio(d) : 1.0;
       switch (e->button.button) {
-         case SDL_BUTTON_LEFT: event.mouse.button = 1; break;
-         case SDL_BUTTON_RIGHT: event.mouse.button = 2; break;
-         case SDL_BUTTON_MIDDLE: event.mouse.button = 3; break;
-         case SDL_BUTTON_X1: event.mouse.button = 4; break;
-         case SDL_BUTTON_X2: event.mouse.button = 5; break;
+         case SDL_BUTTON_LEFT: event.mouse_float.button = 1; break;
+         case SDL_BUTTON_RIGHT: event.mouse_float.button = 2; break;
+         case SDL_BUTTON_MIDDLE: event.mouse_float.button = 3; break;
+         case SDL_BUTTON_X1: event.mouse_float.button = 4; break;
+         case SDL_BUTTON_X2: event.mouse_float.button = 5; break;
       }
-      event.mouse.x = e->button.x * ratio;
-      event.mouse.y = e->button.y * ratio;
-      event.mouse.z = mouse->state.z;
-      event.mouse.w = mouse->state.w;
+      event.mouse_float.x = e->button.x * ratio;
+      event.mouse_float.y = e->button.y * ratio;
+      event.mouse_float.z = mouse->state.z;
+      event.mouse_float.w = mouse->state.w;
       if (e->type == SDL_MOUSEBUTTONDOWN) {
-         event.mouse.type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN;
-         mouse->state.buttons |= 1 << (event.mouse.button - 1);
+         event.mouse_float.type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT;
+         mouse->state.buttons |= 1 << (event.mouse_float.button - 1);
       }
       if (e->type == SDL_MOUSEBUTTONUP) {
-         event.mouse.type = ALLEGRO_EVENT_MOUSE_BUTTON_UP;
-         mouse->state.buttons &= ~(1 << (event.mouse.button - 1));
+         event.mouse_float.type = ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT;
+         mouse->state.buttons &= ~(1 << (event.mouse_float.button - 1));
       }
    }
 
-   event.mouse.pressure = mouse->state.buttons ? 1.0 : 0.0; /* TODO */
-   event.mouse.display = d;
+   event.mouse_float.pressure = mouse->state.buttons ? 1.0 : 0.0; /* TODO */
+   event.mouse_float.display = d;
 
+   _al_event_source_emit_event(es, &event);
+   _al_make_int_mouse_event(&event);
    _al_event_source_emit_event(es, &event);
    _al_event_source_unlock(es);
 }
@@ -193,9 +195,9 @@ static bool sdl_set_mouse_axis(int which, int value)
    return true;
 }
 
-static void sdl_get_mouse_state(ALLEGRO_MOUSE_STATE *ret_state)
+static void sdl_get_mouse_state(ALLEGRO_MOUSE_FLOAT_STATE *ret_state)
 {
-   int x, y, i;
+   float x, y, i;
    float ratio = _al_sdl_get_display_pixel_ratio(mouse->display);
    ALLEGRO_SYSTEM_INTERFACE *sdl = _al_sdl_system_driver();
    sdl->heartbeat();

--- a/src/sdl/sdl_touch.c
+++ b/src/sdl/sdl_touch.c
@@ -28,7 +28,7 @@ typedef struct ALLEGRO_TOUCH_INPUT_SDL
 
 static ALLEGRO_TOUCH_INPUT_DRIVER *vt;
 static ALLEGRO_TOUCH_INPUT_SDL *touch_input;
-static ALLEGRO_MOUSE_STATE mouse_state;
+static ALLEGRO_MOUSE_FLOAT_STATE mouse_state;
 
 static void generate_touch_input_event(unsigned int type, double timestamp,
    int id, float x, float y, float dx, float dy, bool primary,
@@ -74,8 +74,8 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
    }
 
    if (touch_input->touch_input.mouse_emulation_mode != ALLEGRO_MOUSE_EMULATION_NONE) {
-      mouse_state.x = (int)x;
-      mouse_state.y = (int)y;
+      mouse_state.x = x;
+      mouse_state.y = y;
       if (type == ALLEGRO_EVENT_TOUCH_BEGIN)
          mouse_state.buttons++;
       else if (type == ALLEGRO_EVENT_TOUCH_END)
@@ -87,19 +87,19 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
       if (want_mouse_emulation_event) {
 
          switch (type) {
-            case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN; break;
+            case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT; break;
             case ALLEGRO_EVENT_TOUCH_CANCEL:
-            case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP;   break;
-            case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES;        break;
+            case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT;   break;
+            case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES_FLOAT;        break;
          }
 
          event.mouse.type      = type;
          event.mouse.timestamp = timestamp;
          event.mouse.display   = (ALLEGRO_DISPLAY*)disp;
-         event.mouse.x         = (int)x;
-         event.mouse.y         = (int)y;
-         event.mouse.dx        = (int)dx;
-         event.mouse.dy        = (int)dy;
+         event.mouse.x         = x;
+         event.mouse.y         = y;
+         event.mouse.dx        = dx;
+         event.mouse.dy        = dy;
          event.mouse.dz        = 0;
          event.mouse.dw        = 0;
          if (touch_input->touch_input.mouse_emulation_mode != ALLEGRO_MOUSE_EMULATION_5_0_x) {
@@ -114,6 +114,8 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
             al_set_mouse_xy(event.mouse.display, event.mouse.x, event.mouse.y);
          }
 
+         _al_event_source_emit_event(&touch_input->touch_input.mouse_emulation_es, &event);
+         _al_make_int_mouse_event(&event);
          _al_event_source_emit_event(&touch_input->touch_input.mouse_emulation_es, &event);
       }
       _al_event_source_unlock(&touch_input->touch_input.mouse_emulation_es);

--- a/src/win/wtouch_input.c
+++ b/src/win/wtouch_input.c
@@ -155,10 +155,10 @@ static void generate_touch_input_event(int type, double timestamp, int id, float
       ALLEGRO_MOUSE_STATE state;
 
       switch (type) {
-         case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN; break;
+         case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT; break;
          case ALLEGRO_EVENT_TOUCH_CANCEL:
-         case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP;   break;
-         case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES;        break;
+         case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT;   break;
+         case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES_FLOAT;        break;
       }
 
       al_get_mouse_state(&state);
@@ -166,12 +166,12 @@ static void generate_touch_input_event(int type, double timestamp, int id, float
       event.mouse.type      = type;
       event.mouse.timestamp = timestamp;
       event.mouse.display   = (ALLEGRO_DISPLAY*)win_disp;
-      event.mouse.x         = (int)x;
-      event.mouse.y         = (int)y;
+      event.mouse.x         = x;
+      event.mouse.y         = y;
       event.mouse.z         = state.z;
       event.mouse.w         = state.w;
-      event.mouse.dx        = (int)dx;
-      event.mouse.dy        = (int)dy;
+      event.mouse.dx        = dx;
+      event.mouse.dy        = dy;
       event.mouse.dz        = 0;
       event.mouse.dw        = 0;
       event.mouse.button    = 1;
@@ -180,6 +180,8 @@ static void generate_touch_input_event(int type, double timestamp, int id, float
       al_set_mouse_xy(event.mouse.display, event.mouse.x, event.mouse.y);
 
       _al_event_source_lock(&touch_input.mouse_emulation_es);
+      _al_event_source_emit_event(&touch_input.mouse_emulation_es, &event);
+      _al_make_int_mouse_event(&event);
       _al_event_source_emit_event(&touch_input.mouse_emulation_es, &event);
       _al_event_source_unlock(&touch_input.mouse_emulation_es);
    }

--- a/src/x/xtouch.c
+++ b/src/x/xtouch.c
@@ -39,7 +39,7 @@ ALLEGRO_DEBUG_CHANNEL("touch")
 /* the one and only touch object */
 static ALLEGRO_TOUCH_INPUT_STATE touch_input_state;
 static ALLEGRO_TOUCH_INPUT touch_input;
-static ALLEGRO_MOUSE_STATE mouse_state;
+static ALLEGRO_MOUSE_FLOAT_STATE mouse_state;
 static int touch_ids[ALLEGRO_TOUCH_INPUT_MAX_TOUCH_COUNT]; /* the XInput id for touches */
 static int primary_touch_id = -1;
 static bool installed = false;
@@ -101,8 +101,8 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
    }
 
    if (touch_input.mouse_emulation_mode != ALLEGRO_MOUSE_EMULATION_NONE) {
-      mouse_state.x = (int)x;
-      mouse_state.y = (int)y;
+      mouse_state.x = x;
+      mouse_state.y = y;
       if (type == ALLEGRO_EVENT_TOUCH_BEGIN)
          mouse_state.buttons++;
       else if (type == ALLEGRO_EVENT_TOUCH_END)
@@ -114,19 +114,19 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
       if (want_mouse_emulation_event) {
 
          switch (type) {
-            case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN; break;
+            case ALLEGRO_EVENT_TOUCH_BEGIN: type = ALLEGRO_EVENT_MOUSE_BUTTON_DOWN_FLOAT; break;
             case ALLEGRO_EVENT_TOUCH_CANCEL:
-            case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP;   break;
-            case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES;        break;
+            case ALLEGRO_EVENT_TOUCH_END:   type = ALLEGRO_EVENT_MOUSE_BUTTON_UP_FLOAT;   break;
+            case ALLEGRO_EVENT_TOUCH_MOVE:  type = ALLEGRO_EVENT_MOUSE_AXES_FLOAT;        break;
          }
 
          event.mouse.type      = type;
          event.mouse.timestamp = timestamp;
          event.mouse.display   = (ALLEGRO_DISPLAY*)disp;
-         event.mouse.x         = (int)x;
-         event.mouse.y         = (int)y;
-         event.mouse.dx        = (int)dx;
-         event.mouse.dy        = (int)dy;
+         event.mouse.x         = x;
+         event.mouse.y         = y;
+         event.mouse.dx        = dx;
+         event.mouse.dy        = dy;
          event.mouse.dz        = 0;
          event.mouse.dw        = 0;
          if (touch_input.mouse_emulation_mode != ALLEGRO_MOUSE_EMULATION_5_0_x) {
@@ -141,6 +141,8 @@ static void generate_touch_input_event(unsigned int type, double timestamp,
             al_set_mouse_xy(event.mouse.display, event.mouse.x, event.mouse.y);
          }
 
+         _al_event_source_emit_event(&touch_input.mouse_emulation_es, &event);
+         _al_make_int_mouse_event(&event);
          _al_event_source_emit_event(&touch_input.mouse_emulation_es, &event);
       }
       _al_event_source_unlock(&touch_input.mouse_emulation_es);


### PR DESCRIPTION
Now you can catch _FLOAT variants of mouse events which have floating
point coordinates. The regular mouse events are still emitted alongside
the new events.

I haven't added the corresponding floating point API for mouse state and
mouse warping, as it doesn't seem as urgent. We can add it later if
requested.

Fixes #1105