### PR TITLE
Fix compile warning in al_findfirst (src/dos/dfile.c)

### DIFF
--- a/src/dos/dfile.c
+++ b/src/dos/dfile.c
@@ -144,7 +144,7 @@ int al_findfirst(AL_CONST char *pattern, struct al_ffblk *info, int attrib)
 
    if (!ff_data) {
       *allegro_errno = ENOMEM;
-      return NULL;
+      return -1;
    }
 
    /* attach it to the info structure */


### PR DESCRIPTION
This function is returning `NULL` when hitting an out-of-memory error, but it is supposed to return `int`.  The correct "error" return code for this function is `-1`.