### PR TITLE
Incorrect error handling in PHYSFS_close

### DIFF
--- a/addons/physfs/a5_physfs.c
+++ b/addons/physfs/a5_physfs.c
@@ -116,7 +116,7 @@ static bool file_phys_fclose(ALLEGRO_FILE *f)
 
    al_free(fp);
 
-   if (PHYSFS_close(phys_fp) != 0) {
+   if (PHYSFS_close(phys_fp) == 0) {
       al_set_errno(-1);
       return false;
    }


### PR DESCRIPTION
Per https://www.icculus.org/physfs/docs/html/physfs_8h.html#a6822f8ff10073e855a1c3a6485b882f2 the return value from PHYSFS_close() is `nonzero on success, zero on error`