### PR TITLE
allegro 4.2: Sound Blaster 8-bit volume patch by Ron Novy

### DIFF
--- a/src/dos/sb.c
+++ b/src/dos/sb.c
@@ -566,7 +566,7 @@ static int sb_interrupt(void)
       sb_semaphore = TRUE;
 
       ENABLE();                              /* mix some more samples */
-      _mix_some_samples(sb_buf[sb_bufnum], _dos_ds, TRUE);
+      _mix_some_samples(sb_buf[sb_bufnum], _dos_ds, sb_16bit);
       DISABLE();
 
       sb_semaphore = FALSE;
@@ -931,8 +931,8 @@ static int sb_init(int input, int voices)
    if (_mixer_init(sb_dma_mix_size, _sound_freq, sb_stereo, sb_16bit, &digi_driver->voices) != 0)
       return -1;
 
-   _mix_some_samples(sb_buf[0], _dos_ds, TRUE);
-   _mix_some_samples(sb_buf[1], _dos_ds, TRUE);
+   _mix_some_samples(sb_buf[0], _dos_ds, sb_16bit);
+   _mix_some_samples(sb_buf[1], _dos_ds, sb_16bit);
 
    _enable_irq(_sound_irq);
    _install_irq(sb_int, sb_interrupt);
@@ -1156,8 +1156,8 @@ static void sb_rec_stop(void)
    sb_16bit = (sb_dsp_ver >= 0x400);
    _sound_dma = (sb_16bit) ? sb_dma16 : sb_dma8;
 
-   _mix_some_samples(sb_buf[0], _dos_ds, TRUE);
-   _mix_some_samples(sb_buf[1], _dos_ds, TRUE);
+   _mix_some_samples(sb_buf[0], _dos_ds, sb_16bit);
+   _mix_some_samples(sb_buf[1], _dos_ds, sb_16bit);
 
    sb_start();
 }


### PR DESCRIPTION
Fixes issue reported in Allegro.cc forums at this link: https://www.allegro.cc/forums/thread/596505 (Distorted playback of sound samples on Sound Blaster PRO cards in MS-DOS)

This was apparently supposed to be in the 4.2.3 release but was somehow never included.

Details:
> The SB driver is using the function _mix_some_samples from mixer.c and the function looks ok to me... So I think the problem is that the SB driver isn't setting the 'issigned' flag correctly when calling the function... From what I remember the 8-bit sample format for the sound blaster is unsigned... In the SB driver 'issigned' is being set to 'TRUE' for 8 bit sound and 16 bit sound. So if this truly is the problem there are two ways to fix it... You can program the SB to send unsigned data in 16-bit mode and set all the 'issigned' flags to 'FALSE' in SB.c or set the flag appropriately according to the number of bits being used... I think either way should work ok...