### PR TITLE
Fix emscripten build example for bash

### DIFF
--- a/README_sdl.txt
+++ b/README_sdl.txt
@@ -81,9 +81,9 @@ emcmake cmake .. \
     -D WANT_OPENAL=OFF \
     -D ALLEGRO_WAIT_EVENT_SLEEP=ON \
     -D SDL2_INCLUDE_DIR=$EM_CACHE/sysroot/include \
-    -D CMAKE_C_FLAGS="${USE_FLAGS}" \
-    -D CMAKE_CXX_FLAGS="${USE_FLAGS}" \
-    -D CMAKE_EXE_LINKER_FLAGS="${USE_FLAGS} --preload-file data" \
+    -D CMAKE_C_FLAGS="${USE_FLAGS[*]}" \
+    -D CMAKE_CXX_FLAGS="${USE_FLAGS[*]}" \
+    -D CMAKE_EXE_LINKER_FLAGS="${USE_FLAGS[*]} --preload-file data" \
     -D CMAKE_EXECUTABLE_SUFFIX_CXX=".html"
 ```
 


### PR DESCRIPTION
expanding an array in zsh (`echo "${USE_FLAGS}"` ) is different than in bash. zsh will expand the values as you expect, bash only the first item.

When I verified this command initially I was in my zsh terminal, and only later when trying to write a bash script using the same commands did I realize (but it took a long time) the commands weren't portable.

luckily both zsh and bash do the same sensible thing for `"${USE_FLAGS[*]}"`