### PR TITLE
Specify document encoding for allegro._tx

### DIFF
--- a/docs/src/allegro._tx
+++ b/docs/src/allegro._tx
@@ -23,6 +23,7 @@
 @man_shortdesc_force1=allegro
 @man_shortdesc_force2=Allegro game programming library.
 @$\input texinfo
+@$@documentencoding ISO-8859-1
 @$@setfilename allegro.inf
 @$@settitle Allegro Manual
 @$@setchapternewpage odd


### PR DESCRIPTION
The default encoding that texinfo uses is now UTF-8, so the document encoding needs to be specified to avoid build errors.

Encoding:
<pre>$ file docs/src/allegro._tx 
docs/src/allegro._tx: C source, ISO-8859 text
</pre>

Build error:
<pre>[ 35%] Built target makedoc
[ 36%] Generating info/allegro.info
utf8 "\xB0" does not map to Unicode at /home/mwillcock/pkg/share/texinfo/Texinfo/ParserNonXS.pm line 1796, <FH> line 18520.
Malformed UTF-8 character: \xb0 (unexpected continuation byte 0xb0, with no preceding start byte) in pattern match (m//) at /home/mwillcock/pkg/share/texinfo/Texinfo/ParserNonXS.pm line 3364.
Malformed UTF-8 character (fatal) at /home/mwillcock/pkg/share/texinfo/Texinfo/ParserNonXS.pm line 3364.
*** Error code 25</pre>