### PR TITLE
Prevent RLE data in corrupt .tga from overflowing the buffer

### DIFF
--- a/addons/image/pcx.c
+++ b/addons/image/pcx.c
@@ -54,6 +54,11 @@ ALLEGRO_BITMAP *_al_load_pcx_f(ALLEGRO_FILE *f, int flags)
    }
 
    bytes_per_line = al_fread16le(f);
+   /* It can only be this because we only support 8 bit planes */
+   if (bytes_per_line != width) {
+      ALLEGRO_ERROR("Invalid bytes per line %d\n", bytes_per_line);
+      return NULL;
+   }
 
    for (c = 0; c < 60; c++)                /* skip some more junk */
       al_fgetc(f);

--- a/addons/image/tga.c
+++ b/addons/image/tga.c
@@ -13,7 +13,7 @@
  *      By Tim Gunn.
  *
  *      RLE support added by Michal Mertl and Salvador Eduardo Tropea.
- * 
+ *
  *      Palette reading improved by Peter Wang.
  *
  *      Big-endian support added by Eric Botcazou.
@@ -34,6 +34,7 @@ ALLEGRO_DEBUG_CHANNEL("image")
 
 /* raw_tga_read8:
  *  Helper for reading 256-color raw data from TGA files.
+ *  Returns pointer past the end.
  */
 static INLINE unsigned char *raw_tga_read8(unsigned char *b, int w, ALLEGRO_FILE *f)
 {
@@ -44,8 +45,9 @@ static INLINE unsigned char *raw_tga_read8(unsigned char *b, int w, ALLEGRO_FILE
 
 /* rle_tga_read8:
  *  Helper for reading 256-color RLE data from TGA files.
+ *  Returns pointer past the end or NULL for error.
  */
-static void rle_tga_read8(unsigned char *b, int w, ALLEGRO_FILE *f)
+static unsigned char *rle_tga_read8(unsigned char *b, int w, ALLEGRO_FILE *f)
 {
    int value, count, c = 0;
 
@@ -55,6 +57,10 @@ static void rle_tga_read8(unsigned char *b, int w, ALLEGRO_FILE *f)
          /* run-length packet */
          count = (count & 0x7F) + 1;
          c += count;
+         if (c > w) {
+            /* Stepped past the end of the line, error */
+            return NULL;
+         }
          value = al_fgetc(f);
          while (count--)
             *b++ = value;
@@ -63,9 +69,14 @@ static void rle_tga_read8(unsigned char *b, int w, ALLEGRO_FILE *f)
          /* raw packet */
          count++;
          c += count;
+         if (c > w) {
+            /* Stepped past the end of the line, error */
+            return NULL;
+         }
          b = raw_tga_read8(b, count, f);
       }
    } while (c < w);
+   return b;
 }
 
 
@@ -82,6 +93,7 @@ static INLINE int32_t single_tga_read32(ALLEGRO_FILE *f)
 
 /* raw_tga_read32:
  *  Helper for reading 32-bit raw data from TGA files.
+ *  Returns pointer past the end.
  */
 static unsigned int *raw_tga_read32(unsigned int *b, int w, ALLEGRO_FILE *f)
 {
@@ -95,8 +107,9 @@ static unsigned int *raw_tga_read32(unsigned int *b, int w, ALLEGRO_FILE *f)
 
 /* rle_tga_read32:
  *  Helper for reading 32-bit RLE data from TGA files.
+ *  Returns pointer past the end or NULL for error.
  */
-static void rle_tga_read32(unsigned int *b, int w, ALLEGRO_FILE *f)
+static unsigned int *rle_tga_read32(unsigned int *b, int w, ALLEGRO_FILE *f)
 {
    int color, count, c = 0;
 
@@ -106,6 +119,10 @@ static void rle_tga_read32(unsigned int *b, int w, ALLEGRO_FILE *f)
          /* run-length packet */
          count = (count & 0x7F) + 1;
          c += count;
+         if (c > w) {
+            /* Stepped past the end of the line, error */
+            return NULL;
+         }
          color = single_tga_read32(f);
          while (count--)
             *b++ = color;
@@ -114,9 +131,14 @@ static void rle_tga_read32(unsigned int *b, int w, ALLEGRO_FILE *f)
          /* raw packet */
          count++;
          c += count;
+         if (c > w) {
+            /* Stepped past the end of the line, error */
+            return NULL;
+         }
          b = raw_tga_read32(b, count, f);
       }
    } while (c < w);
+   return b;
 }
 
 
@@ -132,6 +154,7 @@ static INLINE void single_tga_read24(ALLEGRO_FILE *f, unsigned char color[3])
 
 /* raw_tga_read24:
  *  Helper for reading 24-bit raw data from TGA files.
+ *  Returns pointer past the end.
  */
 static unsigned char *raw_tga_read24(unsigned char *b, int w, ALLEGRO_FILE *f)
 {
@@ -147,8 +170,9 @@ static unsigned char *raw_tga_read24(unsigned char *b, int w, ALLEGRO_FILE *f)
 
 /* rle_tga_read24:
  *  Helper for reading 24-bit RLE data from TGA files.
+ *  Returns pointer past the end or NULL for error.
  */
-static void rle_tga_read24(unsigned char *b, int w, ALLEGRO_FILE *f)
+static unsigned char *rle_tga_read24(unsigned char *b, int w, ALLEGRO_FILE *f)
 {
    int count, c = 0;
    unsigned char color[3];
@@ -159,6 +183,10 @@ static void rle_tga_read24(unsigned char *b, int w, ALLEGRO_FILE *f)
          /* run-length packet */
          count = (count & 0x7F) + 1;
          c += count;
+         if (c > w) {
+            /* Stepped past the end of the line, error */
+            return NULL;
+         }
          single_tga_read24(f, color);
          while (count--) {
             b[0] = color[0];
@@ -171,9 +199,14 @@ static void rle_tga_read24(unsigned char *b, int w, ALLEGRO_FILE *f)
          /* raw packet */
          count++;
          c += count;
+         if (c > w) {
+            /* Stepped past the end of the line, error */
+            return NULL;
+         }
          b = raw_tga_read24(b, count, f);
       }
    } while (c < w);
+   return b;
 }
 
 
@@ -190,6 +223,7 @@ static INLINE int single_tga_read16(ALLEGRO_FILE *f)
 
 /* raw_tga_read16:
  *  Helper for reading 16-bit raw data from TGA files.
+ *  Returns pointer past the end.
  */
 static unsigned short *raw_tga_read16(unsigned short *b, int w, ALLEGRO_FILE *f)
 {
@@ -203,8 +237,9 @@ static unsigned short *raw_tga_read16(unsigned short *b, int w, ALLEGRO_FILE *f)
 
 /* rle_tga_read16:
  *  Helper for reading 16-bit RLE data from TGA files.
+ *  Returns pointer past the end or NULL for error.
  */
-static void rle_tga_read16(unsigned short *b, int w, ALLEGRO_FILE *f)
+static unsigned short *rle_tga_read16(unsigned short *b, int w, ALLEGRO_FILE *f)
 {
    int color, count, c = 0;
 
@@ -214,6 +249,10 @@ static void rle_tga_read16(unsigned short *b, int w, ALLEGRO_FILE *f)
          /* run-length packet */
          count = (count & 0x7F) + 1;
          c += count;
+         if (c > w) {
+            /* Stepped past the end of the line, error */
+            return NULL;
+         }
          color = single_tga_read16(f);
          while (count--)
             *b++ = color;
@@ -222,9 +261,14 @@ static void rle_tga_read16(unsigned short *b, int w, ALLEGRO_FILE *f)
          /* raw packet */
          count++;
          c += count;
+         if (c > w) {
+            /* Stepped past the end of the line, error */
+            return NULL;
+         }
          b = raw_tga_read16(b, count, f);
       }
    } while (c < w);
+   return b;
 }
 
 
@@ -388,12 +432,20 @@ ALLEGRO_BITMAP *_al_load_tga_f(ALLEGRO_FILE *f, int flags)
       switch (image_type) {
 
          case 1:
-         case 3:
+         case 3: {
+            unsigned char *ptr;
             if (compressed)
-               rle_tga_read8(buf, image_width, f);
+               ptr = rle_tga_read8(buf, image_width, f);
             else
-               raw_tga_read8(buf, image_width, f);
-
+               ptr = raw_tga_read8(buf, image_width, f);
+            if (!ptr) {
+               al_free(buf);
+               al_unlock_bitmap(bmp);
+               al_destroy_bitmap(bmp);
+               ALLEGRO_ERROR("Invalid image data.\n");
+               return NULL;
+            }
+         }
             for (i = 0; i < image_width; i++) {
                int true_x = (left_to_right) ? i : (image_width - 1 - i);
                int pix = buf[i];
@@ -410,11 +462,18 @@ ALLEGRO_BITMAP *_al_load_tga_f(ALLEGRO_FILE *f, int flags)
 
          case 2:
             if (bpp == 32) {
+               unsigned int *ptr;
                if (compressed)
-                  rle_tga_read32((unsigned int *)buf, image_width, f);
+                  ptr = rle_tga_read32((unsigned int *)buf, image_width, f);
                else
-                  raw_tga_read32((unsigned int *)buf, image_width, f);
-
+                  ptr = raw_tga_read32((unsigned int *)buf, image_width, f);
+               if (!ptr) {
+                  al_free(buf);
+                  al_unlock_bitmap(bmp);
+                  al_destroy_bitmap(bmp);
+                  ALLEGRO_ERROR("Invalid image data.\n");
+                  return NULL;
+               }
                for (i = 0; i < image_width; i++) {
                   int true_x = (left_to_right) ? i : (image_width - 1 - i);
                   unsigned char *dest = (unsigned char *)lr->data +
@@ -425,12 +484,12 @@ ALLEGRO_BITMAP *_al_load_tga_f(ALLEGRO_FILE *f, int flags)
                   int r = buf[i * 4 + 1];
                   int g = buf[i * 4 + 2];
                   int b = buf[i * 4 + 3];
-#else					 
+#else
                   int b = buf[i * 4 + 0];
                   int g = buf[i * 4 + 1];
                   int r = buf[i * 4 + 2];
                   int a = buf[i * 4 + 3];
-#endif                  
+#endif
                   if (premul) {
                      r = r * a / 255;
                      g = g * a / 255;
@@ -444,10 +503,18 @@ ALLEGRO_BITMAP *_al_load_tga_f(ALLEGRO_FILE *f, int flags)
                }
             }
             else if (bpp == 24) {
+               unsigned char *ptr;
                if (compressed)
-                  rle_tga_read24(buf, image_width, f);
+                  ptr = rle_tga_read24(buf, image_width, f);
                else
-                  raw_tga_read24(buf, image_width, f);
+                  ptr = raw_tga_read24(buf, image_width, f);
+               if (!ptr) {
+                  al_free(buf);
+                  al_unlock_bitmap(bmp);
+                  al_destroy_bitmap(bmp);
+                  ALLEGRO_ERROR("Invalid image data.\n");
+                  return NULL;
+               }
                for (i = 0; i < image_width; i++) {
                   int true_x = (left_to_right) ? i : (image_width - 1 - i);
                   int b = buf[i * 3 + 0];
@@ -463,14 +530,23 @@ ALLEGRO_BITMAP *_al_load_tga_f(ALLEGRO_FILE *f, int flags)
                }
             }
             else {
+               unsigned short *ptr;
                if (compressed)
-                  rle_tga_read16((unsigned short *)buf, image_width, f);
+                  ptr = rle_tga_read16((unsigned short *)buf, image_width, f);
                else
-                  raw_tga_read16((unsigned short *)buf, image_width, f);
+                  ptr = raw_tga_read16((unsigned short *)buf, image_width, f);
+               if (!ptr) {
+                  al_free(buf);
+                  al_unlock_bitmap(bmp);
+                  al_destroy_bitmap(bmp);
+                  ALLEGRO_ERROR("Invalid image data.\n");
+                  return NULL;
+               }
                for (i = 0; i < image_width; i++) {
                   int true_x = (left_to_right) ? i : (image_width - 1 - i);
                   int pix = *((unsigned short *)(buf + i * 2));
-                  int r = _al_rgb_scale_5[(pix >> 10)];
+                  /* TODO - do something with the 1-bit A value (alpha?) */
+                  int r = _al_rgb_scale_5[(pix >> 10) & 0x1F];
                   int g = _al_rgb_scale_5[(pix >> 5) & 0x1F];
                   int b = _al_rgb_scale_5[(pix & 0x1F)];
 
@@ -597,7 +673,7 @@ bool _al_identify_tga(ALLEGRO_FILE *f)
    uint8_t x[4];
    al_fgetc(f); // skip id length
    al_fread(f, x, 4);
-   
+
    if (x[0] > 1) // TGA colormap must be 0 or 1
       return false;
    if ((x[1] & 0xf7) == 0) // type must be 1, 2, 3, 9, 10 or 11

--- a/addons/image/tga.c
+++ b/addons/image/tga.c
@@ -340,7 +340,7 @@ ALLEGRO_BITMAP *_al_load_tga_f(ALLEGRO_FILE *f, int flags)
          /* paletted image */
          /* Only support 8 bit palettes (up to 256 entries) though in principle the file format could have more(?)*/
          if ((palette_type != 1) || (bpp != 8) || (palette_start + palette_colors) > 256) {
-            ALLEGRO_ERROR("Invalid palette/image/bpp combination %d/%d/%d.\n", image_type, palette_type, bpp);
+            ALLEGRO_ERROR("Invalid image/palette/bpp combination %d/%d/%d.\n", image_type, palette_type, bpp);
             return NULL;
          }
 
@@ -354,7 +354,7 @@ ALLEGRO_BITMAP *_al_load_tga_f(ALLEGRO_FILE *f, int flags)
          else if ((palette_type == 0) && ((bpp == 24) || (bpp == 32))) {
          }
          else {
-            ALLEGRO_ERROR("Invalid palette/image/bpp combination %d/%d/%d.\n", image_type, palette_type, bpp);
+            ALLEGRO_ERROR("Invalid image/palette/bpp combination %d/%d/%d.\n", image_type, palette_type, bpp);
             return NULL;
          }
          break;
@@ -362,7 +362,7 @@ ALLEGRO_BITMAP *_al_load_tga_f(ALLEGRO_FILE *f, int flags)
       case 3:
          /* grayscale image */
          if ((palette_type != 0) || (bpp != 8)) {
-            ALLEGRO_ERROR("Invalid palette/image/bpp combination %d/%d/%d.\n", image_type, palette_type, bpp);
+            ALLEGRO_ERROR("Invalid image/palette/bpp combination %d/%d/%d.\n", image_type, palette_type, bpp);
             return NULL;
          }
 

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -106,7 +106,7 @@ ALLEGRO_BITMAP *_al_create_bitmap_params(ALLEGRO_DISPLAY *current_display,
     * int.  Supporting such bitmaps would require a lot more work.
     * Overflow calc based on https://stackoverflow.com/a/1514309/231929
     */
-   if (w < 0 || h < 0 || (int64_t) w > (INT_MAX/4) / (int64_t) h) {
+   if (w < 0 || h < 0 || (h > 0 && (int64_t) w > (INT_MAX/4) / (int64_t) h)) {
       ALLEGRO_WARN("Rejecting %dx%d bitmap\n", w, h);
       return NULL;
    }

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -100,14 +100,13 @@ ALLEGRO_BITMAP *_al_create_bitmap_params(ALLEGRO_DISPLAY *current_display,
    ALLEGRO_SYSTEM *system = al_get_system_driver();
    ALLEGRO_BITMAP *bitmap;
    ALLEGRO_BITMAP **back;
-   int64_t mul;
    bool result;
-
-   /* Reject bitmaps where a calculation pixel_size*w*h would overflow
+   /* Reject bitmaps with negative dimensions.
+    * Also reject bitmaps where a calculation pixel_size*w*h would overflow
     * int.  Supporting such bitmaps would require a lot more work.
+    * Overflow calc based on https://stackoverflow.com/a/1514309/231929
     */
-   mul = 4 * (int64_t) w * (int64_t) h;
-   if (mul > (int64_t) INT_MAX) {
+   if (w < 0 || h < 0 || (int64_t) w > (INT_MAX/4) / (int64_t) h) {
       ALLEGRO_WARN("Rejecting %dx%d bitmap\n", w, h);
       return NULL;
    }


### PR DESCRIPTION
Also masked out the 1-bit A value from a 15-bit image; this could
cause the bounds of `_al_rgb_scale_5[]` to be exceeded.

**PLEASE REVIEW** as the TGA loader is complicated (may be possible to simplify with a more extensive re-write)

Fixes #1251