### PR TITLE
Fix Sub-Menu Behavior On MacOS

### DIFF
--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -559,6 +559,7 @@ int _al_get_menu_display_height(void)
     if (aitem->popup) {
         ALLEGMenuTarget* sub = [ALLEGMenuTarget targetForMenu:aitem->popup];
         [[sub menu] setTitle:[item title]];
+        [item setAction:nil];
         [item setSubmenu:[sub menu]];
     }
     [pool release];


### PR DESCRIPTION
On MacOS, clicking a sub-menu causes the menu to close and triggers an `ALLEGRO_EVENT_MENU_CLICK`. We expect the sub-menu to open immediately when clicking the item and do nothing if the sub-menu is already open. By disabling the menu item's action when the item being added is a sub-menu we get the correct behavior when clicking on a sub-menu.