### PR TITLE
4.4: fixed DirectInput not working under Wine

### DIFF
--- a/src/win/wkeybd.c
+++ b/src/win/wkeybd.c
@@ -689,7 +689,7 @@ static int key_dinput_init(void)
       goto Error;
 
    /* Create the keyboard device */
-   hr = IDirectInput_CreateDevice(key_dinput, &GUID_SysKeyboardEm2, &key_dinput_device, NULL);
+   hr = IDirectInput_CreateDevice(key_dinput, &GUID_SysKeyboard, &key_dinput_device, NULL);
    if (FAILED(hr))
       goto Error;
 

--- a/src/win/wmouse.c
+++ b/src/win/wmouse.c
@@ -615,7 +615,7 @@ static int mouse_dinput_init(void)
       goto Error;
 
    /* Create the mouse device */
-   hr = IDirectInput_CreateDevice(mouse_dinput, &GUID_SysMouseEm2, &mouse_dinput_device, NULL);
+   hr = IDirectInput_CreateDevice(mouse_dinput, &GUID_SysMouse, &mouse_dinput_device, NULL);
    if (FAILED(hr))
       goto Error;
 


### PR DESCRIPTION
Problem details are here: #1116

This reverts couple of changes from 234ac0ab5b5790ff6d63e0433c89007f491cefde which were not relevant to original commit, but broke DirectInput driver on Wine, because Em2 keyboard and mouse COM classes are not implemented.