### PR TITLE
Fix SDL mouse axis setter

### DIFF
--- a/src/sdl/sdl_mouse.c
+++ b/src/sdl/sdl_mouse.c
@@ -187,10 +187,9 @@ static bool sdl_set_mouse_xy(ALLEGRO_DISPLAY *display, int x, int y)
 
 static bool sdl_set_mouse_axis(int which, int value)
 {
-   if (which == 1) mouse->state.z = value;
-   else if (which == 2) mouse->state.w = value;
-   else return false;
-   return true;
+   if (which == 2) mouse->state.z = value;
+   else if (which == 3) mouse->state.w = value;
+   return false;
 }
 
 static void sdl_get_mouse_state(ALLEGRO_MOUSE_STATE *ret_state)


### PR DESCRIPTION
The correct indices for the z and w mouse values are [2 and 3](https://github.com/liballeg/allegro5/blob/e8457df9492158f2c5f41676e70f0b98c7f5deeb/src/mousenu.c#L173), but the sdl mouse implementation uses 1 and 2. This results in buggy ("sticky") mouse wheel behavior when using SDL (a call to `al_set_mouse_z(0)` would never really clear the z value, so mouse events always kept their previous value given no new wheel input even though the user cleared it)