### PR TITLE
Don't use -flat_namespace in LINK_FLAGS on macOS

### DIFF
--- a/cmake/Common.cmake
+++ b/cmake/Common.cmake
@@ -158,7 +158,7 @@ function(add_our_library target framework_name sources extra_flags link_with)
     if(MACOSX)
         set_target_properties(${target}
             PROPERTIES
-            LINK_FLAGS "-flat_namespace -undefined suppress"
+            LINK_FLAGS "-undefined dynamic_lookup"
             )
     endif(MACOSX)
 


### PR DESCRIPTION
In Homebrew we have started auditing for the usage of flat namespaces in shared libraries, and have found that they are being used in the libraries built by Allegro 5.  The usage of flat namespaces is considered deprecated in modern versions of macOS (https://developer.apple.com/forums//thread/689991), and it can lead to symbol conflicts if a dynamically linked binary ends up linking to Allegro and another library with identically named symbols.  

These flags were added in 2008 in https://github.com/liballeg/allegro5/commit/646aa94fc52640e79864cb471eff8535d02fd719 and have probably remained as a historical artifact.  On modern macOS systems the proper flag should be `-undefined dynamic_lookup` instead, and Allegro builds successfully with these changes in Homebrew CI: https://github.com/Homebrew/homebrew-core/pull/101176.