### PR TITLE
Fixes DirectInput Joystick Lag Issue

### DIFF
--- a/include/allegro5/internal/aintern_wjoydxnu.h
+++ b/include/allegro5/internal/aintern_wjoydxnu.h
@@ -84,6 +84,17 @@ typedef struct ALLEGRO_JOYSTICK_DIRECTX
    char all_names[512]; /* button/stick/axis names with NUL terminators */
 } ALLEGRO_JOYSTICK_DIRECTX;
 
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  void _al_win_joystick_dinput_trigger_enumeration(void);
+#ifdef __cplusplus
+}
+#endif
+
+
 #endif
 
 /* vim: set sts=3 sw=3 et: */


### PR DESCRIPTION
As discussed in issue #1026, this fixes the joystick lag issue caused by frequently calling `IDirectInput8_EnumDevices()`. Instead, we register to receive notifications when devices are connected/disconnected. If we are notified of a device change, we notify the joystick thread to re-enumerate the devices.