### PR TITLE
fix bug in SDL voice driver

### DIFF
--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -54,6 +54,15 @@ static SDL_AudioFormat allegro_format_to_sdl(ALLEGRO_AUDIO_DEPTH d)
    return AUDIO_F32;
 }
 
+static ALLEGRO_AUDIO_DEPTH sdl_format_to_allegro(SDL_AudioFormat d)
+{
+   if (d == AUDIO_S8) return ALLEGRO_AUDIO_DEPTH_INT8;
+   if (d == AUDIO_U8) return ALLEGRO_AUDIO_DEPTH_UINT8;
+   if (d == AUDIO_S16) return ALLEGRO_AUDIO_DEPTH_INT16;
+   if (d == AUDIO_U16) return ALLEGRO_AUDIO_DEPTH_UINT16;
+   return ALLEGRO_AUDIO_DEPTH_FLOAT32;
+}
+
 static int sdl_allocate_voice(ALLEGRO_VOICE *voice)
 {
    SDL_VOICE *sv = al_malloc(sizeof *sv);
@@ -73,6 +82,8 @@ static int sdl_allocate_voice(ALLEGRO_VOICE *voice)
 
    voice->extra = sv;
    sv->voice = voice;
+   // we allow format change above so need to update here
+   voice->depth = sdl_format_to_allegro(sv->spec.format);
 
    return 0;
 }


### PR DESCRIPTION
We pass SDL_AUDIO_ALLOW_FORMAT_CHANGE to SDL_OpenAudioDevice (which is a good idea as only one specific format may be available on the target device) but then completely ignore format changes leading to broken audio. This PR fixes the issue.

(This was the issue that caused audio in emscripten to be broken which uses the SDL driver.)