### PR TITLE
List audio devices

### DIFF
--- a/addons/audio/allegro5/allegro_audio.h
+++ b/addons/audio/allegro5/allegro_audio.h
@@ -359,7 +359,7 @@ ALLEGRO_KCM_AUDIO_FUNC(size_t, al_get_audio_depth_size, (ALLEGRO_AUDIO_DEPTH con
 ALLEGRO_KCM_AUDIO_FUNC(void, al_fill_silence, (void *buf, unsigned int samples,
       ALLEGRO_AUDIO_DEPTH depth, ALLEGRO_CHANNEL_CONF chan_conf));
 
-ALLEGRO_KCM_AUDIO_FUNC(int, al_get_audio_device_count, (void));
+ALLEGRO_KCM_AUDIO_FUNC(int, al_get_num_audio_devices, (void));
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_DEVICE *, al_get_audio_device, (int index));
 ALLEGRO_KCM_AUDIO_FUNC(char *, al_get_audio_device_name, (ALLEGRO_AUDIO_DEVICE * device));
 

--- a/addons/audio/allegro5/allegro_audio.h
+++ b/addons/audio/allegro5/allegro_audio.h
@@ -173,6 +173,10 @@ typedef struct ALLEGRO_MIXER ALLEGRO_MIXER;
  */
 typedef struct ALLEGRO_VOICE ALLEGRO_VOICE;
 
+/* Type: ALLEGRO_AUDIO_DEVICE
+ */
+typedef struct ALLEGRO_AUDIO_DEVICE ALLEGRO_AUDIO_DEVICE;
+
 
 #if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_KCM_AUDIO_SRC)
 /* Type: ALLEGRO_AUDIO_RECORDER
@@ -354,6 +358,10 @@ ALLEGRO_KCM_AUDIO_FUNC(size_t, al_get_audio_depth_size, (ALLEGRO_AUDIO_DEPTH con
 
 ALLEGRO_KCM_AUDIO_FUNC(void, al_fill_silence, (void *buf, unsigned int samples,
       ALLEGRO_AUDIO_DEPTH depth, ALLEGRO_CHANNEL_CONF chan_conf));
+
+ALLEGRO_KCM_AUDIO_FUNC(int, al_get_audio_device_count, (void));
+ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_DEVICE *, al_get_audio_device, (int index));
+ALLEGRO_KCM_AUDIO_FUNC(char *, al_get_audio_device_name, (ALLEGRO_AUDIO_DEVICE * device));
 
 /* Simple audio layer */
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_reserve_samples, (int reserve_samples));

--- a/addons/audio/allegro5/internal/aintern_audio.h
+++ b/addons/audio/allegro5/internal/aintern_audio.h
@@ -84,6 +84,8 @@ struct ALLEGRO_AUDIO_DRIVER {
    
    int            (*allocate_recorder)(struct ALLEGRO_AUDIO_RECORDER *);
    void           (*deallocate_recorder)(struct ALLEGRO_AUDIO_RECORDER *);
+
+   _AL_LIST*      (*get_devices)(void);
 };
 
 extern ALLEGRO_AUDIO_DRIVER *_al_kcm_driver;
@@ -361,6 +363,11 @@ typedef enum {
 } AL_ERROR_ENUM;
 
 extern void _al_set_error(int error, char* string);
+
+struct ALLEGRO_AUDIO_DEVICE {
+   char* name;
+   void* identifier;
+};
 
 /* Supposedly internal */
 ALLEGRO_KCM_AUDIO_FUNC(void*, _al_kcm_feed_stream, (ALLEGRO_THREAD *self, void *vstream));

--- a/addons/audio/alsa.c
+++ b/addons/audio/alsa.c
@@ -878,14 +878,14 @@ static void alsa_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
    snd_pcm_close(data->capture_handle);
 }
 
-void _device_list_dtor(void* value, void* userdata)
+static void _device_list_dtor(void* value, void* userdata)
 {
    ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
    al_free(device->name);
    al_free(device->identifier);
 }
 
-_AL_LIST* alsa_get_devices()
+static _AL_LIST* alsa_get_devices()
 {
    if (!device_list) {
       device_list = _al_list_create();

--- a/addons/audio/alsa.c
+++ b/addons/audio/alsa.c
@@ -41,6 +41,7 @@ do {                                                                  \
 static snd_output_t *snd_output = NULL;
 static char *default_device = "default";
 static char *alsa_device = NULL;
+static _AL_LIST* device_list;
 
 // TODO: Setting this to 256 causes (extreme, about than 10 seconds)
 // lag if the alsa device is really pulseaudio.
@@ -140,6 +141,8 @@ Error:
    other processes to use the device */
 static void alsa_close(void)
 {
+   _al_list_destroy(device_list);
+
    if (alsa_device != default_device)
       al_free(alsa_device);
    
@@ -875,6 +878,73 @@ static void alsa_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
    snd_pcm_close(data->capture_handle);
 }
 
+void _device_list_dtor(void* value, void* userdata)
+{
+   ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
+   al_free(device->name);
+   al_free(device->identifier);
+}
+
+_AL_LIST* alsa_get_devices()
+{
+   if (!device_list) {
+      device_list = _al_list_create();
+
+      int rcard = -1;
+      while(snd_card_next(&rcard) == 0) {
+         if (rcard < 0) return device_list;
+
+         snd_ctl_t *handle;
+         char str[64];
+
+         sprintf(str, "hw:%i", rcard);
+         if (snd_ctl_open(&handle, str, 0) < 0) {
+            return device_list;
+         }
+
+         int dev_num = -1;
+
+         while(1) {
+            if (snd_ctl_pcm_next_device(handle, &dev_num) < 0) {
+               break;
+            }
+
+            if (dev_num < 0) break;
+
+            snd_ctl_card_info_t *card_info;
+            snd_ctl_card_info_alloca(&card_info);
+
+            if (snd_ctl_card_info(handle, card_info) < 0) {
+               break;
+            }
+            else {
+               char *name = snd_ctl_card_info_get_name(card_info);
+               char *identifier = snd_ctl_card_info_get_id(card_info);
+               int len = strlen(name) + 1;
+               int identifier_len = strlen(identifier) + 1;
+
+               ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)al_malloc(sizeof(ALLEGRO_AUDIO_DEVICE));
+               device->identifier = (char*)al_malloc(identifier_len);
+               device->name = (char*)al_malloc(len);
+
+               memset(device->name, 0, len);
+               strcpy(device->name, name);
+
+               memset(device->identifier, 0, identifier_len);
+               strcpy(device->identifier, identifier);
+
+               // identifier or maybe even name should be subdevice gist.github.com/dontknowmyname/4536543
+               _al_list_push_back_ex(device_list, device, _device_list_dtor);
+            }
+         }
+
+         snd_ctl_close(handle);
+      }
+   }
+
+   return device_list;
+}
+
 ALLEGRO_AUDIO_DRIVER _al_kcm_alsa_driver =
 {
    "ALSA",
@@ -899,7 +969,7 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_alsa_driver =
    alsa_allocate_recorder,
    alsa_deallocate_recorder,
 
-   NULL,
+   alsa_get_devices
 };
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/audio/alsa.c
+++ b/addons/audio/alsa.c
@@ -897,7 +897,9 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_alsa_driver =
    alsa_set_voice_position,
 
    alsa_allocate_recorder,
-   alsa_deallocate_recorder
+   alsa_deallocate_recorder,
+
+   NULL,
 };
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/audio/aqueue.m
+++ b/addons/audio/aqueue.m
@@ -576,6 +576,8 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_aqueue_driver = {
    _aqueue_set_voice_position,
 
    _aqueue_allocate_recorder,
-   _aqueue_deallocate_recorder
+   _aqueue_deallocate_recorder,
+
+   NULL
 };
 

--- a/addons/audio/audio.c
+++ b/addons/audio/audio.c
@@ -196,6 +196,8 @@ static ALLEGRO_AUDIO_DRIVER_ENUM get_config_audio_driver(void)
    return ALLEGRO_AUDIO_DRIVER_AUTODETECT;
 }
 
+/* Function: al_get_num_audio_devices
+ */
 int al_get_num_audio_devices()
 {
    if (_al_kcm_driver) {
@@ -211,6 +213,8 @@ int al_get_num_audio_devices()
    return 0;
 }
 
+/* Function: al_get_audio_device
+ */
 ALLEGRO_AUDIO_DEVICE* al_get_audio_device(int index)
 {
    if (_al_kcm_driver) {
@@ -229,6 +233,8 @@ ALLEGRO_AUDIO_DEVICE* al_get_audio_device(int index)
    return 0;
 }
 
+/* Function: al_get_audio_device_name
+ */
 char* al_get_audio_device_name(ALLEGRO_AUDIO_DEVICE * device)
 {
    return device ? device->name : 0;

--- a/addons/audio/audio.c
+++ b/addons/audio/audio.c
@@ -196,7 +196,7 @@ static ALLEGRO_AUDIO_DRIVER_ENUM get_config_audio_driver(void)
    return ALLEGRO_AUDIO_DRIVER_AUTODETECT;
 }
 
-int al_get_audio_device_count()
+int al_get_num_audio_devices()
 {
    if (_al_kcm_driver) {
       if (_al_kcm_driver->get_devices) {

--- a/addons/audio/audio.c
+++ b/addons/audio/audio.c
@@ -196,6 +196,44 @@ static ALLEGRO_AUDIO_DRIVER_ENUM get_config_audio_driver(void)
    return ALLEGRO_AUDIO_DRIVER_AUTODETECT;
 }
 
+int al_get_audio_device_count()
+{
+   if (_al_kcm_driver) {
+      if (_al_kcm_driver->get_devices) {
+         _AL_LIST* audio_devices = _al_kcm_driver->get_devices();
+         return _al_list_size(audio_devices);
+      }
+      else {
+         return -1;
+      }
+   }
+
+   return 0;
+}
+
+ALLEGRO_AUDIO_DEVICE* al_get_audio_device(int index)
+{
+   if (_al_kcm_driver) {
+      if (_al_kcm_driver->get_devices) {
+         _AL_LIST* audio_devices = _al_kcm_driver->get_devices();
+
+         if (index >= 0 && index < _al_list_size(audio_devices)) {
+            return _al_list_item_data(_al_list_at(audio_devices, index));
+         }
+      }
+      else {
+         return 0;
+      }
+   }
+
+   return 0;
+}
+
+char* al_get_audio_device_name(ALLEGRO_AUDIO_DEVICE * device)
+{
+   return device ? device->name : 0;
+}
+
 static bool do_install_audio(ALLEGRO_AUDIO_DRIVER_ENUM mode)
 {
    bool retVal;

--- a/addons/audio/dsound.cpp
+++ b/addons/audio/dsound.cpp
@@ -816,6 +816,13 @@ void _dsound_close_recorder(ALLEGRO_AUDIO_RECORDER *r) {
    capture_device = NULL;
 }
 
+void _device_list_dtor(void* value, void* userdata)
+{
+   ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
+   al_free(device->name);
+   al_free(device->identifier);
+}
+
 BOOL CALLBACK DSEnumCallback(
          LPGUID lpGuid,
          LPCTSTR lpcstrDescription,
@@ -830,12 +837,15 @@ BOOL CALLBACK DSEnumCallback(
 
       ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)al_malloc(sizeof(ALLEGRO_AUDIO_DEVICE));
       device->identifier = (void*)al_malloc(sizeof(GUID));
-      device->name = (char*)al_malloc((desc_size + 1));
+      device->name = (char*)al_malloc(desc_size + 1);
+
+      memset(device->identifier, 0, sizeof(GUID));
+      memset(device->name, 0, desc_size + 1);
 
       memcpy(device->identifier, lpGuid, sizeof(GUID));
       wcstombs(device->name, lpcstrDescription, desc_size);
 
-      _al_list_push_back(device_list, device);
+      _al_list_push_back_ex(device_list, device, _device_list_dtor);
    }
 
    return TRUE;

--- a/addons/audio/dsound.cpp
+++ b/addons/audio/dsound.cpp
@@ -60,7 +60,7 @@ static _AL_LIST* device_list;
 #define MIN_FILL           512
 #define MAX_FILL           1024
 
-BOOL CALLBACK DSEnumCallback(LPGUID lpGuid, LPCTSTR lpcstrDescription, LPCTSTR lpcstrModule, LPVOID lpContext);
+static BOOL CALLBACK DSEnumCallback(LPGUID lpGuid, LPCTSTR lpcstrDescription, LPCTSTR lpcstrModule, LPVOID lpContext);
 
 static HWND get_window()
 {

--- a/addons/audio/dsound.cpp
+++ b/addons/audio/dsound.cpp
@@ -816,14 +816,14 @@ void _dsound_close_recorder(ALLEGRO_AUDIO_RECORDER *r) {
    capture_device = NULL;
 }
 
-void _device_list_dtor(void* value, void* userdata)
+static void _device_list_dtor(void* value, void* userdata)
 {
    ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
    al_free(device->name);
    al_free(device->identifier);
 }
 
-BOOL CALLBACK DSEnumCallback(
+static BOOL CALLBACK DSEnumCallback(
          LPGUID lpGuid,
          LPCTSTR lpcstrDescription,
          LPCTSTR lpcstrModule,
@@ -851,7 +851,7 @@ BOOL CALLBACK DSEnumCallback(
    return TRUE;
 }
 
-_AL_LIST* _dsound_get_devices()
+static _AL_LIST* _dsound_get_devices()
 {
    return device_list;
 }

--- a/addons/audio/dsound.cpp
+++ b/addons/audio/dsound.cpp
@@ -277,6 +277,7 @@ static int _dsound_open()
    DirectSoundEnumerate((LPDSENUMCALLBACK)DSEnumCallback, NULL);
 
    /* FIXME: Use default device until we have device enumeration */
+
    hr = DirectSoundCreate8(NULL, &device, NULL);
    if (FAILED(hr)) {
       ALLEGRO_ERROR("DirectSoundCreate8 failed: %s\n", ds_get_error(hr));
@@ -818,6 +819,8 @@ void _dsound_close_recorder(ALLEGRO_AUDIO_RECORDER *r) {
 
 static void _device_list_dtor(void* value, void* userdata)
 {
+   (void)userdata;
+
    ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
    al_free(device->name);
    al_free(device->identifier);
@@ -833,14 +836,11 @@ static BOOL CALLBACK DSEnumCallback(
    (void)lpContext;
 
    if (lpGuid != NULL) {
-      size_t desc_size = wcslen(lpcstrDescription);
+      size_t desc_size = wcslen(lpcstrDescription) + 1;
 
       ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)al_malloc(sizeof(ALLEGRO_AUDIO_DEVICE));
       device->identifier = (void*)al_malloc(sizeof(GUID));
-      device->name = (char*)al_malloc(desc_size + 1);
-
-      memset(device->identifier, 0, sizeof(GUID));
-      memset(device->name, 0, desc_size + 1);
+      device->name = (char*)al_malloc(desc_size);
 
       memcpy(device->identifier, lpGuid, sizeof(GUID));
       wcstombs(device->name, lpcstrDescription, desc_size);
@@ -851,7 +851,7 @@ static BOOL CALLBACK DSEnumCallback(
    return TRUE;
 }
 
-static _AL_LIST* _dsound_get_devices()
+static _AL_LIST* _dsound_get_devices(void)
 {
    return device_list;
 }

--- a/addons/audio/dsound.cpp
+++ b/addons/audio/dsound.cpp
@@ -300,7 +300,10 @@ static int _dsound_open()
 static void _dsound_close()
 {
    ALLEGRO_DEBUG("Releasing device\n");
+   
+   _al_list_destroy(device_list);
    device->Release();
+   
    ALLEGRO_DEBUG("Released device\n");
    ALLEGRO_INFO("DirectSound closed\n");
 }

--- a/addons/audio/dsound.cpp
+++ b/addons/audio/dsound.cpp
@@ -277,7 +277,7 @@ static int _dsound_open()
    DirectSoundEnumerate((LPDSENUMCALLBACK)DSEnumCallback, NULL);
 
    /* FIXME: Use default device until we have device enumeration */
-   hr = DirectSoundCreate8(NULL, &device, NULL); // pass device guid here or NULL for default playback device
+   hr = DirectSoundCreate8(NULL, &device, NULL);
    if (FAILED(hr)) {
       ALLEGRO_ERROR("DirectSoundCreate8 failed: %s\n", ds_get_error(hr));
       return 1;

--- a/addons/audio/openal.c
+++ b/addons/audio/openal.c
@@ -661,6 +661,8 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_openal_driver = {
    _openal_set_voice_position,
 
    NULL,
+   NULL,
+
    NULL
 };
 

--- a/addons/audio/opensl.c
+++ b/addons/audio/opensl.c
@@ -720,5 +720,7 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_opensl_driver = {
    _opensl_set_voice_position,
 
    NULL,
+   NULL,
+
    NULL
 };

--- a/addons/audio/oss.c
+++ b/addons/audio/oss.c
@@ -621,6 +621,8 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_oss_driver =
    oss_set_voice_position,
 
    NULL,
+   NULL,
+
    NULL
 };
 

--- a/addons/audio/pulseaudio.c
+++ b/addons/audio/pulseaudio.c
@@ -77,6 +77,8 @@ static unsigned int get_buffer_size(const ALLEGRO_CONFIG *config)
 
 static void _device_list_dtor(void* value, void* userdata)
 {
+   (void)userdata;
+
    ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
    al_free(device->name);
    al_free(device->identifier);
@@ -97,16 +99,14 @@ static void sink_info_cb(pa_context *c, const pa_sink_info *i, int eol,
       return;
    *ret = i->state;
 
-   int len = strlen(i->description) + 1;
+   int iden_len = strlen(i->name) + 1;
+   int name_len = strlen(i->description) + 1;
    ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)al_malloc(sizeof(ALLEGRO_AUDIO_DEVICE));
-   device->identifier = (void*)al_malloc(sizeof(uint32_t));
-   device->name = (char*)al_malloc(len);
-
-   memset(device->identifier, 0, sizeof(uint32_t));
-   memset(device->name, 0, len);
-
-   memcpy(device->identifier, &i->index, sizeof(uint32_t));
+   device->identifier = (void*)al_malloc(iden_len);
+   device->name = (char*)al_malloc(name_len);
+   
    strcpy(device->name, i->description);
+   strcpy(device->identifier, i->name);
 
    _al_list_push_back_ex(device_list, device, _device_list_dtor);
 }
@@ -539,7 +539,7 @@ static void pulseaudio_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
    al_free(r->extra);
 }
 
-static _AL_LIST* pulseaudio_get_devices()
+static _AL_LIST* pulseaudio_get_devices(void)
 {
    return device_list;
 }

--- a/addons/audio/pulseaudio.c
+++ b/addons/audio/pulseaudio.c
@@ -54,7 +54,7 @@ typedef struct PULSEAUDIO_VOICE
    char *buffer_end;
 } PULSEAUDIO_VOICE;
 
-_AL_LIST* device_list;
+static _AL_LIST* device_list;
 
 #define DEFAULT_BUFFER_SIZE   1024
 #define MIN_BUFFER_SIZE       128

--- a/addons/audio/pulseaudio.c
+++ b/addons/audio/pulseaudio.c
@@ -75,7 +75,7 @@ static unsigned int get_buffer_size(const ALLEGRO_CONFIG *config)
    return DEFAULT_BUFFER_SIZE;
 }
 
-void _device_list_dtor(void* value, void* userdata)
+static void _device_list_dtor(void* value, void* userdata)
 {
    ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
    al_free(device->name);
@@ -539,7 +539,7 @@ static void pulseaudio_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
    al_free(r->extra);
 }
 
-_AL_LIST* pulseaudio_get_devices()
+static _AL_LIST* pulseaudio_get_devices()
 {
    return device_list;
 }

--- a/addons/audio/pulseaudio.c
+++ b/addons/audio/pulseaudio.c
@@ -54,6 +54,8 @@ typedef struct PULSEAUDIO_VOICE
    char *buffer_end;
 } PULSEAUDIO_VOICE;
 
+_AL_LIST* device_list;
+
 #define DEFAULT_BUFFER_SIZE   1024
 #define MIN_BUFFER_SIZE       128
 
@@ -73,16 +75,40 @@ static unsigned int get_buffer_size(const ALLEGRO_CONFIG *config)
    return DEFAULT_BUFFER_SIZE;
 }
 
+void _device_list_dtor(void* value, void* userdata)
+{
+   ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
+   al_free(device->name);
+   al_free(device->identifier);
+}
+
 static void sink_info_cb(pa_context *c, const pa_sink_info *i, int eol,
    void *userdata)
 {
    (void)c;
    (void)eol;
 
+   if (!device_list) {
+      device_list = _al_list_create();
+   }
+
    pa_sink_state_t *ret = userdata;
    if (!i)
       return;
    *ret = i->state;
+
+   int len = strlen(i->description) + 1;
+   ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)al_malloc(sizeof(ALLEGRO_AUDIO_DEVICE));
+   device->identifier = (void*)al_malloc(sizeof(uint32_t));
+   device->name = (char*)al_malloc(len);
+
+   memset(device->identifier, 0, sizeof(uint32_t));
+   memset(device->name, 0, len);
+
+   memcpy(device->identifier, &i->index, sizeof(uint32_t));
+   strcpy(device->name, i->description);
+
+   _al_list_push_back_ex(device_list, device, _device_list_dtor);
 }
 
 static int pulseaudio_open(void)
@@ -144,6 +170,7 @@ static int pulseaudio_open(void)
       pa_mainloop_free(mainloop);
       return 1;
    }*/
+
    pa_operation_unref(op);
    pa_context_disconnect(c);
    pa_context_unref(c);
@@ -153,6 +180,7 @@ static int pulseaudio_open(void)
 
 static void pulseaudio_close(void)
 {
+   _al_list_destroy(device_list);
 }
 
 static void *pulseaudio_update(ALLEGRO_THREAD *self, void *data)
@@ -511,6 +539,11 @@ static void pulseaudio_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
    al_free(r->extra);
 }
 
+_AL_LIST* pulseaudio_get_devices()
+{
+   return device_list;
+}
+
 ALLEGRO_AUDIO_DRIVER _al_kcm_pulseaudio_driver =
 {
    "PulseAudio",
@@ -535,7 +568,7 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_pulseaudio_driver =
    pulseaudio_allocate_recorder,
    pulseaudio_deallocate_recorder,
 
-   NULL
+   pulseaudio_get_devices
 };
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/audio/pulseaudio.c
+++ b/addons/audio/pulseaudio.c
@@ -533,7 +533,13 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_pulseaudio_driver =
    pulseaudio_set_voice_position,
    
    pulseaudio_allocate_recorder,
-   pulseaudio_deallocate_recorder
+   pulseaudio_deallocate_recorder,
+
+   NULL
 };
 
 /* vim: set sts=3 sw=3 et: */
+
+
+
+/// pa_context_get_sink_info_list to get list of  devices

--- a/addons/audio/pulseaudio.c
+++ b/addons/audio/pulseaudio.c
@@ -539,7 +539,3 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_pulseaudio_driver =
 };
 
 /* vim: set sts=3 sw=3 et: */
-
-
-
-/// pa_context_get_sink_info_list to get list of  devices

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -4,8 +4,6 @@
 
 ALLEGRO_DEBUG_CHANNEL("SDL")
 
-_AL_LIST* device_list;
-
 typedef struct SDL_VOICE
 {
    SDL_AudioDeviceID device;
@@ -20,6 +18,8 @@ typedef struct SDL_RECORDER
    SDL_AudioSpec spec;
    unsigned int fragment;
 } SDL_RECORDER;
+
+static _AL_LIST* device_list;
 
 static void audio_callback(void *userdata, Uint8 *stream, int len)
 {

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -200,6 +200,13 @@ static void sdl_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
    al_free(r->extra);
 }
 
+void _device_list_dtor(void* value, void* userdata)
+{
+   ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
+   al_free(device->name);
+   al_free(device->identifier);
+}
+
 _AL_LIST* sdl_get_devices()
 {
    if (!device_list) {
@@ -207,15 +214,19 @@ _AL_LIST* sdl_get_devices()
 
       int i, count = SDL_GetNumAudioDevices(0);
       for (i = 0; i < count; ++i) {
+         int len = strlen(SDL_GetAudioDeviceName(i, 0)) + 1;
 
          ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)al_malloc(sizeof(ALLEGRO_AUDIO_DEVICE));
          device->identifier = (void*)al_malloc(sizeof(int));
-         device->name = (char*)al_malloc(strlen(SDL_GetAudioDeviceName(i, 0)) + 1);
+         device->name = (char*)al_malloc(len);
+
+         memset(device->identifier, 0, sizeof(int));
+         memset(device->name, 0, len);
 
          memcpy(device->identifier, i, sizeof(int));
          strcpy(device->name, SDL_GetAudioDeviceName(i, 0));
 
-         _al_list_push_back(device_list, device);
+         _al_list_push_back_ex(device_list, device, _device_list_dtor);
       }
    }
 

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -201,17 +201,26 @@ static void sdl_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
 ALLEGRO_AUDIO_DRIVER _al_kcm_sdl_driver =
 {
    "SDL",
+   
    sdl_open,
    sdl_close,
+
    sdl_allocate_voice,
    sdl_deallocate_voice,
+
    sdl_load_voice,
    sdl_unload_voice,
+
    sdl_start_voice,
    sdl_stop_voice,
+
    sdl_voice_is_playing,
+
    sdl_get_voice_position,
    sdl_set_voice_position,
+
    sdl_allocate_recorder,
-   sdl_deallocate_recorder
+   sdl_deallocate_recorder,
+
+   NULL,
 };

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -82,6 +82,7 @@ static int sdl_allocate_voice(ALLEGRO_VOICE *voice)
 static void sdl_deallocate_voice(ALLEGRO_VOICE *voice)
 {
    SDL_VOICE *sv = voice->extra;
+   _al_list_destroy(device_list);
    SDL_CloseAudioDevice(sv->device);
    al_free(sv);
 }
@@ -223,7 +224,7 @@ _AL_LIST* sdl_get_devices()
          memset(device->identifier, 0, sizeof(int));
          memset(device->name, 0, len);
 
-         memcpy(device->identifier, i, sizeof(int));
+         memcpy(device->identifier, &i, sizeof(int));
          strcpy(device->name, SDL_GetAudioDeviceName(i, 0));
 
          _al_list_push_back_ex(device_list, device, _device_list_dtor);

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -4,6 +4,8 @@
 
 ALLEGRO_DEBUG_CHANNEL("SDL")
 
+_AL_LIST* device_list;
+
 typedef struct SDL_VOICE
 {
    SDL_AudioDeviceID device;
@@ -198,6 +200,28 @@ static void sdl_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
    al_free(r->extra);
 }
 
+_AL_LIST* sdl_get_devices()
+{
+   if (!device_list) {
+      device_list = _al_list_create();
+
+      int i, count = SDL_GetNumAudioDevices(0);
+      for (i = 0; i < count; ++i) {
+
+         ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)al_malloc(sizeof(ALLEGRO_AUDIO_DEVICE));
+         device->identifier = (void*)al_malloc(sizeof(int));
+         device->name = (char*)al_malloc(strlen(SDL_GetAudioDeviceName(i, 0)) + 1);
+
+         memcpy(device->identifier, i, sizeof(int));
+         strcpy(device->name, SDL_GetAudioDeviceName(i, 0));
+
+         _al_list_push_back(device_list, device);
+      }
+   }
+
+   return device_list;
+}
+
 ALLEGRO_AUDIO_DRIVER _al_kcm_sdl_driver =
 {
    "SDL",
@@ -222,5 +246,5 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_sdl_driver =
    sdl_allocate_recorder,
    sdl_deallocate_recorder,
 
-   NULL,
+   sdl_get_devices,
 };

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -203,12 +203,13 @@ static void sdl_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
 
 static void _device_list_dtor(void* value, void* userdata)
 {
+   (void)userdata;
+
    ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
    al_free(device->name);
-   al_free(device->identifier);
 }
 
-static _AL_LIST* sdl_get_devices()
+static _AL_LIST* sdl_get_devices(void)
 {
    if (!device_list) {
       device_list = _al_list_create();
@@ -218,13 +219,8 @@ static _AL_LIST* sdl_get_devices()
          int len = strlen(SDL_GetAudioDeviceName(i, 0)) + 1;
 
          ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)al_malloc(sizeof(ALLEGRO_AUDIO_DEVICE));
-         device->identifier = (void*)al_malloc(sizeof(int));
          device->name = (char*)al_malloc(len);
-
-         memset(device->identifier, 0, sizeof(int));
-         memset(device->name, 0, len);
-
-         memcpy(device->identifier, &i, sizeof(int));
+         device->identifier = device->name; // Name returned by SDL2 is used to identify devices.
          strcpy(device->name, SDL_GetAudioDeviceName(i, 0));
 
          _al_list_push_back_ex(device_list, device, _device_list_dtor);

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -201,14 +201,14 @@ static void sdl_deallocate_recorder(ALLEGRO_AUDIO_RECORDER *r)
    al_free(r->extra);
 }
 
-void _device_list_dtor(void* value, void* userdata)
+static void _device_list_dtor(void* value, void* userdata)
 {
    ALLEGRO_AUDIO_DEVICE* device = (ALLEGRO_AUDIO_DEVICE*)value;
    al_free(device->name);
    al_free(device->identifier);
 }
 
-_AL_LIST* sdl_get_devices()
+static _AL_LIST* sdl_get_devices()
 {
    if (!device_list) {
       device_list = _al_list_create();

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1740,3 +1740,25 @@ ignored, as the fragment buffer will no longer be valid.
 Since: 5.1.1
 
 > *[Unstable API]:* The API may need a slight redesign.
+
+
+## Audio device functions
+
+### API: ALLEGRO_AUDIO_DEVICE
+
+An opaque datatype that represents an audio device. 
+
+### API: al_get_num_audio_devices
+
+Get the number of available audio devices on the system. Currently supported
+by the ALSA, SDL, DirectSound8, and PulseAudio drivers.
+
+return -1 for unsupported drivers.
+
+### API: al_get_audio_device
+
+Get the audio device of the specified index.
+
+### API: al_get_audio_device_name
+
+Get the user friendly display name of the device.

--- a/src/misc/list.c
+++ b/src/misc/list.c
@@ -593,7 +593,7 @@ _AL_LIST_ITEM* _al_list_at(_AL_LIST* list, size_t index)
 
       _AL_LIST_ITEM* item = list->root->prev;
 
-      index = list->size - index;
+      index = list->size - index - 1;
 
       while (index--)
          item = item->prev;


### PR DESCRIPTION
Add audio device enumeration to the dsound, sdl, alsa and pulseaudio backends (not implemented: openal, kcm, aqueue, oss).

Example usage:

	int count = al_get_audio_device_count(); // returns -1 for unsupported backends
	printf("audio device count: %d\n", count);
	
	for (int i = 0; i < count; i++)
	{
		ALLEGRO_AUDIO_DEVICE* device = al_get_audio_device(i);
		
		printf("audio device: %s\n", al_get_audio_device_name(device));
	}

the device identifier is also stored so audio device selection could easily be implemented.
