### PR TITLE
Update ex_palette to build with emscripten

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -81,10 +81,11 @@ set(DATA_SHADERS
     ex_prim_shader_pixel.hlsl
     ex_prim_shader_vertex.glsl
     ex_prim_shader_vertex.hlsl
-    ex_shader_multitex_pixel.glsl
-    ex_shader_multitex_pixel.hlsl
     ex_prim_wrap_pixel.glsl
     ex_prim_wrap_pixel.hlsl
+    ex_shader_multitex_pixel.glsl
+    ex_shader_multitex_pixel.hlsl
+    ex_shader_palette_pixel.glsl
     ex_shader_pixel.glsl
     ex_shader_pixel.hlsl
     ex_shader_vertex.glsl
@@ -212,7 +213,7 @@ if(SUPPORT_OPENGL AND NOT SUPPORT_OPENGLES)
     example(ex_opengl_pixel_shader ${IMAGE})
 endif()
 if(SUPPORT_OPENGL AND NOT IPHONE AND NOT ALLEGRO_RASPBERRYPI)
-    example(ex_palette ${IMAGE} ${COLOR} ${DATA_IMAGES})
+    example(ex_palette ${IMAGE} ${COLOR} ${DATA_IMAGES} ${DATA_SHADERS})
 endif()
 
 example(ex_font ${FONT} ${IMAGE} ${DATA_IMAGES})

--- a/examples/data/ex_shader_palette_pixel.glsl
+++ b/examples/data/ex_shader_palette_pixel.glsl
@@ -15,9 +15,9 @@ void main()
   float index = texture2D(al_tex, varying_texcoord).r;
   if (index == 0.0) discard;
 
-  vec4 col_1 = texture2D(pal_tex, vec2(index, 0));
-  vec4 col_2 = texture2D(pal_tex, vec2(index, pal_set_2));
-  gl_FragColor = mix(col_1, col_2, pal_interp);
-  // gl_FragColor = col_1;
-  gl_FragColor = vec4(0,0,1,1);
+  // Although the palette texture was defined to be 7 pixels tall,
+  // allegro forces textures to be at least 16.
+  vec4 col_1 = texture2D(pal_tex, vec2(index, pal_set_1 / 15.0));
+  vec4 col_2 = texture2D(pal_tex, vec2(index, pal_set_2 / 15.0));
+  gl_FragColor = vec4(mix(col_1, col_2, pal_interp).rgb, 1.0);
 }

--- a/examples/data/ex_shader_palette_pixel.glsl
+++ b/examples/data/ex_shader_palette_pixel.glsl
@@ -1,0 +1,23 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform sampler2D al_tex;
+uniform sampler2D pal_tex;
+uniform float pal_set_1;
+uniform float pal_set_2;
+uniform float pal_interp;
+varying vec4 varying_color;
+varying vec2 varying_texcoord;
+
+void main()
+{
+  float index = texture2D(al_tex, varying_texcoord).r;
+  if (index == 0.0) discard;
+
+  vec4 col_1 = texture2D(pal_tex, vec2(index, 0));
+  vec4 col_2 = texture2D(pal_tex, vec2(index, pal_set_2));
+  gl_FragColor = mix(col_1, col_2, pal_interp);
+  // gl_FragColor = col_1;
+  gl_FragColor = vec4(0,0,1,1);
+}

--- a/examples/ex_bitmap.c
+++ b/examples/ex_bitmap.c
@@ -73,7 +73,9 @@ int main(int argc, char **argv)
     
     // Load the image and time how long it took for the log.
     t0 = al_get_time();
-    bitmap = al_load_bitmap(filename);
+    al_set_new_bitmap_flags(ALLEGRO_MEMORY_BITMAP);
+    // bitmap = al_load_bitmap(filename);
+    bitmap = al_create_bitmap(100, 100);
     t1 = al_get_time();
     if (!bitmap) {
        abort_example("%s not found or failed to load\n", filename);
@@ -143,6 +145,12 @@ int main(int argc, char **argv)
         // Redraw, but only if the event queue is empty
         if (redraw && al_is_event_queue_empty(queue)) {
             redraw = false;
+
+            al_set_target_bitmap(bitmap);
+            al_clear_to_color(al_map_rgba(255,0,255,255));
+            al_set_target_backbuffer(display);
+
+
             // Clear so we don't get trippy artifacts left after zoom.
             al_clear_to_color(al_map_rgb_f(0, 0, 0));
             if (zoom == 1)

--- a/examples/ex_bitmap.c
+++ b/examples/ex_bitmap.c
@@ -73,9 +73,7 @@ int main(int argc, char **argv)
     
     // Load the image and time how long it took for the log.
     t0 = al_get_time();
-    al_set_new_bitmap_flags(ALLEGRO_MEMORY_BITMAP);
-    // bitmap = al_load_bitmap(filename);
-    bitmap = al_create_bitmap(100, 100);
+    bitmap = al_load_bitmap(filename);
     t1 = al_get_time();
     if (!bitmap) {
        abort_example("%s not found or failed to load\n", filename);
@@ -145,12 +143,6 @@ int main(int argc, char **argv)
         // Redraw, but only if the event queue is empty
         if (redraw && al_is_event_queue_empty(queue)) {
             redraw = false;
-
-            al_set_target_bitmap(bitmap);
-            al_clear_to_color(al_map_rgba(255,0,255,255));
-            al_set_target_backbuffer(display);
-
-
             // Clear so we don't get trippy artifacts left after zoom.
             al_clear_to_color(al_map_rgb_f(0, 0, 0));
             if (zoom == 1)

--- a/examples/ex_palette.c
+++ b/examples/ex_palette.c
@@ -80,12 +80,12 @@ int main(int argc, char **argv)
    for (j = 0; j < 7; j++) {
       for (i = 0; i < 256; i++) {
          float r, g, b, h, s, l;
-         r = pal_hex[i] >> 16;
-         g = (pal_hex[i] >> 8) & 255;
-         b = pal_hex[i] & 255;
+         r = (pal_hex[i] >> 16) / 255.0;
+         g = ((pal_hex[i] >> 8) & 255) / 255.0;
+         b = (pal_hex[i] & 255) / 255.0;
          
          al_color_rgb_to_hsl(r, g, b, &h, &s, &l);
-         h += j * 60;
+         h += j * 50;
          al_color_hsl_to_rgb(h, s, l, &r, &g, &b);
 
          pals[j][i * 3 + 0] = r;
@@ -99,9 +99,9 @@ int main(int argc, char **argv)
    al_set_target_bitmap(pal_bitmap);
    for (int y = 0; y < 7; y++) {
       for (int x = 0; x < 256; x++) {
-         float r = pals[y][x * 3 + 0];
-         float g = pals[y][x * 3 + 1];
-         float b = pals[y][x * 3 + 2];
+         float r = pals[y][x * 3 + 0] * 255.0;
+         float g = pals[y][x * 3 + 1] * 255.0;
+         float b = pals[y][x * 3 + 2] * 255.0;
          al_put_pixel(x, y, al_map_rgb(r,g,b));
       }
    }

--- a/examples/ex_palette.c
+++ b/examples/ex_palette.c
@@ -18,7 +18,6 @@ int pal_hex[256];
 typedef struct {
    float x, y, angle, t;
    int flags, i, j;
-   float pal[256];
 } Sprite;
 
 static void interpolate_palette(float *pal, float *pal1, float *pal2, float t)
@@ -31,10 +30,23 @@ static void interpolate_palette(float *pal, float *pal1, float *pal2, float t)
    }
 }
 
+static void set_pal(ALLEGRO_DISPLAY *display, ALLEGRO_BITMAP *pal_bitmap, float *pal)
+{
+   al_set_target_bitmap(pal_bitmap);
+   for (int x = 0; x < 256; x++) {
+      float r = pal[x * 3 + 0];
+      float g = pal[x * 3 + 1];
+      float b = pal[x * 3 + 2];
+      al_put_pixel(x, 0, al_map_rgb(r,g,b));
+   }
+   al_set_target_backbuffer(display);
+   al_set_shader_sampler("pal_tex", pal_bitmap, 1);
+}
+
 int main(int argc, char **argv)
 {
    ALLEGRO_DISPLAY *display;
-   ALLEGRO_BITMAP *bitmap, *background;
+   ALLEGRO_BITMAP *bitmap, *background, *pal_bitmap;
    ALLEGRO_TIMER *timer;
    ALLEGRO_EVENT_QUEUE *queue;
    bool redraw = true;
@@ -84,13 +96,23 @@ int main(int argc, char **argv)
    background = al_load_bitmap("data/bkg.png");
    /* Continue even if fail to load. */
 
+   // al_set_new_bitmap_flags(ALLEGRO_MEMORY_BITMAP);
+   // al_set_new_bitmap_flags(ALLEGRO_VIDEO_BITMAP);
+   // al_set_new_bitmap_format(ALLEGRO_PIXEL_FORMAT_ARGB_8888);
+   // al_set_new_bitmap_format(ALLEGRO_PIXEL_FORMAT_ANY_32_NO_ALPHA);
+   al_set_new_bitmap_format(ALLEGRO_PIXEL_FORMAT_ANY);
+   pal_bitmap = al_create_bitmap(255, 1);
+   al_set_target_bitmap(pal_bitmap);
+
+   al_set_target_backbuffer(display);
+
    /* Create 7 palettes with changed hue. */
    for (j = 0; j < 7; j++) {
       for (i = 0; i < 256; i++) {
          float r, g, b, h, s, l;
-         r = (pal_hex[i] >> 16) / 255.0;
-         g = ((pal_hex[i] >> 8) & 255) / 255.0;
-         b = (pal_hex[i] & 255) / 255.0;
+         r = pal_hex[i] >> 16;
+         g = (pal_hex[i] >> 8) & 255;
+         b = pal_hex[i] & 255;
          
          al_color_rgb_to_hsl(r, g, b, &h, &s, &l);
          if (j == 6) {
@@ -116,44 +138,32 @@ int main(int argc, char **argv)
    }
 
    shader = al_create_shader(ALLEGRO_SHADER_GLSL);
-   
-   al_attach_shader_source(
-      shader,
-      ALLEGRO_VERTEX_SHADER,
-      "attribute vec4 al_pos;\n"
-      "attribute vec4 al_color;\n"
-      "attribute vec2 al_texcoord;\n"
-      "uniform mat4 al_projview_matrix;\n"
-      "varying vec4 varying_color;\n"
-      "varying vec2 varying_texcoord;\n"
-      "void main()\n"
-      "{\n"
-      "  varying_color = al_color;\n"
-      "  varying_texcoord = al_texcoord;\n"
-      "  gl_Position = al_projview_matrix * al_pos;\n"
-      "}\n"
-   );
-   al_attach_shader_source(
+   if (!al_attach_shader_source(shader, ALLEGRO_VERTEX_SHADER,
+         al_get_default_shader_source(ALLEGRO_SHADER_AUTO, ALLEGRO_VERTEX_SHADER))) {
+      abort_example("al_attach_shader_source for vertex shader failed: %s\n", al_get_shader_log(shader));
+   }
+   if (!al_attach_shader_source(
       shader,
       ALLEGRO_PIXEL_SHADER,
+      "precision mediump float;\n"
       "uniform sampler2D al_tex;\n"
-      "uniform vec3 pal[256];\n"
+      "uniform sampler2D pal_tex;\n"
+      "uniform float pal_set_1;\n"
+      "uniform float pal_set_2;\n"
       "varying vec4 varying_color;\n"
       "varying vec2 varying_texcoord;\n"
       "void main()\n"
       "{\n"
-      "  vec4 c = texture2D(al_tex, varying_texcoord);\n"
-      "  int index = int(c.r * 255.0);\n"
-      "  if (index != 0) {;\n"
-      "    gl_FragColor = vec4(pal[index], 1);\n"
-      "  }\n"
-      "  else {;\n"
-      "    gl_FragColor = vec4(0, 0, 0, 0);\n"
-      "  };\n"
+      "  float index = texture2D(al_tex, varying_texcoord).r;\n"
+      "  if (index == 0.0) discard;\n"
+      "  gl_FragColor = texture2D(pal_tex, vec2(index, 0));\n"
       "}\n"
-   );
-   
-   al_build_shader(shader);
+   )) {
+      abort_example("al_attach_shader_source_file for pixel shader failed: %s\n", al_get_shader_log(shader));
+   }
+   if (!al_build_shader(shader))
+      abort_example("al_build_shader failed: %s\n", al_get_shader_log(shader));
+
    al_use_shader(shader);
 
    timer = al_create_timer(1.0 / 60);
@@ -162,6 +172,8 @@ int main(int argc, char **argv)
    al_register_event_source(queue, al_get_display_event_source(display));
    al_register_event_source(queue, al_get_timer_event_source(timer));
    al_start_timer(timer);
+
+   bool once = false;
 
    while (1) {
       ALLEGRO_EVENT event;
@@ -193,25 +205,30 @@ int main(int argc, char **argv)
          redraw = false;
          al_clear_to_color(al_map_rgb_f(0, 0, 0));
 
-         interpolate_palette(pal, pals[p1 * 2], pals[p2 * 2], pos);
+         // al_set_shader_float("pal_set_1", p1 * 2);
+         // al_set_shader_float("pal_set_2", p2 * 2);
+         if (!once) {
+            interpolate_palette(pal, pals[p1 * 2], pals[p2 * 2], pos);
+            set_pal(display, pal_bitmap, pal);
+            once = true;
+         }
 
-         al_set_shader_float_vector("pal", 3, pal, 256);
          if (background)
             al_draw_bitmap(background, 0, 0, 0);
 
          for (i = 0; i < 8; i++) {
             Sprite *s = sprite + 7 - i;
-            float pos = (1 + sin((t / 60 + s->t) * 2 * ALLEGRO_PI)) / 2;
-            interpolate_palette(pal, pals[s->i], pals[s->j], pos);
-            al_set_shader_float_vector("pal", 3, pal, 256);
+            // float pos = (1 + sin((t / 60 + s->t) * 2 * ALLEGRO_PI)) / 2;
+            // interpolate_palette(pal, pals[s->i], pals[s->j], pos);
+            // set_pal(display, pal_bitmap, pal);
             al_draw_rotated_bitmap(bitmap,
                64, 64, s->x, s->y, s->angle, s->flags);
          }
          
          {
             float sc = 0.5;
-            al_set_shader_float_vector("pal", 3,
-               pals[(int)t % 20 > 15 ? 6 : 0], 256);
+            // set_pal(display, pal_bitmap, pals[(int)t % 20 > 15 ? 6 : 0]);
+
             #define D al_draw_scaled_rotated_bitmap
             D(bitmap, 0, 0,   0,   0,  sc,  sc, 0, 0);
             D(bitmap, 0, 0, 640,   0, -sc,  sc, 0, 0);


### PR DESCRIPTION
Fixes #1315

Demo: https://tedious-porter.surge.sh/ex_palette.html

- WebGL only supports non-const array index access in shaders, which makes the approach to palette swapping done by `ex_palette` not portable via emscripten. Instead of using a uniform to store the palette, and updating/interpolating it on the CPU every cycle, I changed the program to instead pre-generate a texture with all the colors and added uniforms to do the interpolation on the GPU.
- A (smaller) necessary change was to specify the precision for the fragment shader–webgl requires this
- Added a neat feature–press P and the palette texture will be rendered (scaled up)
- Extracted the fragment shader source to a data file, and replaced the vertex shader with the provided allegro default

Please note I cannot build natively on my Mac (Unrelated to these changes, I can't get the build to work, first error being: `error: use of undeclared identifier 'ALLEGRO_TIMEOUT_SDL'`). I can attempt to build it on my Windows machine tomorrow (unless a reviewer shares that it worked for them).