### PR TITLE
Use NSColor controlTextColor for textlog on osx

### DIFF
--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -207,9 +207,11 @@ int _al_show_native_message_box(ALLEGRO_DISPLAY *display,
 
 - (void)appendText: (NSString*)text
 {
+   NSDictionary *attributes = [NSDictionary dictionaryWithObject:[NSColor controlTextColor] forKey:NSForegroundColorAttributeName];
+   NSAttributedString *attributedString = [[[NSAttributedString alloc] initWithString:text attributes:attributes] autorelease];
    NSTextStorage* store = [self textStorage];
    [store beginEditing];
-   [[store mutableString] appendString:text];
+   [store appendAttributedString:attributedString];
    [store endEditing];
 }
 @end


### PR DESCRIPTION
Minor bug fix - when using the dark theme on Mac, the textlog text is black on a gray background so is unreadable.