### PR TITLE
enable logs and fix al_get_next_event for emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,12 @@ option(WANT_EXAMPLES "Build example programs" on)
 option(WANT_POPUP_EXAMPLES "Use popups instead of printf for fatal errors" on)
 option(WANT_TESTS "Build test programs" on)
 
+option(WANT_NO_THREADS "Do not use threads (only useful for emscripten without web workers)" off)
+
+if(WANT_NO_THREADS)
+    set(ALLEGRO_NO_THREADS 1)
+endif()
+
 #-----------------------------------------------------------------------------#
 #
 #   Set up compilers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,10 +204,10 @@ option(WANT_EXAMPLES "Build example programs" on)
 option(WANT_POPUP_EXAMPLES "Use popups instead of printf for fatal errors" on)
 option(WANT_TESTS "Build test programs" on)
 
-option(WANT_NO_THREADS "Do not use threads (only useful for emscripten without web workers)" off)
+option(WANT_WAIT_EVENT_SLEEP "Use sleep instead of threads in al_wait_for_event (only useful for emscripten without web workers)" off)
 
-if(WANT_NO_THREADS)
-    set(ALLEGRO_NO_THREADS 1)
+if(WANT_WAIT_EVENT_SLEEP)
+    set(ALLEGRO_WAIT_EVENT_SLEEP 1)
 endif()
 
 #-----------------------------------------------------------------------------#

--- a/README_sdl.txt
+++ b/README_sdl.txt
@@ -1,0 +1,102 @@
+SDL
+===
+
+This is an experimental port which uses SDL2 to create the Allegro
+window and OpenGL context.
+
+
+Dependencies
+------------
+
+SDL2 is required.
+
+
+Building
+--------
+
+Pass -D ALLEGRO_SDL=on to cmake to enable building for SDL2.
+
+
+Limitations
+-----------
+
+SDL2 requires calling SDL_PumpEvents() from the main thread regularly to
+generate events. Currently Allegro5 makes those calls from the timer
+subsystem - so as long as you have any timers running things will work
+fine. If your Allegro 5 program uses no timers it may get stuck because
+no SDL2 events can be received.
+
+
+Emscripten
+----------
+
+One reason the SDL2 port is useful is that it allows running Allegro on
+platforms not supported directly by Allegro, such as Emscripten. This is
+even more experimental but here are some example steps that will compile
+most of the examples for running in a web browser:
+
+1. Make sure to set up the emscripten environment by running the
+
+emsdk_env.sh
+
+or equivalent as provided by emscripten.
+
+2. The "--preload-file data" option below includes a folder named "data"
+with each binary, so we make sure each example and demo has such a
+folder:
+
+( cd examples; ln -s {path-to-allegro-source-folder}/examples/data )
+mkdir demos/speed/data
+touch demos/speed/data/nothing.txt
+
+3. Create a build folder and configure CMake, using emcmake
+
+mkdir build_emscripten
+cd build_emscripten
+
+USE_FLAGS=(
+    -s USE_FREETYPE=1
+    -s USE_VORBIS=1
+    -s USE_OGG=1
+    -s USE_LIBJPEG=1
+    -s USE_SDL=2
+    -s USE_LIBPNG=1
+    -s FULL_ES2=1
+    -s ASYNCIFY
+    -s TOTAL_MEMORY=2147418112
+    -O3
+    )
+
+emcmake cmake {path-to-allegro-source-folder}
+    -D CMAKE_BUILD_TYPE=Release
+    -D ALLEGRO_SDL=ON
+    -D SHARED=OFF
+    -D WANT_MONOLITH=ON
+    -D WANT_ALLOW_SSE=OFF
+    -D WANT_DOCS=OFF
+    -D WANT_TESTS=OFF
+    -D WANT_OPENAL=OFF
+    -D ALLEGRO_WAIT_EVENT_SLEEP=ON
+     # not sure why these are not found automatically with emcmake, so
+     # we use a  hack - we manually specify the cache path, so cmake
+     # will fail on first run in the compile test but populate the cache
+     # (from the -s options) and on second run it all works
+    -D SDL2_INCLUDE_DIR=$EM_CACHE/include
+    -D PNG_PNG_INCLUDE_DIR=$EM_CACHE/include
+    -D PNG_LIBRARY=$EM_CACHE/wasm/libpng.a
+    -D JPEG_INCLUDE_DIR=$EM_CACHE/include
+    -D JPEG_LIBRARY=$EM_CACHE/wasm/libjpeg.a
+    -D FREETYPE_INCLUDE_DIRS=$EM_CACHE/include
+    -D FREETYPE_LIBRARY=$EM_CACHE/wasm/libfreetype.a
+    -D VORBIS_INCLUDE_DIR=$EM_CACHE/include/vorbis
+    -D VORBIS_LIBRARY=$EM_CACHE/wasm/libvorbis.a
+    -D VORBISFILE_LIBRARY=$EM_CACHE/wasm/libvorbis.a
+    -D OGG_INCLUDE_DIR=$EM_CACHE/include
+    -D OGG_LIBRARY=$EM_CACHE/wasm/libogg.a
+    -D CMAKE_C_FLAGS="${USE_FLAGS[@]}"
+    -D CMAKE_CXX_FLAGS="${USE_FLAGS[@]}"
+    -D CMAKE_EXE_LINKER_FLAGS="${USE_FLAGS[@]} --preload-file data"
+    -D CMAKE_EXECUTABLE_SUFFIX=".html"
+
+To compile your own game adjust as necessary. You can use the
+lib/liballegro_monolith-static.a library.

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -54,6 +54,15 @@ static SDL_AudioFormat allegro_format_to_sdl(ALLEGRO_AUDIO_DEPTH d)
    return AUDIO_F32;
 }
 
+static ALLEGRO_AUDIO_DEPTH sdl_format_to_allegro(SDL_AudioFormat d)
+{
+   if (d == AUDIO_S8) return ALLEGRO_AUDIO_DEPTH_INT8;
+   if (d == AUDIO_U8) return ALLEGRO_AUDIO_DEPTH_UINT8;
+   if (d == AUDIO_S16) return ALLEGRO_AUDIO_DEPTH_INT16;
+   if (d == AUDIO_U16) return ALLEGRO_AUDIO_DEPTH_UINT16;
+   return ALLEGRO_AUDIO_DEPTH_FLOAT32;
+}
+
 static int sdl_allocate_voice(ALLEGRO_VOICE *voice)
 {
    SDL_VOICE *sv = al_malloc(sizeof *sv);
@@ -73,6 +82,8 @@ static int sdl_allocate_voice(ALLEGRO_VOICE *voice)
 
    voice->extra = sv;
    sv->voice = voice;
+   // we allow format change above so need to update here
+   voice->depth = sdl_format_to_allegro(sv->spec.format);
 
    return 0;
 }

--- a/include/allegro5/platform/alplatf.h.cmake
+++ b/include/allegro5/platform/alplatf.h.cmake
@@ -120,5 +120,8 @@
 /* Define if we are building with SDL backend. */
 #cmakedefine ALLEGRO_SDL
 
+/* Define if no threads should be used (only useful for emscripten without web workers) */
+#cmakedefine ALLEGRO_NO_THREADS
+
 /*---------------------------------------------------------------------------*/
 /* vi: set ft=c ts=3 sts=3 sw=3 et: */

--- a/include/allegro5/platform/alplatf.h.cmake
+++ b/include/allegro5/platform/alplatf.h.cmake
@@ -120,8 +120,8 @@
 /* Define if we are building with SDL backend. */
 #cmakedefine ALLEGRO_SDL
 
-/* Define if no threads should be used (only useful for emscripten without web workers) */
-#cmakedefine ALLEGRO_NO_THREADS
+/* Define if sleep should be used instead of threads (only useful for emscripten without web workers) */
+#cmakedefine ALLEGRO_WAIT_EVENT_SLEEP
 
 /*---------------------------------------------------------------------------*/
 /* vi: set ft=c ts=3 sts=3 sw=3 et: */

--- a/src/debug.c
+++ b/src/debug.c
@@ -303,14 +303,11 @@ void _al_trace_suffix(const char *msg, ...)
       return;
    }
 
-#ifdef __EMSCRIPTEN__
-   printf("%s", static_trace_buffer);
-#endif
 #ifdef ALLEGRO_ANDROID
    (void)__android_log_print(ANDROID_LOG_INFO, "allegro", "%s",
       static_trace_buffer);
 #endif
-#ifdef ALLEGRO_IPHONE
+#if defined(ALLEGRO_IPHONE) || defined(__EMSCRIPTEN__)
    fprintf(stderr, "%s", static_trace_buffer);
    fflush(stderr);
 #endif

--- a/src/debug.c
+++ b/src/debug.c
@@ -176,7 +176,7 @@ static void open_trace_file(void)
       if (s)
          trace_info.trace_file = fopen(s, "w");
       else
-#if defined(ALLEGRO_IPHONE) || defined(ALLEGRO_ANDROID)
+#if defined(ALLEGRO_IPHONE) || defined(ALLEGRO_ANDROID) || defined(__EMSCRIPTEN__)
          /* iPhone and Android don't like us writing files, so we'll be doing
           * something else there by default. */
          trace_info.trace_file = NULL;
@@ -303,6 +303,9 @@ void _al_trace_suffix(const char *msg, ...)
       return;
    }
 
+#ifdef __EMSCRIPTEN__
+   printf("%s", static_trace_buffer);
+#endif
 #ifdef ALLEGRO_ANDROID
    (void)__android_log_print(ANDROID_LOG_INFO, "allegro", "%s",
       static_trace_buffer);

--- a/src/events.c
+++ b/src/events.c
@@ -23,9 +23,6 @@
 
 
 #include <string.h>
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
 
 #include "allegro5/allegro.h"
 #include "allegro5/internal/aintern.h"
@@ -405,16 +402,14 @@ void al_wait_for_event(ALLEGRO_EVENT_QUEUE *queue, ALLEGRO_EVENT *ret_event)
 
    _al_mutex_lock(&queue->mutex);
    {
-      #ifdef __EMSCRIPTEN__
       while (is_event_queue_empty(queue)) {
-         emscripten_sleep(1);
+         #ifdef ALLEGRO_NO_THREADS
+         al_rest(1);
          heartbeat();
-      }
-      #else
-      while (is_event_queue_empty(queue)) {
+         #else
          _al_cond_wait(&queue->cond, &queue->mutex);
+         #endif
       }
-      #endif
 
       if (ret_event) {
          next_event = get_next_event_if_any(queue, true);

--- a/src/events.c
+++ b/src/events.c
@@ -403,7 +403,7 @@ void al_wait_for_event(ALLEGRO_EVENT_QUEUE *queue, ALLEGRO_EVENT *ret_event)
    _al_mutex_lock(&queue->mutex);
    {
       while (is_event_queue_empty(queue)) {
-         #ifdef ALLEGRO_NO_THREADS
+         #ifdef ALLEGRO_WAIT_EVENT_SLEEP
          al_rest(1);
          heartbeat();
          #else

--- a/src/events.c
+++ b/src/events.c
@@ -404,7 +404,7 @@ void al_wait_for_event(ALLEGRO_EVENT_QUEUE *queue, ALLEGRO_EVENT *ret_event)
    {
       while (is_event_queue_empty(queue)) {
          #ifdef ALLEGRO_WAIT_EVENT_SLEEP
-         al_rest(1);
+         al_rest(0.001);
          heartbeat();
          #else
          _al_cond_wait(&queue->cond, &queue->mutex);

--- a/src/events.c
+++ b/src/events.c
@@ -23,6 +23,9 @@
 
 
 #include <string.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 #include "allegro5/allegro.h"
 #include "allegro5/internal/aintern.h"
@@ -402,9 +405,16 @@ void al_wait_for_event(ALLEGRO_EVENT_QUEUE *queue, ALLEGRO_EVENT *ret_event)
 
    _al_mutex_lock(&queue->mutex);
    {
+      #ifdef __EMSCRIPTEN__
+      while (is_event_queue_empty(queue)) {
+         emscripten_sleep(1);
+         heartbeat();
+      }
+      #else
       while (is_event_queue_empty(queue)) {
          _al_cond_wait(&queue->cond, &queue->mutex);
       }
+      #endif
 
       if (ret_event) {
          next_event = get_next_event_if_any(queue, true);


### PR DESCRIPTION
For getting logs, with emscripten stdout appears in the logs so I simply made Allegro's logging functions write to stdout instead of a file when compiling with emcc.

With emscripten you normally cannot directly use the main() function once converted to javascript because it never returns, so the website would just hang. Instead you create a function which handles one frame and then call it repeatedly from a javascript timer. That's how we previously got some Allegro programs to work by compiling against the SDL2 port and then modifying code so it would not use main().

However there is an alternative way called ASYNCIFY: https://emscripten.org/docs/porting/asyncify.html
It transforms the C code into javascript code which can pause and resume any function, and specifically does so whenever a call to emscripten_sleep() is made. I added a small hack to al_wait_next_event to instead of waiting forever (which would immediately deadlock all of the Allegro examples) repeatedly call emscripten_sleep(1). That way most of the unmodified Allegro examples seem to work.

The existing heartbeat() used for SDL2 does not work for this because al_wait_next_event() with the SDL driver relies on some timer to wake up the unconditional wait (our SDL2 port when not using a timer is currently broken as we cannot receive any SDL events until a timer is triggered).

So, basically this adds another hack on top of the SDL2 hack, but it works rather well: I got 2/3 demos working and after compiling freetype, ttf and ogg/vorbis to javascript I believe over 100/137 examples: http://allegro5.org/examples

The speed demo uses some of the more unusual event functions instead of al_get_next_event() and should be easy to fix but like with the normal SDL2 driver I don't know if there's a good method that will work in all possible cases.

Audio is all messed up, haven't investigated that yet.

If someone wants to reproduce, this is the script I used to configure Allegro to compile the examples:
```bash
# we need to call emsdk_env.sh to set up all the emscripten paths
. /home/elias/stuff/emscripten/emsdk/emsdk_env.sh
mkdir build_emscripten
cd build_emscripten

USE_FLAGS=(
    -s USE_FREETYPE=1
    -s USE_VORBIS=1
    -s USE_OGG=1
    -s USE_LIBJPEG=1
    -s USE_SDL=2
    -s USE_LIBPNG=1
    -s FULL_ES2=1
    -s ASYNCIFY
    -s TOTAL_MEMORY=2147418112
    -O3
    )

emscripten=(
    emcmake cmake ../../allegro/git
    -D CMAKE_BUILD_TYPE=Debug
    -D ALLEGRO_SDL=ON
    -D SHARED=OFF
    -D WANT_MONOLITH=ON
    -D WANT_ALLOW_SSE=OFF
    -D WANT_DOCS=OFF
    -D WANT_TESTS=OFF
    -D WANT_OPENAL=OFF
     # not sure why these are not found automatically with emcmake, so
     # we use a  hack - we manually specify the cache path, so cmake
     # will fail on first run in the compile test but populate the cache
     # (from the -s options) and on second run it all works
    -D SDL2_INCLUDE_DIR=$EM_CACHE/include
    -D PNG_PNG_INCLUDE_DIR=$EM_CACHE/include
    -D PNG_LIBRARY=$EM_CACHE/wasm/libpng.a
    -D JPEG_INCLUDE_DIR=$EM_CACHE/include
    -D JPEG_LIBRARY=$EM_CACHE/wasm/libjpeg.a
    -D FREETYPE_INCLUDE_DIRS=$EM_CACHE/include
    -D FREETYPE_LIBRARY=$EM_CACHE/wasm/libfreetype.a
    -D VORBIS_INCLUDE_DIR=$EM_CACHE/include/vorbis
    -D VORBIS_LIBRARY=$EM_CACHE/wasm/libvorbis.a
    -D VORBISFILE_LIBRARY=$EM_CACHE/wasm/libvorbis.a
    -D OGG_INCLUDE_DIR=$EM_CACHE/include
    -D OGG_LIBRARY=$EM_CACHE/wasm/libogg.a
    -D CMAKE_C_FLAGS="${USE_FLAGS[@]}"
    -D CMAKE_CXX_FLAGS="${USE_FLAGS[@]}"
    -D CMAKE_EXE_LINKER_FLAGS="${USE_FLAGS[@]} --preload-file data"
     # does not actually work (but can edit the toolchain file)
    -D CMAKE_EXECUTABLE_SUFFIX=".html"
   )

"${emscripten[@]}" # will fail if ports are not downloaded yet
"${emscripten[@]}" # second time it should succeed

# set a link to the data dir, that way emcc can pack it up for each example
( cd examples; ln -s ../../../allegro/git/examples/data )
# create empty data dir in case of the speed demo
mkdir demos/speed/data
touch demos/speed/data/nothing.txt

emmake make
```
