### PR TITLE
Fix Menu Items Leading to Submenus Can't Be Disabled On MacOS

### DIFF
--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -576,6 +576,9 @@ int _al_get_menu_display_height(void)
     NSString* key = extract_accelerator(caption);
     [item setTitle:caption];
     [item setKeyEquivalent:key];
+    if (aitem->popup) {
+        [item setEnabled:(aitem->flags & ALLEGRO_MENU_ITEM_DISABLED) ? NO : YES];
+    }
     [pool release];
 }
 // Remove an item, keep the NSMenu in sync


### PR DESCRIPTION
On MacOS, menu items that lead to submenus can't be disabled. These changes are a continuation of my previous pull request (#1344) which disabled the action for items that lead to submenus. A side effect of that change was that `validateMenuItem()` is no longer being called for these types of items.

I couldn't find a way to get `validateMenuItem()` to be called without also causing the previous issue to come back. [Apple's documentation](https://developer.apple.com/documentation/appkit/nsvalidateduserinterfaceitem) isn't very clear on what happens when the item's action is set to `nil`. Since my experiments show that `validateMenuItem()` is not getting called at all, this suggests to me that these items are not being validated.

The item's enable/disabled state is determined by that validation check. It seems to me that manually enabling/disabling the item with `setEnabled()` should work under this specific set of conditions. In my testing, this does work. Items that aren't being validated with `validateMenuItem()` retain their enabled/disabled state until their state is changed with `setEnabled()`.

This commit just adds a small bit of code in `updateItem()` to manually set the enabled/disabled state when the item leads to a submenu.