### PR TITLE
Fix build failure with sanitizers enabled

### DIFF
--- a/docs/scripts/dawk.c
+++ b/docs/scripts/dawk.c
@@ -244,7 +244,8 @@ bool d_match(dstr line, const char *regex)
 
    for (i = 0; i < MAX_MATCH; i++) {
       if (trex_getsubexp(re->reg, i, &match)) {
-         strncpy(d_submatches[i], match.begin, match.len);
+         if (match.begin)
+            strncpy(d_submatches[i], match.begin, match.len);
          d_submatches[i][match.len] = '\0';
       }
       else {


### PR DESCRIPTION
Without this change the build fails with GCC's sanitizers enabled (probably ubsan) due to calling strncpy with a NULL source parameter:

```
[...]/allegro5/docs/scripts/dawk.c:247:10: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x558d2fc7fda0 in d_match [...]/allegro5/docs/scripts/dawk.c:247
    #1 0x558d2fc7d698 in main [...]/allegro5/docs/scripts/make_html_refs.c:34
    #2 0x7f97781ec7ec in __libc_start_main ../csu/libc-start.c:332
    #3 0x558d2fc7d389 in _start ([...]/allegro5-native-Debug/docs/make_html_refs+0x1c389)
```

Reproduction: build with gcc flag `-fsanitize=undefined`, and environment variable `UBSAN_OPTIONS=print_stacktrace=1,halt_on_error=1,abort_on_error=1` set.
