### PR TITLE
Bug in Windows OpenGL display creation

### DIFF
--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -1241,7 +1241,7 @@ static void display_thread_proc(void *arg)
       DWORD lock_time;
       HWND wnd = win_disp->window;
 
-      if (disp->flags & ALLEGRO_FULLSCREEN == 0) { // Not fullscreen mode
+      if ((disp->flags & ALLEGRO_FULLSCREEN) == 0) { // Not fullscreen mode
          ShowWindow(wnd, SW_SHOWNORMAL);
          SetForegroundWindow(wnd);
          UpdateWindow(wnd);
@@ -1278,7 +1278,7 @@ static void display_thread_proc(void *arg)
           * fullscreen window without input.
           */
          while (GetForegroundWindow() != wnd) {
-            al_rest(0.01);
+            al_rest(0.1);
             SetForegroundWindow(wnd);
          }
          UpdateWindow(wnd);

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -1273,9 +1273,11 @@ static void display_thread_proc(void *arg)
        * absolutely need this to succeed, else we trap the user in a
        * fullscreen window without input.
        */
-      while (GetForegroundWindow() != wnd) {
-         al_rest(0.01);
-         SetForegroundWindow(wnd);
+      if (disp->flags & ALLEGRO_FULLSCREEN) {
+         while (GetForegroundWindow() != wnd) {
+            al_rest(0.01);
+            SetForegroundWindow(wnd);
+         }
       }
       UpdateWindow(wnd);
 


### PR DESCRIPTION
There's an infinite loop which ensures to focus the window when being created, which is apparently only strictly needed in fullscreen mode.

Sometimes the window simply cannot be focused, in which case the window creation fails after 10 seconds. This happens sporadically and is not reproducable, but for me it happens every time when launching the executable with a WiX installer after installation has finished. (Seems to lock the foreground?)

The interval of failure also seems to be dependent on the speed of the computer. It fails more often in the virtual machine which is very slow, but it has also failed on my main dev pc at some point. By starting an allegro application at the same time from 150 threads i was able to reproduce it sometimes.

Since focusing isn't strictly necessary when not in fullscreen mode, this simple fix makes it work for me, no more crashes (window is still being focused tho).