### PR TITLE
Add support to generate projects with suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,10 @@
 
 # Set the project name.
 # We use C++ in a few cases.
-project(ALLEGRO C CXX)
+set(ALLEGRO_PROJECT_SUFFIX "" CACHE STRING "Project suffix")
+set(ALLEGRO_PROJECT_NAME "ALLEGRO" CACHE STRING "Project default name")
+
+project(${ALLEGRO_PROJECT_NAME}${ALLEGRO_PROJECT_SUFFIX} C CXX)
 
 cmake_minimum_required(VERSION 2.8.5 FATAL_ERROR)
 if(COMMAND cmake_policy)


### PR DESCRIPTION
So to create visual studio solutions like: ALLEGRO_PCCLIENT.sln, ALLEGRO_PCSERVER.sln.

Example:
cmake -B /build/pcserver -G "Visual Studio 15 2017" -DIS_SERVER=True -DALLEGRO_PROJECT_SUFFIX:STRING="_PCSERVER"