### PR TITLE
Update video.c

### DIFF
--- a/addons/video/video.c
+++ b/addons/video/video.c
@@ -280,7 +280,7 @@ bool al_init_video_addon(void)
    }
 
    _al_add_exit_func(al_shutdown_video_addon, "al_shutdown_video_addon");
-
+   video_inited = true;
    return true;
 }
 


### PR DESCRIPTION
al_init_video_addon() did not update the bool "video_inited", therefore making it always stay on the default given value (false) which gives al_is_video_addon_initialized() a wrong result

Found it when al_init_video_addon gave me a 1 at debuggin and al_is_video_addon_initalized a 0,
Tested on Win11 and Arch Linux (If somehow, for some unknown reason, video_inited changes using magic powder)