### PR TITLE
Fix usage of SDL_Init for emscripten

### DIFF
--- a/src/sdl/sdl_system.c
+++ b/src/sdl/sdl_system.c
@@ -148,7 +148,7 @@ static ALLEGRO_SYSTEM *sdl_initialize(int flags)
    unsigned int sdl_flags = SDL_INIT_EVERYTHING;
 #ifdef __EMSCRIPTEN__
    // SDL currently does not support haptic feedback for emscripten.
-   sdl_flags -= SDL_INIT_HAPTIC;
+   sdl_flags &= ~SDL_INIT_HAPTIC;
 #endif
    if (SDL_Init(sdl_flags) < 0) {
       ALLEGRO_ERROR("SDL_Init failed: %s", SDL_GetError());

--- a/src/sdl/sdl_system.c
+++ b/src/sdl/sdl_system.c
@@ -144,7 +144,16 @@ static ALLEGRO_SYSTEM *sdl_initialize(int flags)
    ALLEGRO_SYSTEM_SDL *s = al_calloc(1, sizeof *s);
    s->system.vt = vt;
 
-   SDL_Init(SDL_INIT_EVERYTHING);
+   // TODO: map allegro flags to sdl flags.
+   unsigned int sdl_flags = SDL_INIT_EVERYTHING;
+#ifdef __EMSCRIPTEN__
+   // SDL currently does not support haptic feedback for emscripten.
+   sdl_flags -= SDL_INIT_HAPTIC;
+#endif
+   if (SDL_Init(sdl_flags) < 0) {
+      ALLEGRO_ERROR("SDL_Init failed: %s", SDL_GetError());
+      return NULL;
+   }
 
    _al_vector_init(&s->system.displays, sizeof (ALLEGRO_DISPLAY_SDL *));
 


### PR DESCRIPTION
This patch fixes audio for emscripten.

I printed errors as SDL_GetError was called, and saw this:

<img width="598" alt="image" src="https://user-images.githubusercontent.com/4071474/160258826-258c921f-1d13-4010-bdea-4f31076cabab.png">

Debugging told me the audio system was being initialized, but then shut down. Turns out that if any subsytem requested by SDL_Init cannot start, SDL will shutdown everything. So the haptic subsystem failing was problematic.

It fails because SDL configured the haptic subsytem to not build for emscripten (guess it's not supported).

This behavior in SDL_Init is a recent change. About 6 months ago SDL changed the init function to shutdown things when any requested subsystem failed to start: https://github.com/libsdl-org/SDL/commit/0e294e90ae6953777cc78b5d09dd5c8966dc96ab . Previously, it would just return -1, but allegro ignores the return code, so it didn't matter (not fully understanding why everything still worked even though every subsystem after the haptic would have not been initialized...shrug)

I confirmed that the audio demos now play sound in the browser when built locally, using the instructions found in the SDL readme.

Fixes #1321
