### PR TITLE
docs: Clarify the difference between minimal and regular shader

### DIFF
--- a/docs/src/refman/shader.txt
+++ b/docs/src/refman/shader.txt
@@ -57,7 +57,7 @@ which dictates the language used to program the shader.
 * ALLEGRO_SHADER_GLSL - OpenGL Shading Language
 * ALLEGRO_SHADER_HLSL - High Level Shader Language (for Direct3D)
 * ALLEGRO_SHADER_AUTO_MINIMAL - Like ALLEGRO_SHADER_AUTO, but pick a
-  more minimal implementation that supports only basic alpha blending.
+  more minimal implementation that may not support alpha testing.
 * ALLEGRO_SHADER_GLSL_MINIMAL - Minimal GLSL shader.
 * ALLEGRO_SHADER_HLSL_MINIMAL - Minimal HLSL shader.
 * ALLEGRO_SHADER_HLSL_SM_3_0 - HLSL shader using shader model 3_0.


### PR DESCRIPTION
Both kinds of shaders fully support all alpha blending modes, which isn't clear from the current wording. Currently, the only difference between those shaders is that minimal GLSL shader doesn't implement alpha testing, so make it explicit in the docs.