### PR TITLE
allegro 4.4: fixes wrong assert in mouse.c in set_mouse_range

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -858,7 +858,7 @@ void set_mouse_range(int x1, int y1, int x2, int y2)
    ASSERT(x1 >= 0);
    ASSERT(y1 >= 0);
    ASSERT(x2 >= x1);
-   ASSERT(y2 >= y2);
+   ASSERT(y2 >= y1);
 
    if (!mouse_driver)
       return;


### PR DESCRIPTION
minor fix for a wrong assert in the mouse.c code when setting the mouse range in `set_mouse_range`.

It used to do this:
```C
ASSERT(y2 >= y2);
```

which doesn't make sense. To make sure the mouse boundaries are right the assert should be:

```C
ASSERT(y2 >= y1);
```

for a rectangle from (x1,y1) to (x2,y2).