### PR TITLE
Migrate to GTK3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y xvfb libvorbis-dev libtheora-dev libwebp-dev libphysfs-dev libopusfile-dev libdumb1-dev libflac-dev libpulse-dev libgtk2.0-dev pandoc libcurl4-nss-dev libenet-dev pulseaudio libasound2-dev libopenal-dev libgl1-mesa-dev libglu-dev;
+                  sudo apt-get install -y xvfb libvorbis-dev libtheora-dev libwebp-dev libphysfs-dev libopusfile-dev libdumb1-dev libflac-dev libpulse-dev libgtk-3-dev pandoc libcurl4-nss-dev libenet-dev pulseaudio libasound2-dev libopenal-dev libgl1-mesa-dev libglu-dev;
                   mkdir build
                   cd build
                   . ../tests/grab_bitmap_suites.sh

--- a/addons/native_dialog/CMakeLists.txt
+++ b/addons/native_dialog/CMakeLists.txt
@@ -37,7 +37,7 @@ if(WIN32)
 endif(WIN32)
 
 if(NOT SUPPORT_NATIVE_DIALOG AND SUPPORT_X11 AND NOT ALLEGRO_RASPBERRYPI)
-    pkg_check_modules(GTK gtk+-2.0)
+    pkg_check_modules(GTK gtk+-3.0)
     pkg_check_modules(GT gthread-2.0)
     if(GTK_FOUND AND GT_FOUND)
         list(APPEND NATIVE_DIALOG_SOURCES ${GTK_NATIVE_DIALOG_SOURCES})

--- a/addons/native_dialog/gtk_dialog.c
+++ b/addons/native_dialog/gtk_dialog.c
@@ -41,7 +41,7 @@ static void really_make_transient(GtkWidget *window, ALLEGRO_DISPLAY_XGLX *glx)
       parent = gdk_x11_window_foreign_new_for_display(gdk, glx->window);
 
    if (gdk_window != NULL)
-      gtk_window_set_transient_for(GTK_WINDOW(window), parent);
+      gdk_window_set_transient_for(gdk_window, parent);
 }
 
 static void realized(GtkWidget *window, gpointer data)

--- a/addons/native_dialog/gtk_dialog.c
+++ b/addons/native_dialog/gtk_dialog.c
@@ -1,4 +1,5 @@
 #include <gtk/gtk.h>
+#include <gdk/gdkx.h>
 
 #include "allegro5/allegro.h"
 #include "allegro5/allegro_native_dialog.h"
@@ -29,16 +30,19 @@ void _al_shutdown_native_dialog_addon(void)
    _al_gtk_set_display_overridable_interface(false);
 }
 
-
 static void really_make_transient(GtkWidget *window, ALLEGRO_DISPLAY_XGLX *glx)
 {
-   GdkDisplay *gdk = gdk_drawable_get_display(GDK_DRAWABLE(window->window));
-   GdkWindow *parent = gdk_window_lookup_for_display(gdk, glx->window);
-   if (!parent)
-      parent = gdk_window_foreign_new_for_display(gdk, glx->window);
-   gdk_window_set_transient_for(window->window, parent);
-}
 
+   GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
+   GdkDisplay *gdk = GDK_DISPLAY(gdk_window_get_display(gdk_window));
+
+   GdkWindow *parent = gdk_x11_window_lookup_for_display(gdk, glx->window);
+   if (!parent)
+      parent = gdk_x11_window_foreign_new_for_display(gdk, glx->window);
+
+   if (gdk_window != NULL)
+      gtk_window_set_transient_for(GTK_WINDOW(window), parent);
+}
 
 static void realized(GtkWidget *window, gpointer data)
 {

--- a/addons/native_dialog/gtk_dialog.c
+++ b/addons/native_dialog/gtk_dialog.c
@@ -51,7 +51,7 @@ void _al_gtk_make_transient(ALLEGRO_DISPLAY *display, GtkWidget *window)
    /* Set the current display window (if any) as the parent of the dialog. */
    ALLEGRO_DISPLAY_XGLX *glx = (void *)display;
    if (glx) {
-      if (!GTK_WIDGET_REALIZED(window))
+      if (!gtk_widget_get_realized(window))
          g_signal_connect(window, "realize", G_CALLBACK(realized), (void *)glx);
       else
          really_make_transient(window, glx);

--- a/addons/native_dialog/gtk_filesel.c
+++ b/addons/native_dialog/gtk_filesel.c
@@ -42,8 +42,8 @@ static gboolean create_gtk_file_dialog(gpointer data)
       gtk_file_chooser_dialog_new(al_cstr(fd->title),
                                   NULL,
                                   save ? GTK_FILE_CHOOSER_ACTION_SAVE : folder ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER : GTK_FILE_CHOOSER_ACTION_OPEN,
-                                  GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                                  save ? GTK_STOCK_SAVE : GTK_STOCK_OPEN, GTK_RESPONSE_ACCEPT, NULL);
+                                  "_Cancel", GTK_RESPONSE_CANCEL,
+                                  save ? "_Save" : "_Open", GTK_RESPONSE_ACCEPT, NULL);
 
    _al_gtk_make_transient(display, window);
 

--- a/addons/native_dialog/gtk_menu.c
+++ b/addons/native_dialog/gtk_menu.c
@@ -108,7 +108,7 @@ static GtkWidget *build_menu_item(ALLEGRO_MENU_ITEM *aitem)
       }
       else {
          /* always create an image menu item, in case the user ever sets an icon */
-         gitem = gtk_menu_item_new_with_label(al_cstr(caption));
+         gitem = gtk_menu_item_new_with_mnemonic(al_cstr(caption));
 
       }
       

--- a/addons/native_dialog/gtk_textlog.c
+++ b/addons/native_dialog/gtk_textlog.c
@@ -100,12 +100,6 @@ static gboolean create_native_text_log(gpointer data)
    gtk_container_add(GTK_CONTAINER(top), scroll);
    GtkWidget *view = gtk_text_view_new();
    gtk_text_view_set_editable(GTK_TEXT_VIEW(view), false);
-   if (textlog->flags & ALLEGRO_TEXTLOG_MONOSPACE) {
-      PangoFontDescription *font_desc;
-      font_desc = pango_font_description_from_string("Monospace");
-      gtk_widget_modify_font(view, font_desc);
-      pango_font_description_free(font_desc);
-   }
    gtk_container_add(GTK_CONTAINER(scroll), view);
    gtk_widget_show(view);
    gtk_widget_show(scroll);

--- a/addons/native_dialog/gtk_textlog.c
+++ b/addons/native_dialog/gtk_textlog.c
@@ -59,7 +59,7 @@ static gboolean textlog_key_press(GtkWidget *w, GdkEventKey *gevent,
    ALLEGRO_NATIVE_DIALOG *textlog = userdata;
    (void)w;
 
-   if (gevent->keyval == GDK_Escape) {
+   if (gevent->keyval == GDK_KEY_Escape) {
       emit_close_event(textlog, true);
    }
 

--- a/addons/native_dialog/gtk_textlog.c
+++ b/addons/native_dialog/gtk_textlog.c
@@ -80,6 +80,8 @@ static gboolean create_native_text_log(gpointer data)
 {
    Msg *msg = data;
    ALLEGRO_NATIVE_DIALOG *textlog = msg->dialog;
+   GtkCssProvider *css_provider;
+   GtkStyleContext *context;
 
    /* Create a new text log window. */
    GtkWidget *top = gtk_window_new(GTK_WINDOW_TOPLEVEL);
@@ -100,6 +102,17 @@ static gboolean create_native_text_log(gpointer data)
    gtk_container_add(GTK_CONTAINER(top), scroll);
    GtkWidget *view = gtk_text_view_new();
    gtk_text_view_set_editable(GTK_TEXT_VIEW(view), false);
+   gtk_widget_set_name(GTK_WIDGET(view), "native_text_log");
+   if (textlog->flags & ALLEGRO_TEXTLOG_MONOSPACE) {
+      css_provider = gtk_css_provider_new();
+      gtk_css_provider_load_from_data(GTK_CSS_PROVIDER(css_provider),
+                                      "#native_text_log {\n"
+                                      "   font: 11px 'Monospace';\n"
+                                      "}\n", -1, NULL);
+      context = gtk_widget_get_style_context(GTK_WIDGET(view));
+      gtk_style_context_add_provider(context, GTK_STYLE_PROVIDER(css_provider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+      g_object_unref(css_provider);
+   }
    gtk_container_add(GTK_CONTAINER(scroll), view);
    gtk_widget_show(view);
    gtk_widget_show(scroll);

--- a/addons/native_dialog/gtk_textlog.c
+++ b/addons/native_dialog/gtk_textlog.c
@@ -107,7 +107,7 @@ static gboolean create_native_text_log(gpointer data)
       css_provider = gtk_css_provider_new();
       gtk_css_provider_load_from_data(GTK_CSS_PROVIDER(css_provider),
                                       "#native_text_log {\n"
-                                      "   font: 11px 'Monospace';\n"
+                                      "   font-family: monospace;\n"
                                       "}\n", -1, NULL);
       context = gtk_widget_get_style_context(GTK_WIDGET(view));
       gtk_style_context_add_provider(context, GTK_STYLE_PROVIDER(css_provider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/addons/native_dialog/gtk_xgtk.c
+++ b/addons/native_dialog/gtk_xgtk.c
@@ -1,4 +1,5 @@
 #include <gtk/gtk.h>
+#include <gtk/gtkx.h>
 
 #include "allegro5/allegro.h"
 #include "allegro5/internal/aintern_native_dialog_cfg.h"
@@ -94,7 +95,7 @@ static gboolean do_create_display_hook(gpointer data)
    g_signal_connect(G_OBJECT(window), "configure-event",
       G_CALLBACK(xgtk_handle_configure_event), display);
 
-   vbox = gtk_vbox_new(FALSE, 0);
+   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
    gtk_container_add(GTK_CONTAINER(window), vbox);
 
    socket = gtk_socket_new();


### PR DESCRIPTION
Debian is working to reduce the dependencies on GTK2, and has posted a bug on the Allegro5-package:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=967247

I have done some work on this migrating to GTK3, and got some ways through - see the diffs here in this pull request.

The problems I have ran in to: 

First - and the biggest problem: I am not sure at all about how the function _really_make_transient_ should work. What I have in this pull request works for me, but chances are great that there's some other simpler method using internal Allegro calls. A my diff is now, works on my system, but it surely can be nicer.

Number two is regarding icons in GTK menus. GTK_STOCK_* icons has been deprecated, so in my work I have simply removed the icons here. 

Number three: Fonts in GTK uses GTK_STYLEs and css styling. In my case it affects the log window, which doesn't get a monospace font. Really minor problem to me.

Other than this, on my system this builds, and works alright in the testing I have made.

Please review and test my changes and help out with the _really_make_transient_ function. 
