### PR TITLE
audio: Fix edge-case looping in Ogg Vorbis stream

### DIFF
--- a/addons/acodec/ogg.c
+++ b/addons/acodec/ogg.c
@@ -402,10 +402,13 @@ static size_t ogg_stream_update(ALLEGRO_AUDIO_STREAM *stream, void *data,
    
    if (stream->spl.loop == _ALLEGRO_PLAYMODE_STREAM_ONEDIR) {
       if (ctime + btime > extra->loop_end) {
+         const int frame_size = word_size * extra->vi->channels;
          read_length = (extra->loop_end - ctime) * rate * (double)word_size * (double)extra->vi->channels;
          if (read_length < 0)
             return 0;
-         read_length += read_length % word_size;
+         if (read_length % frame_size > 0) {
+           read_length += (frame_size - (read_length % frame_size));
+         }
       }
    }
    while (pos < (unsigned long)read_length) {


### PR DESCRIPTION
When playing an Ogg Vorbis stream, the loop case is handled partially
incorrectly. The number of channels in the stream was not taken into
account when advancing the next read length to a multiple of the frame
size. This problem manifests with carefully crafted (or accidentally
input) loop points.

Enhances commit 20ed5af76b2a1cd00fda3c3ceaa86e76366fb828.