### PR TITLE
Move another method to the main thread

### DIFF
--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -2319,8 +2319,8 @@ static void set_icons(ALLEGRO_DISPLAY *display, int num_icons, ALLEGRO_BITMAP* b
    NSImage *image = NSImageFromAllegroBitmap(bitmap);
    (void)display;
    [NSApp performSelectorOnMainThread: @selector(setApplicationIconImage:)
-                           withObject: image
-                        waitUntilDone: YES];
+      withObject: image
+      waitUntilDone: YES];
    [image release];
    [pool drain];
 }

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -2318,7 +2318,9 @@ static void set_icons(ALLEGRO_DISPLAY *display, int num_icons, ALLEGRO_BITMAP* b
    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
    NSImage *image = NSImageFromAllegroBitmap(bitmap);
    (void)display;
-   [NSApp setApplicationIconImage: image];
+   [NSApp performSelectorOnMainThread: @selector(setApplicationIconImage:)
+                           withObject: image
+                        waitUntilDone: YES];
    [image release];
    [pool drain];
 }

--- a/src/macosx/system.m
+++ b/src/macosx/system.m
@@ -66,9 +66,9 @@ static void osx_tell_dock(void)
 {
    ProcessSerialNumber psn = { 0, kCurrentProcess };
    TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-    [[NSApplication sharedApplication] performSelectorOnMainThread: @selector(activateIgnoringOtherApps:)
-                                                        withObject: [NSNumber numberWithBool:YES]
-                                                     waitUntilDone: YES];
+   [[NSApplication sharedApplication] performSelectorOnMainThread: @selector(activateIgnoringOtherApps:)
+      withObject: [NSNumber numberWithBool:YES]
+      waitUntilDone: YES];
 }
 
 

--- a/src/macosx/system.m
+++ b/src/macosx/system.m
@@ -67,7 +67,7 @@ static void osx_tell_dock(void)
    ProcessSerialNumber psn = { 0, kCurrentProcess };
    TransformProcessType(&psn, kProcessTransformToForegroundApplication);
     [[NSApplication sharedApplication] performSelectorOnMainThread: @selector(activateIgnoringOtherApps:)
-                                                        withObject: YES
+                                                        withObject: [NSNumber numberWithBool:YES]
                                                      waitUntilDone: YES];
 }
 


### PR DESCRIPTION
`setApplicationIconImage:` needs to be run from the main thread (seen when running ex_icon under the debugger)
Also fixed calling `activateIgnoringOtherApps:` - if a method takes an argument that is not an `NSObject` it needs to be wrapped in an `NSObject` before using the `performSelectorOnMainThread:` mechanism.

(MacOS Mojave 10.14.6)
