### PR TITLE
Fix native dialogs addon compatibility with older GTK+ versions

### DIFF
--- a/addons/native_dialog/gtk_menu.c
+++ b/addons/native_dialog/gtk_menu.c
@@ -393,7 +393,7 @@ static gboolean do_show_popup_menu(gpointer data)
                               GDK_GRAVITY_NORTH_WEST,
                               NULL);
 #else
-      gtk_menu_popup(args->menu->extra1, menu, NULL, NULL, NULL, 1, 0);
+      gtk_menu_popup(args->menu->extra1, NULL, NULL, NULL, NULL, 1, 0);
 #endif
 
    if (!position_called) {

--- a/addons/native_dialog/gtk_menu.c
+++ b/addons/native_dialog/gtk_menu.c
@@ -387,9 +387,14 @@ static gboolean do_show_popup_menu(gpointer data)
 
    bool position_called = false;
    if (menu)
+      /* gtk_menu_popup_at_widget only exists in gtk newer than 3.22 */
+#if GTK_CHECK_VERSION(3, 22, 0)
       gtk_menu_popup_at_widget(args->menu->extra1, menu,  GDK_GRAVITY_SOUTH_WEST,
                               GDK_GRAVITY_NORTH_WEST,
                               NULL);
+#else
+      gtk_menu_popup(args->menu->extra1, menu, NULL, NULL, NULL, 1, 0);
+#endif
 
    if (!position_called) {
       ALLEGRO_DEBUG("Position canary not called, most likely the menu didn't show "


### PR DESCRIPTION
This is part of the fix for #1276 . Having this commit cherry-picked on top of `5.2.7` branch, I was able to build liballegro_dialog and ex_menu, the latter working as expected.