### PR TITLE
add a new display flag ALLEGRO_OPENGL_CORE_PROFILE

### DIFF
--- a/docs/src/refman/display.txt
+++ b/docs/src/refman/display.txt
@@ -160,6 +160,13 @@ ALLEGRO_OPENGL_ES_PROFILE
     Note: Currently this is only supported by the X11/GLX driver.
     Since: 5.1.13
 
+ALLEGRO_OPENGL_CORE_PROFILE
+:   Used together with ALLEGRO_OPENGL, requests that the OpenGL context
+    uses the OpenGL Core profile. A specific version can be requested
+    with [al_set_new_display_option].
+    Note: Currently this is only supported by the X11/GLX driver.
+    Since: 5.2.7
+
 ALLEGRO_DIRECT3D
 :   Require the driver to do rendering with Direct3D and
     provide a Direct3D device.

--- a/include/allegro5/display.h
+++ b/include/allegro5/display.h
@@ -27,6 +27,7 @@ enum {
    ALLEGRO_GTK_TOPLEVEL_INTERNAL       = 1 << 12,
    ALLEGRO_MAXIMIZED                   = 1 << 13,
    ALLEGRO_OPENGL_ES_PROFILE           = 1 << 14,
+   ALLEGRO_OPENGL_CORE_PROFILE         = 1 << 15,
 };
 
 /* Possible parameters for al_set_display_option.

--- a/src/opengl/ogl_bitmap.c
+++ b/src/opengl/ogl_bitmap.c
@@ -780,10 +780,9 @@ static ALLEGRO_LOCKED_REGION *ogl_lock_compressed_region(ALLEGRO_BITMAP *bitmap,
     * See also pitfalls 7 & 8 from:
     * http://www.opengl.org/resources/features/KilgardTechniques/oglpitfall/
     */
-#ifdef GL_CLIENT_PIXEL_STORE_BIT
-   glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT);
-#endif
-   {
+   int previous_alignment;
+   glGetIntegerv(GL_PACK_ALIGNMENT, &previous_alignment);
+   if (previous_alignment != 1) {
       glPixelStorei(GL_PACK_ALIGNMENT, 1);
       e = glGetError();
       if (e) {
@@ -842,9 +841,9 @@ static ALLEGRO_LOCKED_REGION *ogl_lock_compressed_region(ALLEGRO_BITMAP *bitmap,
       }
    }
 
-#ifdef GL_CLIENT_PIXEL_STORE_BIT
-   glPopClientAttrib();
-#endif
+   if (previous_alignment != 1) {
+      glPixelStorei(GL_PACK_ALIGNMENT, previous_alignment);
+   }
 
    if (old_disp != NULL) {
       _al_set_current_display_only(old_disp);
@@ -908,10 +907,9 @@ static void ogl_unlock_compressed_region(ALLEGRO_BITMAP *bitmap)
    }
 
    /* Keep this in sync with ogl_lock_compressed_region. */
-#ifdef GL_CLIENT_PIXEL_STORE_BIT
-   glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT);
-#endif
-   {
+   int previous_alignment;
+   glGetIntegerv(GL_UNPACK_ALIGNMENT, &previous_alignment);
+   if (previous_alignment != 1) {
       glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
       e = glGetError();
       if (e) {
@@ -934,9 +932,9 @@ static void ogl_unlock_compressed_region(ALLEGRO_BITMAP *bitmap)
          _al_pixel_format_name(lock_format), _al_gl_error_string(e));
    }
 
-#ifdef GL_CLIENT_PIXEL_STORE_BIT
-   glPopClientAttrib();
-#endif
+   if (previous_alignment != 1) {
+      glPixelStorei(GL_UNPACK_ALIGNMENT, previous_alignment);
+   }
 
    if (old_disp) {
       _al_set_current_display_only(old_disp);


### PR DESCRIPTION
This adds a new display flag, just like the existing ALLEGRO_OPENGL_ES_PROFILE but instead of "ES" requests the "core" profile. I do not have a specific use for this feature at the moment but it's something also supported by SDL and I believe is required on MacOS to use any OpenGL past version 2.x. Currently only implemented for X11.

This PR also fixes Allegro to work with an OpenGL core profile (on all platforms). Most of the work was already done when it was made to work with the ES profile in the past - there just was 4 uses of a "glPushClientAttrib" function which does not exist in the core profile - I replaced its use with an explicit query and restore instead.

With this all examples and tests still work like normal, and all the examples I tried now even work when requesting OpenGL 3.2 with core profile. (To test it's enough to add ALLEGRO_OPENGL | ALLEGRO_OPENGL_3_0 | ALLEGRO_OPENGL_ES_PROFILE to the display flags, that will automatically also set the minimum version to 3.2.)