### PR TITLE
Allow SDL joysticks to be reconfigured after init

### DIFF
--- a/src/sdl/sdl_joystick.c
+++ b/src/sdl/sdl_joystick.c
@@ -49,9 +49,6 @@ static SDL_Joystick *get_sdl(ALLEGRO_JOYSTICK *allegro)
 
 void _al_sdl_joystick_event(SDL_Event *e)
 {
-   if (count <= 0)
-      return;
-
    ALLEGRO_EVENT event;
    memset(&event, 0, sizeof event);
 
@@ -97,7 +94,7 @@ void _al_sdl_joystick_event(SDL_Event *e)
 static bool sdl_init_joystick(void)
 {
    count = SDL_NumJoysticks();
-   joysticks = calloc(count, sizeof * joysticks);
+   joysticks = count > 0 ? calloc(count, sizeof * joysticks) : NULL;
    int i;
    for (i = 0; i < count; i++) {
       joysticks[i].sdl = SDL_JoystickOpen(i);
@@ -131,6 +128,7 @@ static void sdl_exit_joystick(void)
    }
    count = 0;
    free(joysticks);
+   joysticks = NULL;
 }
 
 static bool sdl_reconfigure_joysticks(void)


### PR DESCRIPTION
Currently joysticks do not work with programs built with emscripten+SDL backend. You can verify this by trying to use a gamepad with the joystick events example [here](https://allegro5.org/examples/examples/ex_joystick_events.html).

The SDL joystick code reads the number of joysticks connected on init, keeping track of the number found in a `count` variable. If a new controller connects, SDL emits an event, but currently the event handling code _ignores all events_ if on init it found zero controllers.

On the web, the `gamepadconnected` event [only fires after the first input on the controller](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API/Using_the_Gamepad_API). This means that on the web, SDL will have zero controllers on setup... unless you happen to be twiddling the controller inputs on setup. The example above initializes too quickly to see this behavior, but it was the first thing I noticed while debugging this issue in my (more setup-intensive) application: controllers only worked if I was twiddling the controller during setup.

The fix is:
1) Don't ignore events if allegro doesn't yet know about any controllers. After all, one of those events is "new controller connected"!
2) Call `sdl_reconfigure_joysticks` when a controller connects or disconnects

I confirmed this patch works for my application and for the above example:
<img width="636" alt="image" src="https://user-images.githubusercontent.com/4071474/162593884-c518de3d-2e30-4fcf-9f01-9b208f0ec63f.png">
