### PR TITLE
add default files to some audio examples

### DIFF
--- a/examples/ex_acodec_multi.c
+++ b/examples/ex_acodec_multi.c
@@ -11,6 +11,10 @@
 
 #include "common.c"
 
+char *default_files[] = {NULL, "data/welcome.voc",
+   "data/haiku/earth_0.ogg", "data/haiku/water_0.ogg",
+   "data/haiku/fire_0.ogg", "data/haiku/air_0.ogg"};
+
 int main(int argc, char **argv)
 {
    int i;
@@ -27,8 +31,9 @@ int main(int argc, char **argv)
    open_log();
 
    if (argc < 2) {
-      log_printf("This example needs to be run from the command line.\nUsage: %s {audio_files}\n", argv[0]);
-      goto done;
+      log_printf("This example can be run from the command line.\nUsage: %s {audio_files}\n", argv[0]);
+      argv = default_files;
+      argc = 6;
    }
 
    al_init_acodec_addon();
@@ -128,7 +133,6 @@ int main(int argc, char **argv)
 
    al_uninstall_audio();
 
-done:
    close_log(true);
 
    return 0;

--- a/examples/ex_audio_simple.c
+++ b/examples/ex_audio_simple.c
@@ -17,6 +17,13 @@
 #define RESERVED_SAMPLES   16
 #define MAX_SAMPLE_DATA    10
 
+const char *default_files[] = {NULL, "data/welcome.wav",
+         "data/haiku/fire_0.ogg", "data/haiku/fire_1.ogg",
+         "data/haiku/fire_2.ogg", "data/haiku/fire_3.ogg",
+         "data/haiku/fire_4.ogg", "data/haiku/fire_5.ogg",
+         "data/haiku/fire_6.ogg", "data/haiku/fire_7.ogg",
+         };
+
 int main(int argc, const char *argv[])
 {
    ALLEGRO_SAMPLE *sample_data[MAX_SAMPLE_DATA] = {NULL};
@@ -40,8 +47,9 @@ int main(int argc, const char *argv[])
    open_log();
 
    if (argc < 2) {
-      log_printf("This example needs to be run from the command line.\nUsage: %s {audio_files}\n", argv[0]);
-      goto done;
+      log_printf("This example can be run from the command line.\nUsage: %s {audio_files}\n", argv[0]);
+      argv = default_files;
+      argc = 10;
    }
    argc--;
    argv++;
@@ -227,7 +235,6 @@ Restart:
    /* Sample data and other objects will be automatically freed. */
    al_uninstall_audio();
 
-done:
    al_destroy_display(display);
    close_log(true);
    return 0;

--- a/examples/ex_kcm_direct.c
+++ b/examples/ex_kcm_direct.c
@@ -7,6 +7,8 @@
 
 #include "common.c"
 
+char *default_files[] = {NULL, "data/welcome.wav"};
+
 int main(int argc, char **argv)
 {
    ALLEGRO_VOICE *voice;
@@ -20,8 +22,9 @@ int main(int argc, char **argv)
    open_log();
 
    if (argc < 2) {
-      log_printf("This example needs to be run from the command line.\nUsage: %s {audio_files}\n", argv[0]);
-      goto done;
+      log_printf("This example can be run from the command line.\nUsage: %s {audio_files}\n", argv[0]);
+      argv = default_files;
+      argc = 2;
    }
 
    al_init_acodec_addon();
@@ -93,7 +96,6 @@ int main(int argc, char **argv)
    }
 
    al_uninstall_audio();
-done:
    close_log(true);
 
    return 0;

--- a/examples/ex_mixer_chain.c
+++ b/examples/ex_mixer_chain.c
@@ -11,6 +11,9 @@
 
 #include "common.c"
 
+char *default_files[] = {NULL, "data/haiku/water_0.ogg",
+   "data/haiku/water_7.ogg"};
+
 int main(int argc, char **argv)
 {
    ALLEGRO_VOICE *voice;
@@ -29,8 +32,9 @@ int main(int argc, char **argv)
    open_log();
 
    if (argc < 3) {
-      log_printf("This example needs to be run from the command line.\nUsage: %s file1 file2\n", argv[0]);
-      goto done;
+      log_printf("This example can be run from the command line.\nUsage: %s file1 file2\n", argv[0]);
+      argv = default_files;
+      argc = 3;
    }
 
    al_init_acodec_addon();
@@ -117,7 +121,6 @@ int main(int argc, char **argv)
 
    al_uninstall_audio();
 
-done:
    close_log(true);
 
    return 0;

--- a/examples/ex_stream_file.c
+++ b/examples/ex_stream_file.c
@@ -20,6 +20,8 @@
  */
 //#define BYPASS_MIXER
 
+char *default_files[] = {NULL, "../demos/skater/data/menu/skate2.ogg"};
+
 int main(int argc, char **argv)
 {
    int i;
@@ -35,9 +37,10 @@ int main(int argc, char **argv)
    open_log();
 
    if (argc < 2) {
-      log_printf("This example needs to be run from the command line.\n");
+      log_printf("This example can be run from the command line.\n");
       log_printf("Usage: %s [--loop] {audio_files}\n", argv[0]);
-      goto done;
+      argv = default_files;
+      argc = 2;
    }
 
    if (strcmp(argv[1], "--loop") == 0) {
@@ -122,7 +125,6 @@ int main(int argc, char **argv)
    al_destroy_voice(voice);
 
    al_uninstall_audio();
-done:
    close_log(true);
 
    return 0;

--- a/examples/ex_stream_file.c
+++ b/examples/ex_stream_file.c
@@ -84,6 +84,12 @@ int main(int argc, char **argv)
 
       stream = al_load_audio_stream(filename, 4, 2048);
       if (!stream) {
+         /* If it is not packed, e.g. on Android or iOS. */
+         if (!strcmp(filename, default_files[1])) {
+            stream = al_load_audio_stream("data/welcome.wav", 4, 2048);
+         }
+      }
+      if (!stream) {
          log_printf("Could not create an ALLEGRO_AUDIO_STREAM from '%s'!\n",
                  filename);
          continue;


### PR DESCRIPTION
This is a very minor PR. Some of our audio examples won't work without providing a file on the command line, even though most of them use a default file in that case. I added default files to 5 more:

- ex_acodec_multi
- ex_audio_simple
- ex_kcm_direct
- ex_mixer_chain
- ex_stream_file