### PR TITLE
Allow minimum bitmap size to be something other than 16 on non-Android platforms

### DIFF
--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -32,6 +32,13 @@ config_selection=new
 # card.
 prim_d3d_legacy_detection=default
 
+# For compatibility reasons, video bitmaps smaller than this size are
+# backed by textures with this size. This is often no longer necessary
+# on more modern systems, and should be set to < 16 if you're creating
+# bitmaps smaller than this size. Note that on Android, this is ignored
+# if smaller than 32.
+min_bitmap_size=16
+
 [audio]
 
 # Driver can be 'default', 'openal', 'alsa', 'oss', 'pulseaudio' or 'directsound'

--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -456,7 +456,9 @@ relevant if you plan to use this bitmap with the primitives addon. If
 you try to create a bitmap smaller than this, this call will not fail
 but the returned bitmap will be a section of a larger bitmap with the
 minimum size. The minimum size that will work on all platforms is 32 by
-32.
+32. There is an experimental switch to turns this padding off by editing
+the system configuration (see `min_bitmap_size` key in
+[al_get_system_config]).
 
 Some platforms do not directly support display bitmaps whose dimensions
 are not powers of two. Allegro handles this by creating a larger bitmap

--- a/include/allegro5/internal/aintern_system.h
+++ b/include/allegro5/internal/aintern_system.h
@@ -59,6 +59,7 @@ struct ALLEGRO_SYSTEM
    _AL_VECTOR displays; /* Keep a list of all displays attached to us. */
    ALLEGRO_PATH *user_exe_path;
    int mouse_wheel_precision;
+   int min_bitmap_size;
    bool installed;
 };
 

--- a/src/opengl/ogl_bitmap.c
+++ b/src/opengl/ogl_bitmap.c
@@ -1025,6 +1025,7 @@ ALLEGRO_BITMAP *_al_ogl_create_bitmap(ALLEGRO_DISPLAY *d, int w, int h,
    int true_h;
    int block_width;
    int block_height;
+   ALLEGRO_SYSTEM *system = al_get_system_driver();
    (void)d;
 
    format = _al_get_real_pixel_format(d, format);
@@ -1053,8 +1054,8 @@ ALLEGRO_BITMAP *_al_ogl_create_bitmap(ALLEGRO_DISPLAY *d, int w, int h,
     * work with them on some of these chips. This is a
     * workaround.
     */
-   if (true_w < 16) true_w = 16;
-   if (true_h < 16) true_h = 16;
+   if (true_w < system->min_bitmap_size) true_w = system->min_bitmap_size;
+   if (true_h < system->min_bitmap_size) true_h = system->min_bitmap_size;
 
    /* glReadPixels requires 32 byte aligned rows */
    if (IS_ANDROID) {

--- a/src/system.c
+++ b/src/system.c
@@ -264,6 +264,10 @@ bool al_install_system(int version, int (*atexit_ptr)(void (*)(void)))
    active_sysdrv = real_system;
    active_sysdrv->mouse_wheel_precision = 1;
 
+   const char *min_bitmap_size = al_get_config_value(
+      al_get_system_config(), "graphics", "min_bitmap_size");
+   active_sysdrv->min_bitmap_size = min_bitmap_size ? atoi(min_bitmap_size) : 16;
+
    ALLEGRO_INFO("Allegro version: %s\n", ALLEGRO_VERSION_STR);
 
    if (strcmp(al_get_app_name(), "") == 0) {

--- a/src/win/d3d_bmp.cpp
+++ b/src/win/d3d_bmp.cpp
@@ -667,6 +667,7 @@ void _al_d3d_refresh_texture_memory(ALLEGRO_DISPLAY *display)
 static bool d3d_upload_bitmap(ALLEGRO_BITMAP *bitmap)
 {
    ALLEGRO_BITMAP_EXTRA_D3D *d3d_bmp = get_extra(bitmap);
+   ALLEGRO_SYSTEM *system = al_get_system_driver();
    int bitmap_format = al_get_bitmap_format(bitmap);
    int system_format = d3d_bmp->system_format;
    int block_width = al_get_pixel_block_width(bitmap_format);
@@ -699,8 +700,8 @@ static bool d3d_upload_bitmap(ALLEGRO_BITMAP *bitmap)
       }
 
       // Some cards/drivers don't like small textures
-      if (d3d_bmp->texture_w < 16) d3d_bmp->texture_w = 16;
-      if (d3d_bmp->texture_h < 16) d3d_bmp->texture_h = 16;
+      if (d3d_bmp->texture_w < system->min_bitmap_size) d3d_bmp->texture_w = system->min_bitmap_size;
+      if (d3d_bmp->texture_h < system->min_bitmap_size) d3d_bmp->texture_h = system->min_bitmap_size;
 
       ASSERT(d3d_bmp->texture_w % block_width == 0);
       ASSERT(d3d_bmp->texture_h % block_height == 0);


### PR DESCRIPTION
Fixes #1210