### PR TITLE
fix wrong LC_ALL: x/xkeyboard.c Changes setlocale to  LC_CTYPE 

### DIFF
--- a/src/x/xkeyboard.c
+++ b/src/x/xkeyboard.c
@@ -707,7 +707,7 @@ static int x_keyboard_init(void)
 
 #ifdef ALLEGRO_XWINDOWS_WITH_XIM
    /* Otherwise we are restricted to ISO-8859-1 characters. */
-   if (setlocale(LC_ALL, "") == NULL) {
+   if (setlocale(LC_CTYPE, "") == NULL) {
       TRACE(PREFIX_W "Could not set default locale.\n");
    }
 


### PR DESCRIPTION
This fixes allegro changing the locale for LC_NUMERIC and more when installing keyboard in the x platform. This is for allegro 4.

Mention in the forums: https://www.allegro.cc/forums/thread/609919
Fixed in newer allegro: https://github.com/liballeg/allegro5/blob/ce68911b41684d6353b23ac06ec6cd6e913d87d1/src/x/xkeyboard.c#L743