### PR TITLE
Fixed addons cmake to not overwrite dependencies

### DIFF
--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -106,19 +106,19 @@ if(SUPPORT_FONT AND WANT_TTF)
         if(TTF_COMPILES)
             set(TTF_LIBRARIES ${FREETYPE_LIBRARIES})
         else()
-            if(FREETYPE_ZLIB)
+            if(FREETYPE_ZLIB AND NOT DEFINED ZLIB_FOUND)
                 find_package(ZLIB)
             endif()
 
-            if(FREETYPE_BZIP2)
+            if(FREETYPE_BZIP2 AND NOT DEFINED BZIP2_FOUND)
                 find_package(BZip2)
             endif()
 
-            if(FREETYPE_PNG)
+            if(FREETYPE_PNG AND NOT DEFINED PNG_FOUND)
                 find_package(PNG)
             endif()
 			
-            if (FREETYPE_HARFBUZZ)
+            if (FREETYPE_HARFBUZZ AND NOT DEFINED HARFBUZZ_FOUND)
                 find_package(HarfBuzz)
             endif()
 


### PR DESCRIPTION
There was an issue when loading external dependencies. `find_package(PKG)` is used, it tries to find the library and then sets `PKG_FOUND` to `TRUE`.

I called cmake manually and set all dependencies, for example `-DFREETYPE_INCLUDE_DIRS=... -DZLIB_LIBRARIES=...`.

In the addons/CMakeLists however, `find_package(ZLIB)` was called no matter what, which for whatever reason found a .dll in the VMware Workstation directory and overwrote my correct `ZLIB_LIBRARIES=.../zlib.lib` with some weird `ZLIB_LIBRARIES=.../VMware/Workstation/zlib1.dll.lib`, which caused freetype compilation to fail.

With this small fix `find_package()` is not called if PKG_FOUND is already set to true. Now you can add `-DZLIB_FOUND=true` to the command line if the library is specified manually.

Please review and merge this at the next opportunity, thanks in advance!