### PR TITLE
allegro4: xwin.c: fix broken xwin_set_window_name

### DIFF
--- a/src/x/xwin.c
+++ b/src/x/xwin.c
@@ -2722,10 +2722,10 @@ static void _xwin_private_set_window_name(AL_CONST char *name, AL_CONST char *gr
    else
       _al_sane_strncpy(_xwin.application_class, group, sizeof(_xwin.application_class));
 
-   if (_xwin.window != None) {
+   if (_xwin.wm_window != None) {
       hint.res_name = _xwin.application_name;
       hint.res_class = _xwin.application_class;
-      XSetClassHint(_xwin.display, _xwin.window, &hint);
+      XSetClassHint(_xwin.display, _xwin.wm_window, &hint);
    }
 }
 


### PR DESCRIPTION
Commit f05270883f2b4382b79ea3248d985938cd9934dc that introduced the use of three windows
broke xwin_set_window_name.

Adopt the same approach as commit 2e64350d03ff958960c3ccf4c2cc87437727afea
and fix this by setting the Class Hints for the managed window instead of
the real window.