### PR TITLE
Add audio identification / al_identify_sample()

### DIFF
--- a/addons/acodec/acodec.c
+++ b/addons/acodec/acodec.c
@@ -24,25 +24,23 @@ bool al_init_acodec_addon(void)
 
    ret &= al_register_sample_loader(".wav", _al_load_wav);
    ret &= al_register_sample_saver(".wav", _al_save_wav);
-   ret &= al_register_audio_stream_loader(".wav", _al_load_wav_audio_stream);
-
    ret &= al_register_sample_loader_f(".wav", _al_load_wav_f);
    ret &= al_register_sample_saver_f(".wav", _al_save_wav_f);
+   ret &= al_register_audio_stream_loader(".wav", _al_load_wav_audio_stream);
    ret &= al_register_audio_stream_loader_f(".wav", _al_load_wav_audio_stream_f);
+   ret &= al_register_sample_identifier(".wav", _al_identify_wav);
 
    /* buil-in VOC loader */
    ret &= al_register_sample_loader(".voc", _al_load_voc);
    ret &= al_register_sample_loader_f(".voc", _al_load_voc_f);
+   ret &= al_register_sample_identifier(".voc", _al_identify_voc);
 
 #ifdef ALLEGRO_CFG_ACODEC_FLAC
    ret &= al_register_sample_loader(".flac", _al_load_flac);
    ret &= al_register_audio_stream_loader(".flac", _al_load_flac_audio_stream);
    ret &= al_register_sample_loader_f(".flac", _al_load_flac_f);
    ret &= al_register_audio_stream_loader_f(".flac", _al_load_flac_audio_stream_f);
-#endif
-
-#ifdef ALLEGRO_CFG_ACODEC_MODAUDIO
-   ret &= _al_register_dumb_loaders();
+   ret &= al_register_sample_identifier(".flac", _al_identify_flac);
 #endif
 
 #ifdef ALLEGRO_CFG_ACODEC_VORBIS
@@ -50,6 +48,7 @@ bool al_init_acodec_addon(void)
    ret &= al_register_audio_stream_loader(".ogg", _al_load_ogg_vorbis_audio_stream);
    ret &= al_register_sample_loader_f(".ogg", _al_load_ogg_vorbis_f);
    ret &= al_register_audio_stream_loader_f(".ogg", _al_load_ogg_vorbis_audio_stream_f);
+   ret &= al_register_sample_identifier(".ogg", _al_identify_ogg_vorbis);
 #endif
 
 #ifdef ALLEGRO_CFG_ACODEC_OPUS
@@ -57,13 +56,20 @@ bool al_init_acodec_addon(void)
    ret &= al_register_audio_stream_loader(".opus", _al_load_ogg_opus_audio_stream);
    ret &= al_register_sample_loader_f(".opus", _al_load_ogg_opus_f);
    ret &= al_register_audio_stream_loader_f(".opus", _al_load_ogg_opus_audio_stream_f);
+   ret &= al_register_sample_identifier(".opus", _al_identify_ogg_opus);
 #endif
 
+#ifdef ALLEGRO_CFG_ACODEC_MODAUDIO
+   ret &= _al_register_dumb_loaders();
+#endif
+
+   /* MP3 will mis-identify a lot of mod files, so put its identifier last */
 #ifdef ALLEGRO_CFG_ACODEC_MP3
    ret &= al_register_sample_loader(".mp3", _al_load_mp3);
    ret &= al_register_audio_stream_loader(".mp3", _al_load_mp3_audio_stream);
    ret &= al_register_sample_loader_f(".mp3", _al_load_mp3_f);
    ret &= al_register_audio_stream_loader_f(".mp3", _al_load_mp3_audio_stream_f);
+   ret &= al_register_sample_identifier(".mp3", _al_identify_mp3);
 #endif
 
    acodec_inited = ret;

--- a/addons/acodec/acodec.h
+++ b/addons/acodec/acodec.h
@@ -11,6 +11,7 @@ ALLEGRO_AUDIO_STREAM *_al_load_wav_audio_stream_f(ALLEGRO_FILE* f,
    size_t buffer_count, unsigned int samples);
 bool _al_save_wav(const char *filename, ALLEGRO_SAMPLE *spl);
 bool _al_save_wav_f(ALLEGRO_FILE *pf, ALLEGRO_SAMPLE *spl);
+bool _al_identify_wav(ALLEGRO_FILE *f);
 
 /*
  * Built-in Port of A4 Creative Voice file (.voc) Loader.
@@ -19,6 +20,7 @@ bool _al_save_wav_f(ALLEGRO_FILE *pf, ALLEGRO_SAMPLE *spl);
  */
 ALLEGRO_SAMPLE *_al_load_voc(const char *filename);
 ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *fp);
+bool _al_identify_voc(ALLEGRO_FILE *f);
 
 
 #ifdef ALLEGRO_CFG_ACODEC_FLAC
@@ -28,6 +30,7 @@ ALLEGRO_AUDIO_STREAM *_al_load_flac_audio_stream(const char *filename,
    size_t buffer_count, unsigned int samples);
 ALLEGRO_AUDIO_STREAM *_al_load_flac_audio_stream_f(ALLEGRO_FILE* f,
    size_t buffer_count, unsigned int samples);
+bool _al_identify_flac(ALLEGRO_FILE *f);
 #endif
 
 #ifdef ALLEGRO_CFG_ACODEC_MODAUDIO
@@ -41,6 +44,7 @@ ALLEGRO_AUDIO_STREAM *_al_load_ogg_vorbis_audio_stream(const char *filename,
    size_t buffer_count, unsigned int samples);
 ALLEGRO_AUDIO_STREAM *_al_load_ogg_vorbis_audio_stream_f(ALLEGRO_FILE* file,
    size_t buffer_count, unsigned int samples);
+bool _al_identify_ogg_vorbis(ALLEGRO_FILE *f);
 #endif
 
 #ifdef ALLEGRO_CFG_ACODEC_OPUS
@@ -50,6 +54,7 @@ ALLEGRO_AUDIO_STREAM *_al_load_ogg_opus_audio_stream(const char *filename,
    size_t buffer_count, unsigned int samples);
 ALLEGRO_AUDIO_STREAM *_al_load_ogg_opus_audio_stream_f(ALLEGRO_FILE* file,
    size_t buffer_count, unsigned int samples);
+bool _al_identify_ogg_opus(ALLEGRO_FILE *f);
 #endif
 
 #ifdef ALLEGRO_CFG_ACODEC_MP3
@@ -59,6 +64,7 @@ ALLEGRO_AUDIO_STREAM *_al_load_mp3_audio_stream(const char *filename,
    size_t buffer_count, unsigned int samples);
 ALLEGRO_AUDIO_STREAM *_al_load_mp3_audio_stream_f(ALLEGRO_FILE* f,
    size_t buffer_count, unsigned int samples);
+bool _al_identify_mp3(ALLEGRO_FILE *f);
 #endif
 
 #endif

--- a/addons/acodec/flac.c
+++ b/addons/acodec/flac.c
@@ -640,4 +640,14 @@ ALLEGRO_AUDIO_STREAM *_al_load_flac_audio_stream_f(ALLEGRO_FILE* f,
 }
 
 
+bool _al_identify_flac(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "fLaC", 4) == 0)
+      return true;
+   return false;
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/addons/acodec/modaudio.c
+++ b/addons/acodec/modaudio.c
@@ -3,6 +3,7 @@
  * author: Matthew Leverton
  */
 
+#include <ctype.h>
 
 #define _FILE_OFFSET_BITS 64
 #include "allegro5/allegro.h"
@@ -614,6 +615,176 @@ static ALLEGRO_AUDIO_STREAM *load_s3m_audio_stream(const char *filename,
 
 #endif // DUMB_MAJOR_VERSION
 
+static bool _al_identify_669(ALLEGRO_FILE *f)
+{
+   uint8_t x[2];
+   if (al_fread(f, x, 2) < 2)
+      return false;
+   if (memcmp(x, "if", 2) == 0 || memcmp(x, "JN", 2) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_amf(ALLEGRO_FILE *f)
+{
+   uint8_t x[3];
+   if (al_fread(f, x, 3) < 3)
+      return false;
+   if (memcmp(x, "AMF", 3) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_asy(ALLEGRO_FILE *f)
+{
+   uint8_t x[24];
+   if (al_fread(f, x, 24) < 24)
+      return false;
+   if (memcmp(x, "ASYLUM Music Format V1.0", 24) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_it(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "IMPM", 4) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_mod(ALLEGRO_FILE *f)
+{
+   static const char mod_sigs[][4] = {
+      "M.K.", "M!K!", "M&K!", "N.T.",
+      "NSMS", "FLT4", "M\0\0\0", "8\0\0\0",
+      "FEST", "FLT8", "CD81", "OCTA",
+      "OKTA", "16CN", "32CN"
+   };
+   uint8_t x[4];
+   if (!al_fseek(f, 0x438, ALLEGRO_SEEK_CUR))
+      return false;
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   for (size_t i = 0; i < sizeof(mod_sigs) / 4; ++i) {
+      if (memcmp(x, mod_sigs[i], 4) == 0)
+         return true;
+   }
+   if (memcmp(x + 2, "CH", 2) == 0 && isdigit(x[0]) && isdigit(x[1])) /* ##CH */
+      return true;
+   if (memcmp(x + 1, "CHN", 3) == 0 && isdigit(x[0])) /* #CHN */
+      return true;
+   if (memcmp(x, "TDZ", 3) == 0 && isdigit(x[3])) /* TDZ? */
+      return true;
+   return false;
+}
+
+static bool _al_identify_mtm(ALLEGRO_FILE *f)
+{
+   uint8_t x[3];
+   if (al_fread(f, x, 3) < 3)
+      return false;
+   if (memcmp(x, "MTM", 3) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_okt(ALLEGRO_FILE *f)
+{
+   uint8_t x[8];
+   if (al_fread(f, x, 8) < 8)
+      return false;
+   if (memcmp(x, "OKTASONG", 8) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_psm(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "PSM\x00", 4) == 0 || memcmp(x, "PSM\xFE", 4) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_ptm(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   if (!al_fseek(f, 0x2C, ALLEGRO_SEEK_CUR))
+      return false;
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "DSMF", 4) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_riff(ALLEGRO_FILE *f)
+{
+   static const char riff_fmts[][4] = {
+      "AM  ", "AMFF", "DSMF"
+   };
+   uint8_t x[4];
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "RIFF", 4) != 0)
+      return false;
+   if (!al_fseek(f, 4, ALLEGRO_SEEK_CUR))
+      return false;
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   for (size_t i = 0; i < sizeof(riff_fmts) / 4; ++i) {
+      if (memcmp(x, riff_fmts[i], 4) == 0)
+         return true;
+   }
+   return false;
+}
+
+static bool _al_identify_s3m(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   if (!al_fseek(f, 0x2C, ALLEGRO_SEEK_CUR))
+      return false;
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "SCRM", 4) == 0)
+      return true;
+   return false;
+}
+
+static bool _al_identify_stm(ALLEGRO_FILE *f)
+{
+   static const char stm_fmts[][8] = {
+      "!Scream!", "BMOD2STM", "WUZAMOD!"
+   };
+   uint8_t x[10];
+   if (!al_fseek(f, 20, ALLEGRO_SEEK_CUR))
+      return false;
+   if (al_fread(f, x, 10) < 8)
+      return false;
+   if (x[9] != 2)
+      return false;
+   for (size_t i = 0; i < sizeof(stm_fmts) / 8; ++i) {
+      if (memcmp(x, stm_fmts[i], 8) == 0)
+         return true;
+   }
+   return false;
+}
+
+static bool _al_identify_xm(ALLEGRO_FILE *f)
+{
+   uint8_t x[16];
+   if (al_fread(f, x, 16) < 16)
+      return false;
+   if (memcmp(x, "Extended Module:", 16) == 0)
+      return true;
+   return false;
+}
+
 bool _al_register_dumb_loaders(void)
 {
    bool ret = true;
@@ -626,30 +797,43 @@ bool _al_register_dumb_loaders(void)
     */
    ret &= al_register_audio_stream_loader(".669", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".669", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".669", _al_identify_669);
    ret &= al_register_audio_stream_loader(".amf", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".amf", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".amf", _al_identify_amf);
    ret &= al_register_audio_stream_loader(".asy", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".asy", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".asy", _al_identify_asy);
    ret &= al_register_audio_stream_loader(".it", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".it", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".it", _al_identify_it);
    ret &= al_register_audio_stream_loader(".mod", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".mod", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".mod", _al_identify_mod);
    ret &= al_register_audio_stream_loader(".mtm", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".mtm", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".mtm", _al_identify_mtm);
    ret &= al_register_audio_stream_loader(".okt", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".okt", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".okt", _al_identify_okt);
    ret &= al_register_audio_stream_loader(".psm", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".psm", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".psm", _al_identify_psm);
    ret &= al_register_audio_stream_loader(".ptm", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".ptm", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".ptm", _al_identify_ptm);
    ret &= al_register_audio_stream_loader(".riff", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".riff", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".riff", _al_identify_riff);
    ret &= al_register_audio_stream_loader(".s3m", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".s3m", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".s3m", _al_identify_s3m);
    ret &= al_register_audio_stream_loader(".stm", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".stm", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".stm", _al_identify_stm);
    ret &= al_register_audio_stream_loader(".xm", load_dumb_audio_stream);
    ret &= al_register_audio_stream_loader_f(".xm", load_dumb_audio_stream_f);
+   ret &= al_register_sample_identifier(".xm", _al_identify_xm);
 #else
    /*
     * DUMB 0.9.3 supported only these 4 formats and had no *_any loader.
@@ -658,12 +842,16 @@ bool _al_register_dumb_loaders(void)
     */
    ret &= al_register_audio_stream_loader(".xm", load_xm_audio_stream);
    ret &= al_register_audio_stream_loader_f(".xm", load_xm_audio_stream_f);
+   ret &= al_register_sample_identifier(".xm", _al_identify_xm);
    ret &= al_register_audio_stream_loader(".it", load_it_audio_stream);
    ret &= al_register_audio_stream_loader_f(".it", load_it_audio_stream_f);
+   ret &= al_register_sample_identifier(".it", _al_identify_it);
    ret &= al_register_audio_stream_loader(".mod", load_mod_audio_stream);
    ret &= al_register_audio_stream_loader_f(".mod", load_mod_audio_stream_f);
+   ret &= al_register_sample_identifier(".mod", _al_identify_mod);
    ret &= al_register_audio_stream_loader(".s3m", load_s3m_audio_stream);
    ret &= al_register_audio_stream_loader_f(".s3m", load_s3m_audio_stream_f);
+   ret &= al_register_sample_identifier(".s3m", _al_identify_s3m);
 #endif // DUMB_MAJOR_VERSION
    return ret;
 }

--- a/addons/acodec/ogg.c
+++ b/addons/acodec/ogg.c
@@ -533,4 +533,20 @@ ALLEGRO_AUDIO_STREAM *_al_load_ogg_vorbis_audio_stream_f(ALLEGRO_FILE *file,
 }
 
 
+bool _al_identify_ogg_vorbis(ALLEGRO_FILE *f)
+{
+   uint8_t x[8];
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "OggS", 4) != 0)
+      return false;
+   if (!al_fseek(f, 23, ALLEGRO_SEEK_CUR))
+      return false;
+   if (al_fread(f, x, 8) < 8)
+      return false;
+   if (memcmp(x, "\x1E\x01vorbis", 8) == 0)
+      return true;
+   return false;
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/addons/acodec/opus.c
+++ b/addons/acodec/opus.c
@@ -469,4 +469,20 @@ ALLEGRO_AUDIO_STREAM *_al_load_ogg_opus_audio_stream_f(ALLEGRO_FILE *file,
 }
 
 
+bool _al_identify_ogg_opus(ALLEGRO_FILE *f)
+{
+   uint8_t x[10];
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "OggS", 4) != 0)
+      return false;
+   if (!al_fseek(f, 22, ALLEGRO_SEEK_CUR))
+      return false;
+   if (al_fread(f, x, 10) < 10)
+      return false;
+   if (memcmp(x, "\x01\x13OpusHead", 10) == 0)
+      return true;
+   return false;
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/addons/acodec/voc.c
+++ b/addons/acodec/voc.c
@@ -101,20 +101,20 @@ static AL_VOC_DATA *voc_open(ALLEGRO_FILE *fp)
 
    /* Begin checking the Header info */
    readcount = al_fread(fp, hdrbuf, 0x16);
-   if (readcount != 0x16                                     /*shorter header*/
-       || !memcmp(hdrbuf, "Creative Voice File\0x1A", 0x14)  /*wrong id */
-       || !memcmp(hdrbuf+0x15 , "\0x00\0x1A", 0x2)) {        /*wrong offset */
+   if (readcount != 0x16                                       /*short header*/
+       || memcmp(hdrbuf, "Creative Voice File\x1A", 0x14) != 0 /*wrong id */
+       || memcmp(hdrbuf+0x14, "\x1A\x00", 0x2) != 0) {         /*wrong offset */
       ALLEGRO_ERROR("voc_open: File does not appear to be a valid VOC file");
       return NULL;
    }
 
-   al_fread(fp, &vocversion, 2);
+   READNBYTES(fp, vocversion, 2, NULL);
    if (vocversion != 0x10A && vocversion != 0x114) {   // known ver 1.10 -1.20
       ALLEGRO_ERROR("voc_open: File is of unknown version");
       return NULL;
    }
    /* checksum version check */
-   al_fread(fp, &checkver, 2);
+   READNBYTES(fp, checkver, 2, NULL);
    if (checkver != ~vocversion + 0x1234) {
       ALLEGRO_ERROR("voc_open: Bad VOC Version Identification Number");
       return NULL;

--- a/addons/acodec/voc.c
+++ b/addons/acodec/voc.c
@@ -355,3 +355,13 @@ ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *file)
  * that this format will ever be used as such.
  */
 
+
+bool _al_identify_voc(ALLEGRO_FILE *f)
+{
+   uint8_t x[22];
+   if (al_fread(f, x, 22) < 22)
+      return false;
+   if (memcmp(x, "Creative Voice File\x1A\x1A\x00", 22) == 0)
+      return true;
+   return false;
+}

--- a/addons/acodec/wav.c
+++ b/addons/acodec/wav.c
@@ -527,4 +527,21 @@ bool _al_save_wav_f(ALLEGRO_FILE *pf, ALLEGRO_SAMPLE *spl)
    return true;
 }
 
+
+bool _al_identify_wav(ALLEGRO_FILE *f)
+{
+   uint8_t x[4];
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "RIFF", 4) != 0)
+      return false;
+   if (!al_fseek(f, 4, ALLEGRO_SEEK_CUR))
+      return false;
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   if (memcmp(x, "WAVE", 4) == 0)
+      return true;
+   return false;
+}
+
 /* vim: set sts=3 sw=3 et: */

--- a/addons/audio/allegro5/allegro_audio.h
+++ b/addons/audio/allegro5/allegro_audio.h
@@ -397,6 +397,9 @@ ALLEGRO_KCM_AUDIO_FUNC(bool, al_register_audio_stream_loader_f, (const char *ext
 	ALLEGRO_AUDIO_STREAM *(*stream_loader)(ALLEGRO_FILE *fp,
 	    size_t buffer_count, unsigned int samples)));
 
+ALLEGRO_KCM_AUDIO_FUNC(bool, al_register_sample_identifier, (const char *ext,
+	bool (*identifier)(ALLEGRO_FILE *fp)));
+
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_SAMPLE *, al_load_sample, (const char *filename));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_save_sample, (const char *filename,
 	ALLEGRO_SAMPLE *spl));
@@ -409,6 +412,8 @@ ALLEGRO_KCM_AUDIO_FUNC(bool, al_save_sample_f, (ALLEGRO_FILE* fp, const char *id
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_STREAM *, al_load_audio_stream_f, (ALLEGRO_FILE* fp, const char *ident,
 	size_t buffer_count, unsigned int samples));
 
+ALLEGRO_KCM_AUDIO_FUNC(char const *, al_identify_sample_f, (ALLEGRO_FILE *fp));
+ALLEGRO_KCM_AUDIO_FUNC(char const *, al_identify_sample, (char const *filename));
 
 #if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_KCM_AUDIO_SRC)
 

--- a/addons/audio/audio.c
+++ b/addons/audio/audio.c
@@ -221,7 +221,7 @@ const ALLEGRO_AUDIO_DEVICE* al_get_audio_output_device(int index)
       if (_al_kcm_driver->get_output_devices) {
          _AL_LIST* audio_devices = _al_kcm_driver->get_output_devices();
 
-         if (index >= 0 && index < _al_list_size(audio_devices)) {
+         if (index >= 0 && index < (int)_al_list_size(audio_devices)) {
             return _al_list_item_data(_al_list_at(audio_devices, index));
          }
       }

--- a/addons/video/allegro5/allegro_video.h
+++ b/addons/video/allegro5/allegro_video.h
@@ -71,6 +71,9 @@ ALLEGRO_VIDEO_FUNC(bool, al_is_video_addon_initialized, (void));
 ALLEGRO_VIDEO_FUNC(void, al_shutdown_video_addon, (void));
 ALLEGRO_VIDEO_FUNC(uint32_t, al_get_allegro_video_version, (void));
 
+ALLEGRO_VIDEO_FUNC(char const *, al_identify_video_f, (ALLEGRO_FILE *fp));
+ALLEGRO_VIDEO_FUNC(char const *, al_identify_video, (char const *filename));
+
 #ifdef __cplusplus
    }
 #endif

--- a/addons/video/allegro5/internal/aintern_video.h
+++ b/addons/video/allegro5/internal/aintern_video.h
@@ -36,9 +36,9 @@ struct ALLEGRO_VIDEO {
    void *data;
 };
 
-typedef bool (*ALLEGRO_VIDEO_IDENTIFIER_FUNCTION)(const char *filename);
+typedef bool (*ALLEGRO_VIDEO_IDENTIFIER_FUNCTION)(ALLEGRO_FILE *f);
 
 void _al_compute_scaled_dimensions(int frame_w, int frame_h, float aspect_ratio, float *scaled_w, float *scaled_h);
 
 ALLEGRO_VIDEO_INTERFACE *_al_video_ogv_vtable(void);
-bool _al_video_identify_ogv(const char* filename);
+bool _al_video_identify_ogv(ALLEGRO_FILE *f);

--- a/addons/video/ogv.c
+++ b/addons/video/ogv.c
@@ -1361,25 +1361,17 @@ ALLEGRO_VIDEO_INTERFACE *_al_video_ogv_vtable(void)
    return &ogv_vtable;
 }
 
-bool _al_video_identify_ogv(const char* filename)
+bool _al_video_identify_ogv(ALLEGRO_FILE *f)
 {
-   ALLEGRO_FILE* fp = al_fopen(filename, "rb");
-   bool ret = false;
-   if (!fp) {
-      ALLEGRO_ERROR("Could not open %s", filename);
-      return false;
-   }
    uint8_t x[4];
-   if (al_fread(fp, x, 4) == 4) {
-      /* TODO: This technically only verifies that this is an OGG container,
-       * saying nothing of the contents. Maybe refactor read_headers and make
-       * use of it here. */
-      if (memcmp(x, "OggS", 4) == 0) {
-         ret = true;
-      }
-   }
-   al_fclose(fp);
-   return ret;
+   if (al_fread(f, x, 4) < 4)
+      return false;
+   /* TODO: This technically only verifies that this is an OGG container,
+    * saying nothing of the contents. Maybe refactor read_headers and make
+    * use of it here. */
+   if (memcmp(x, "OggS", 4) == 0)
+      return true;
+   return false;
 }
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/video/video.c
+++ b/addons/video/video.c
@@ -60,12 +60,12 @@ typedef struct VideoHandler {
 
 static _AL_VECTOR handlers = _AL_VECTOR_INITIALIZER(VideoHandler);
 
-static const char* identify_video(const char* filename)
+static const char* identify_video(ALLEGRO_FILE *f)
 {
    size_t i;
    for (i = 0; i < _al_vector_size(&handlers); i++) {
       VideoHandler *l = _al_vector_ref(&handlers, i);
-      if (l->identifier(filename)) {
+      if (l->identifier(f)) {
          return l->extension;
       }
    }
@@ -100,8 +100,9 @@ ALLEGRO_VIDEO *al_open_video(char const *filename)
    ALLEGRO_VIDEO *video;
    const char *ext;
    video = al_calloc(1, sizeof *video);
-   
-   ext = identify_video(filename);
+
+   ASSERT(filename);
+   ext = al_identify_video(filename);
    if (!ext) {
       ext = strrchr(filename, '.');
       if (!ext) {
@@ -310,6 +311,28 @@ void al_shutdown_video_addon(void)
 uint32_t al_get_allegro_video_version(void)
 {
    return ALLEGRO_VERSION_INT;
+}
+
+
+/* Function: al_identify_video_f
+ */
+char const *al_identify_video_f(ALLEGRO_FILE *fp)
+{
+   return identify_video(fp);
+}
+
+
+/* Function: al_identify_video
+ */
+char const *al_identify_video(char const *filename)
+{
+   char const *ext;
+   ALLEGRO_FILE *fp = al_fopen(filename, "rb");
+   if (!fp)
+      return NULL;
+   ext = identify_video(fp);
+   al_fclose(fp);
+   return ext;
 }
 
 /* The returned width and height are always greater than or equal to the frame

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1614,6 +1614,54 @@ See also: [al_save_sample], [al_register_sample_saver_f],
 [al_init_acodec_addon]
 
 
+### API: al_register_sample_identifier
+
+Register an identify handler for [al_identify_sample]. The given
+function will be used to detect files for the given extension. It will
+be called with a single argument of type [ALLEGRO_FILE] which is a
+file handle opened for reading and located at the first byte of the
+file. The handler should try to read as few bytes as possible to
+safely determine if the given file contents correspond to the type
+with the extension and return true in that case, false otherwise.
+The file handle must not be closed but there is no need to reset it
+to the beginning.
+
+The extension should include the leading dot ('.') character.
+It will be matched case-insensitively.
+
+The `identifier` argument may be NULL to unregister an entry.
+
+Returns true on success, false on error.
+Returns false if unregistering an entry that doesn't exist.
+
+Since: 5.2.8
+
+See also: [al_identify_bitmap]
+
+### API: al_identify_sample
+
+This works exactly as [al_identify_sample_f] but you specify the filename of the file for which to detect the type and not a file handle. The extension, if any, of the passed filename is not taken into account - only the file contents.
+
+Since: 5.2.8
+
+See also: [al_init_acodec_addon], [al_identify_sample_f], [al_register_sample_identifier]
+
+### API: al_identify_sample_f
+
+Tries to guess the audio file type of the open ALLEGRO_FILE by
+reading the first few bytes. By default Allegro cannot recognize any
+file types, but calling [al_init_acodec_addon] will add detection of the
+types it can read. You can also use [al_register_sample_identifier] to add
+identification for custom file types.
+
+Returns a pointer to a static string with a file extension for the
+type, including the leading dot. For example ".wav" or ".ogg". Returns
+NULL if the audio type cannot be determined.
+
+Since: 5.2.8
+
+See also: [al_init_acodec_addon], [al_identify_sample], [al_register_sample_identifier]
+
 ## Audio recording
 
 Allegro's audio recording routines give you real-time access to raw,

--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -1675,8 +1675,8 @@ See also: [al_register_bitmap_saver]
 ### API: al_load_bitmap
 
 Loads an image file into a new [ALLEGRO_BITMAP].
-The file type is determined by the extension, except if the file has
-no extension in which case [al_identify_bitmap] is used instead.
+The file type is determined by [al_identify_bitmap], using the extension
+as a fallback in case identification is not possible.
 
 Returns NULL on error.
 
@@ -1693,8 +1693,8 @@ See also: [al_load_bitmap_flags], [al_load_bitmap_f],
 ### API: al_load_bitmap_flags
 
 Loads an image file into a new [ALLEGRO_BITMAP].
-The file type is determined by the extension, except if the file has
-no extension in which case [al_identify_bitmap] is used instead.
+The file type is determined by [al_identify_bitmap], using the extension
+as a fallback in case identification is not possible.
 
 Returns NULL on error.
 
@@ -1799,9 +1799,9 @@ See also: [al_load_bitmap]
 ### API: al_load_bitmap_f
 
 Loads an image from an [ALLEGRO_FILE] stream into a new [ALLEGRO_BITMAP].
-The file type is determined by the passed 'ident' parameter, which is a file
-name extension including the leading dot. If (and only if) 'ident' is
-NULL, the file type is determined with [al_identify_bitmap_f] instead.
+The file type is determined by [al_identify_bitmap_f]. If identification is
+not possible, the passed 'ident' parameter, which is a file name extension
+including the leading dot, is used as a fallback, if it is not NULL.
 
 This is the same as calling [al_load_bitmap_flags_f] with 0 for the flags
 parameter.
@@ -1819,9 +1819,9 @@ See also: [al_load_bitmap_flags_f], [al_load_bitmap],
 ### API: al_load_bitmap_flags_f
 
 Loads an image from an [ALLEGRO_FILE] stream into a new [ALLEGRO_BITMAP].
-The file type is determined by the passed 'ident' parameter, which is a file
-name extension including the leading dot. If (and only if) 'ident' is
-NULL, the file type is determined with [al_identify_bitmap_f] instead.
+The file type is determined by [al_identify_bitmap_f]. If identification is
+not possible, the passed 'ident' parameter, which is a file name extension
+including the leading dot, is used as a fallback, if it is not NULL.
 
 The flags parameter is the same as for [al_load_bitmap_flags].
 

--- a/docs/src/refman/video.txt
+++ b/docs/src/refman/video.txt
@@ -92,6 +92,29 @@ meta info so you can query e.g. the size or audio rate.
 
 Since: 5.1.0
 
+## API: al_identify_video
+
+This works exactly as [al_identify_video_f] but you specify the filename of the file for which to detect the type and not a file handle. The extension, if any, of the passed filename is not taken into account - only the file contents.
+
+Since: 5.2.8
+
+See also: [al_init_video_addon], [al_identify_video_f]
+
+## API: al_identify_video_f
+
+Tries to guess the video file type of the open ALLEGRO_FILE by
+reading the first few bytes. By default Allegro cannot recognize any
+file types, but calling [al_init_video_addon] will add detection of the
+types it can read.
+
+Returns a pointer to a static string with a file extension for the
+type, including the leading dot. For example ".ogv". Returns
+NULL if the video type cannot be determined.
+
+Since: 5.2.8
+
+See also: [al_init_video_addon], [al_identify_video]
+
 ## API: al_close_video
 
 Closes the video and frees all allocated resources. The video pointer


### PR DESCRIPTION
This adds the function al_identify_sample() and related function al_register_sample_identifier(), which adjusts the behavior of al_load_sample() and al_load_audio_stream() to function the same way as al_load_bitmap() and al_load_video(), by attempting to detect the file format before considering the file extension.

Some of the identifier functions, specifically for some DUMB formats and the heuristic MP3 detection, have real potential to break code that may currently be using custom audio formats registered with al_register_sample_loader() and al_register_audio_stream_loader(), due to the potential for false-positives. Particularly uncompressed mod/tracker formats are very prone to being mis-detected as MP3 due to repetitive byte patterns.

The MP3 identifier function uses an algorithm that is similar to minimp3's mp3dec_detect family of functions, but has the advantage of only loading a fixed portion of the file contents (8KB), and typically runs about 100x faster than calling mp3dec_detect().

_This contains some code copy-pasted verbatim from minimp3, to avoid dependencies on non-public interface parts of minimp3, however it is CC0 licensed (https://github.com/lieff/minimp3/blob/master/LICENSE) and I invoke my right to copy this code and re-release it under Allegro's license._

A new pair of functions, al_identify_video() and al_identify_video_f(), are also added to the video addon for interface parity with image and audio. They function as expected and only support detecting the file format ".ogv".

Outdated al_load_bitmap() documentation is also fixed to correctly describe how format detection actually works.

Test program with results: https://gist.github.com/tehsausage/1d1f17344ed474e8c8fe0005a0c277d6