### PR TITLE
Set joystick button name for SDL game controllers

### DIFF
--- a/src/sdl/sdl_joystick.c
+++ b/src/sdl/sdl_joystick.c
@@ -116,7 +116,8 @@ static bool sdl_init_joystick(void)
       info->num_buttons = bn;
       int b;
       for (b = 0; b < bn; b++) {
-         info->button[b].name = "button";
+         info->button[b].name = SDL_IsGameController(i) ?
+            SDL_GameControllerGetStringForButton(b) : "button";
       }
    }
    SDL_JoystickEventState(SDL_ENABLE);


### PR DESCRIPTION
SDL provides a function to map a button to a name, but only for SDL game controllers (not SDL joysticks). Allegro doesn't have a distinction between controllers/joysticks, which is fine. But when possible allegro can query SDL for the name of a button if supported.