### PR TITLE
Generate links to example source code in the reference manual

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -15,7 +15,7 @@ mark_as_advanced(CTAGS)
 
 #-----------------------------------------------------------------------------#
 
-option(DOC_GIT_REF "Git ref to use for source links in the documentation. If empty, will query git for this." "")
+set(DOC_GIT_REF "" CACHE STRING "Git ref to use for source links in the documentation. If empty, will query git for this.")
 
 set(REAL_DOC_GIT_REF "")
 if(DOC_GIT_REF)

--- a/docs/Refman.cmake
+++ b/docs/Refman.cmake
@@ -78,7 +78,9 @@ set(LATEX_DIR ${CMAKE_CURRENT_BINARY_DIR}/latex)
 set(PDF_DIR ${CMAKE_CURRENT_BINARY_DIR}/pdf)
 
 set(PROTOS ${CMAKE_CURRENT_BINARY_DIR}/protos)
+set(API_EXAMPLES ${CMAKE_CURRENT_BINARY_DIR}/examples)
 set(PROTOS_TIMESTAMP ${PROTOS}.timestamp)
+set(EXAMPLES_DIR ${CMAKE_SOURCE_DIR}/examples)
 set(HTML_REFS ${CMAKE_CURRENT_BINARY_DIR}/html_refs)
 set(HTML_REFS_TIMESTAMP ${HTML_REFS}.timestamp)
 set(INDEX_ALL ${CMAKE_CURRENT_BINARY_DIR}/index_all.txt)
@@ -88,6 +90,7 @@ set(SCRIPT_DIR ${CMAKE_SOURCE_DIR}/docs/scripts)
 set(MAKE_PROTOS ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/make_protos)
 set(MAKE_HTML_REFS ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/make_html_refs)
 set(MAKE_INDEX ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/make_index)
+set(SCAN_EXAMPLES ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/scan_examples)
 set(MAKE_DOC ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/make_doc
     --pandoc "${PANDOC}"
     --protos ${PROTOS}
@@ -110,6 +113,7 @@ add_executable(insert_timestamp
    scripts/insert_timestamp.c
    ${DAWK_SOURCES})
 add_executable(make_search_index scripts/make_search_index.c ${DAWK_SOURCES})
+add_executable(scan_examples scripts/scan_examples.c ${DAWK_SOURCES})
 
 #-----------------------------------------------------------------------------#
 #
@@ -181,6 +185,41 @@ endif()
 
 #-----------------------------------------------------------------------------#
 #
+# API Examples
+#
+#-----------------------------------------------------------------------------#
+
+# Build a list of all the API entries. Then cross-reference these against
+# which of the example files make use of them.
+
+set(RESP ${CMAKE_CURRENT_BINARY_DIR}/ex_files)
+
+file(GLOB EXAMPLE_FILES
+  ${EXAMPLES_DIR}/*.c
+  ${EXAMPLES_DIR}/*.cpp)
+
+file(GLOB EXAMPLE_FILES_REL
+  RELATIVE ${CMAKE_SOURCE_DIR}
+  ${EXAMPLES_DIR}/*.c
+  ${EXAMPLES_DIR}/*.cpp)
+
+foreach(f IN LISTS EXAMPLE_FILES_REL)
+  string(APPEND multiline "${f}\n")
+endforeach()
+
+file(WRITE ${RESP} "${multiline}")
+
+add_custom_command(
+    OUTPUT ${API_EXAMPLES}
+    DEPENDS ${PROTOS}
+	    ${EXAMPLE_FILES}
+	    ${SCAN_EXAMPLES}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMAND ${SCAN_EXAMPLES} --protos ${PROTOS} "@${RESP}" > ${API_EXAMPLES}.t
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${API_EXAMPLES}.t ${API_EXAMPLES})
+
+#-----------------------------------------------------------------------------#
+#
 #   HTML
 #
 #-----------------------------------------------------------------------------#
@@ -239,12 +278,14 @@ if(WANT_DOCS_HTML)
                 ${CMAKE_CURRENT_BINARY_DIR}/inc.a.html
                 ${CMAKE_CURRENT_BINARY_DIR}/inc.z.html
                 ${SEARCH_INDEX_JS}
+		${API_EXAMPLES}
                 make_doc
                 insert_timestamp
             COMMAND
                 ${INSERT_TIMESTAMP} ${CMAKE_SOURCE_DIR}/include/allegro5/base.h > inc.timestamp.html
             COMMAND
                 ${MAKE_DOC}
+                --examples ${API_EXAMPLES}
                 --to html
                 --raise-sections
                 --include-before-body inc.a.html
@@ -266,13 +307,13 @@ if(WANT_DOCS_HTML)
             OUTPUT ${HTML_DIR}/images/${image}.png
             DEPENDS
                 ${SRC_REFMAN_DIR}/images/${image}.png
-            COMMAND 
+            COMMAND
                 "${CMAKE_COMMAND}" -E copy
                 "${SRC_REFMAN_DIR}/images/${image}.png" "${HTML_DIR}/images/${image}.png"
-            ) 
+            )
          list(APPEND HTML_IMAGES ${HTML_DIR}/images/${image}.png)
     endforeach(image)
-    
+
     add_custom_target(html ALL DEPENDS ${HTML_PAGES} ${HTML_IMAGES})
 
     foreach(file pandoc.css autosuggest.js)

--- a/docs/scripts/make_doc.c
+++ b/docs/scripts/make_doc.c
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || (_XOPEN_SOURCE >= 500)
+#if defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || (_XOPEN_SOURCE >= 500) || defined(__APPLE__)
    #include <unistd.h>
    #define USE_MKSTEMP 1
 #elif defined(_MSC_VER)
@@ -256,7 +256,7 @@ void call_pandoc(const char *input, const char *output,
       }
    }
 
-   sprintf(cmd, "\"%s\" %s %s %s --to %s --output %s",
+   sprintf(cmd, "\"%s\" %s %s %s --from markdown --to %s --output %s",
       pandoc, input_native, pandoc_options, extra_options, to_format, output);
    if (system(cmd) != 0) {
       d_abort("system call failed: ", cmd);

--- a/docs/scripts/make_doc.h
+++ b/docs/scripts/make_doc.h
@@ -15,6 +15,8 @@ extern dstr tmp_pandoc_output;
 
 const char *lookup_prototype(const char *name);
 const char *lookup_source(const char *name);
+const char *lookup_example(const char *name);
+const char* example_source(dstr buffer, const char *file_name, const char *line_number);
 extern void call_pandoc(const char *input, const char *output,
     const char *extra_options);
 extern void make_single_doc(int argc, char *argv[]);

--- a/docs/scripts/make_single.c
+++ b/docs/scripts/make_single.c
@@ -8,6 +8,9 @@ static void postprocess_latex(void);
 static void cat(void);
 static void print_sans_backslashes(const char *p);
 
+static void insert_examples(void);
+static char current_api[64];
+
 void make_single_doc(int argc, char *argv[])
 {
    d_init(argc, argv);
@@ -37,6 +40,12 @@ static void preprocess(void)
    dstr line;
 
    while (d_getline(line)) {
+      /* If this is a heading, a new section is about to start.
+	 Insert the pending code examples (if any) beforehand. */
+      if (line[0] == '#') {
+	 insert_examples();
+      }
+
       /* Raise sections by one level. Top-most becomes the document title. */
       if (line[0] == '#' && raise_sections) {
          if (line[1] == ' ') {
@@ -71,6 +80,7 @@ static void preprocess(void)
             d_printf("~~~~");
          }
          d_printf("\n[Source Code](%s)\n", source);
+	 strcpy(current_api, name);
       }
       else if (d_match(line, "^__ALLEGRO_5_CFG")) {
          char *allegro5_cfg = load_allegro5_cfg();
@@ -81,6 +91,8 @@ static void preprocess(void)
          d_print(line);
       }
    }
+   /* Finally insert any examples for the last section */
+   insert_examples();
 }
 
 static void postprocess_latex(void)
@@ -132,5 +144,35 @@ static void print_sans_backslashes(const char *p)
          fputc(*p, D_STDOUT);
    }
 }
+
+static void insert_examples(void) {
+   if (*current_api) {
+      const char* exs = lookup_example(current_api);
+      if (exs) {
+	 /* This will be of the form "FILE:LINE FILE:LINE FILE:LINE " */
+	 dstr items;
+	 char* pitem = strcpy(items, exs);
+	 d_print("Examples:\n");
+	 char* item;
+	 while ((item = strsep(&pitem, " ")) != NULL) {
+	    dstr buffer;
+	    char* filename = strsep(&item, ":");
+	    if (item) {
+	       dstr base;
+	       d_basename(filename, NULL, base);
+	       d_printf("* [%s](%s)\n",
+			base,
+			example_source(buffer, filename, item));
+	    }
+	 }
+	 d_print("");
+      }
+      strcpy(current_api, "");
+   }
+}
+
+/* Local Variables: */
+/* c-basic-offset: 3 */
+/* End: */
 
 /* vim: set sts=3 sw=3 et: */

--- a/docs/scripts/scan_examples.c
+++ b/docs/scripts/scan_examples.c
@@ -1,0 +1,229 @@
+/*
+ * scan_examples OPTIONS EXAMPLE-FILES
+ *
+ * Load a prototypes file containing API elements
+ * and scan files for examples using those elements
+ * Output is to standard output and comprises lines
+ * of the form "API: FILE:LINE FILE:LINE FILE:LINE"
+ * No more than 3 examples will be output for each
+ * API.
+ *
+ * Options are:
+ *    --protos PROTOS-FILE
+ *
+ * It is possible to use a response file to specify
+ * options or files. Including @FILENAME on the
+ * command line will read that file line-by-line
+ * and insert each line as if it were specified on
+ * the command line. This is to avoid very long
+ * command lines.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "dawk.h"
+
+#define SL_INITIAL_CAPACITY 64
+#define EXAMPLES_PER_API 3
+
+static dstr protos;
+
+typedef struct {
+  char **items;
+  int count;
+  int capacity;
+} slist_t;
+
+static void sl_init(slist_t *);
+static void sl_free(slist_t *);
+static void sl_clear(slist_t *);
+static void sl_append(slist_t *, const char *);
+
+static void cleanup(void);
+static void load_api_list(void);
+static slist_t apis;
+
+static char **responsefile(int* pargc, char **argv);
+
+
+/* Table of which APIs are in which examples */
+static int *table;
+/* Lookup to index the best examples */
+typedef struct {
+   /* Index into table */
+   int index;
+   /* How many APIs are used in each example */
+   int count;
+} lookup_t;
+static lookup_t *lookup;
+static int compare(const void *pa, const void *pb) {
+   return ((const lookup_t *) pa)->count - ((const lookup_t *) pb)->count;
+}
+
+int main(int argc, char* argv[])
+{
+  dstr line;
+  int i, j;
+  argv = responsefile(&argc, argv);
+  /* Handle --protos flag */
+  if (argc >=3 && strcmp(argv[1], "--protos") == 0) {
+     strcpy(protos, argv[2]);
+     argc -= 2;
+     memmove(&argv[1], &argv[3], argc * sizeof(char*));
+  } else {
+     strcpy(protos, "protos");
+  }
+  d_cleanup = cleanup;
+  sl_init(&apis);
+  load_api_list();
+  table = calloc(apis.count * argc, sizeof(int));
+
+  lookup = calloc(argc, sizeof(lookup_t));
+  for (j = 0; j < argc; ++j) {
+     lookup[j].index = j;
+  }
+
+  for (j = 1; j < argc; ++j) {
+    d_open_input(argv[j]);
+    while (d_getline(line)) {
+      for (i = 0; i < apis.count; ++i) {
+	if (strstr(line, apis.items[i])) {
+	  int *ptr = &table[i + j * apis.count];
+	  if (*ptr == 0) {
+	    *ptr = d_line_num;
+	    ++lookup[j].count;
+	  }
+	}
+      }
+    }
+    d_close_input();
+  }
+  /* Sort the files */
+  qsort(lookup, argc, sizeof(lookup_t), compare);
+  /* Output the EXAMPLES_PER_API (three) 'best' examples */
+  for (i = 0; i < apis.count; ++i) {
+     int found = 0;
+     for (j = 0; j < argc && found < EXAMPLES_PER_API; ++j) {
+	int index = lookup[j].index;
+	int line_num = table[i + index * apis.count];
+	if (line_num != 0) {
+	   if (found == 0) {
+	      d_printf("%s: ", apis.items[i]);
+	   }
+	   ++found;
+	   d_printf("%s:%d ", argv[index], line_num);
+	}
+     }
+     if (found > 0) {
+	d_print("\n");
+     }
+  }
+  d_cleanup();
+  return 0;
+}
+
+void cleanup(void)
+{
+  free(table);
+  free(lookup);
+  sl_free(&apis);
+}
+
+void sl_init(slist_t* s)
+{
+  s->items = NULL;
+  s->count = s->capacity = 0;
+}
+
+void sl_append(slist_t *s, const char *item)
+{
+  if (s->count == s->capacity) {
+    int capacity = s->capacity == 0 ? SL_INITIAL_CAPACITY : (s->capacity * 2);
+    s->items = realloc(s->items, capacity * sizeof(char*));
+    s->capacity = capacity;
+  }
+  s->items[s->count++] = strcpy(malloc(1+strlen(item)), item);
+}
+
+void sl_free(slist_t *s)
+{
+   sl_clear(s);
+   free(s->items);
+   s->items = NULL;
+   s->capacity = 0;
+}
+
+void sl_clear(slist_t *s)
+{
+   int i;
+   for (i = 0; i < s->count; ++i) {
+      free(s->items[i]);
+   }
+   s->count = 0;
+}
+void load_api_list(void)
+{
+   dstr line;
+   d_open_input(protos);
+   while (d_getline(line)) {
+      int i;
+      bool found = false;
+      char *ptr = line;
+      strsep(&ptr, ":");
+      for (i = apis.count - 1; i >=0; --i) {
+	 if (strcmp(line, apis.items[i]) == 0) {
+	    found = true;
+	    break;
+	 }
+      }
+      if (!found) {
+	 sl_append(&apis, line);
+      }
+   }
+  d_close_input();
+}
+
+/* Re-process the command line args by loading any response files */
+char **responsefile(int *pargc, char **argv)
+{
+   static slist_t args;
+   static char** new_argv;
+   int argc = *pargc;
+   int i;
+   bool found_at = false;
+   for (i = 1; i < argc; ++i) {
+      if (*argv[i] == '@') {
+	 found_at = true;
+	 break;
+      }
+   }
+   if (!found_at) {
+      /* Nothing to do */
+      return argv;
+   }
+   sl_clear(&args);
+   for (i = 0; i < argc; ++i) {
+      if (*argv[i] == '@') {
+	 d_open_input(argv[i] + 1);
+	 dstr line;
+	 while (d_getline(line)) {
+	    sl_append(&args, line);
+	 }
+	 d_close_input();
+      } else {
+	 sl_append(&args, argv[i]);
+      }
+   }
+   /* Make a copy because code might alter the argv array */
+   new_argv = realloc(new_argv, args.count * sizeof(char*));
+   memcpy(new_argv, args.items, args.count * sizeof(char*));
+   *pargc = args.count;
+   return new_argv;
+}
+
+
+
+/* Local Variables: */
+/* c-basic-offset: 3 */
+/* End: */
+/* vim: set sts=3 sw=3 et: */


### PR DESCRIPTION
Please can you have a look at this? It
1. Uses the already generated `protos` file to get the API entries
2. Scans for each entry in all the examples and picks the best 3 examples for each one
3. Inserts these into the generated reference manual markdown pages, which are later converted to HTML

The first two items needed a new executable `scan_examples` and the last was by modifying the existing `make_doc`.

Tested on Debian and MacOS (not Windows) - in particular I'm not sure I got the CMake dependencies right so that it rebuilds when necessary, and never otherwise.

Fix for #1178 