### PR TITLE
Audio: functions for checking if voice/mixer has anything attached

### DIFF
--- a/addons/audio/allegro5/allegro_audio.h
+++ b/addons/audio/allegro5/allegro_audio.h
@@ -324,6 +324,7 @@ ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_MIXER_QUALITY, al_get_mixer_quality, (const ALLEG
 ALLEGRO_KCM_AUDIO_FUNC(float, al_get_mixer_gain, (const ALLEGRO_MIXER *mixer));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_mixer_playing, (const ALLEGRO_MIXER *mixer));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_mixer_attached, (const ALLEGRO_MIXER *mixer));
+ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_mixer_has_attached, (const ALLEGRO_MIXER *mixer));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_mixer_frequency, (ALLEGRO_MIXER *mixer, unsigned int val));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_mixer_quality, (ALLEGRO_MIXER *mixer, ALLEGRO_MIXER_QUALITY val));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_mixer_gain, (ALLEGRO_MIXER *mixer, float gain));
@@ -348,6 +349,7 @@ ALLEGRO_KCM_AUDIO_FUNC(unsigned int, al_get_voice_position, (const ALLEGRO_VOICE
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_CHANNEL_CONF, al_get_voice_channels, (const ALLEGRO_VOICE *voice));
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_DEPTH, al_get_voice_depth, (const ALLEGRO_VOICE *voice));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_voice_playing, (const ALLEGRO_VOICE *voice));
+ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_voice_has_attached, (const ALLEGRO_VOICE* voice));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_voice_position, (ALLEGRO_VOICE *voice, unsigned int val));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_voice_playing, (ALLEGRO_VOICE *voice, bool val));
 

--- a/addons/audio/allegro5/allegro_audio.h
+++ b/addons/audio/allegro5/allegro_audio.h
@@ -324,7 +324,7 @@ ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_MIXER_QUALITY, al_get_mixer_quality, (const ALLEG
 ALLEGRO_KCM_AUDIO_FUNC(float, al_get_mixer_gain, (const ALLEGRO_MIXER *mixer));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_mixer_playing, (const ALLEGRO_MIXER *mixer));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_mixer_attached, (const ALLEGRO_MIXER *mixer));
-ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_mixer_has_attached, (const ALLEGRO_MIXER *mixer));
+ALLEGRO_KCM_AUDIO_FUNC(bool, al_mixer_has_attachments, (const ALLEGRO_MIXER *mixer));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_mixer_frequency, (ALLEGRO_MIXER *mixer, unsigned int val));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_mixer_quality, (ALLEGRO_MIXER *mixer, ALLEGRO_MIXER_QUALITY val));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_mixer_gain, (ALLEGRO_MIXER *mixer, float gain));
@@ -349,7 +349,7 @@ ALLEGRO_KCM_AUDIO_FUNC(unsigned int, al_get_voice_position, (const ALLEGRO_VOICE
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_CHANNEL_CONF, al_get_voice_channels, (const ALLEGRO_VOICE *voice));
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_DEPTH, al_get_voice_depth, (const ALLEGRO_VOICE *voice));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_voice_playing, (const ALLEGRO_VOICE *voice));
-ALLEGRO_KCM_AUDIO_FUNC(bool, al_get_voice_has_attached, (const ALLEGRO_VOICE* voice));
+ALLEGRO_KCM_AUDIO_FUNC(bool, al_voice_has_attachments, (const ALLEGRO_VOICE* voice));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_voice_position, (ALLEGRO_VOICE *voice, unsigned int val));
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_set_voice_playing, (ALLEGRO_VOICE *voice, bool val));
 

--- a/addons/audio/kcm_mixer.c
+++ b/addons/audio/kcm_mixer.c
@@ -934,9 +934,9 @@ bool al_get_mixer_attached(const ALLEGRO_MIXER *mixer)
    return mixer->ss.parent.u.ptr;
 }
 
-/* Function: al_get_mixer_has_attached
+/* Function: al_mixer_has_attachments
  */
-bool al_get_mixer_has_attached(const ALLEGRO_MIXER* mixer)
+bool al_mixer_has_attachments(const ALLEGRO_MIXER* mixer)
 {
    ASSERT(mixer);
 

--- a/addons/audio/kcm_mixer.c
+++ b/addons/audio/kcm_mixer.c
@@ -931,6 +931,15 @@ bool al_get_mixer_attached(const ALLEGRO_MIXER *mixer)
 {
    ASSERT(mixer);
 
+   return mixer->ss.parent.u.ptr;
+}
+
+/* Function: al_get_mixer_has_attached
+ */
+bool al_get_mixer_has_attached(const ALLEGRO_MIXER* mixer)
+{
+   ASSERT(mixer);
+
    return _al_vector_is_nonempty(&mixer->streams);
 }
 

--- a/addons/audio/kcm_voice.c
+++ b/addons/audio/kcm_voice.c
@@ -464,6 +464,14 @@ bool al_get_voice_playing(const ALLEGRO_VOICE *voice)
    return voice->attached_stream ? true : false;
 }
 
+/* Function: al_get_voice_has_attached
+ */
+bool al_get_voice_has_attached(const ALLEGRO_VOICE* voice)
+{
+   ASSERT(voice);
+
+   return voice->attached_stream;
+}
 
 /* Function: al_set_voice_position
  */

--- a/addons/audio/kcm_voice.c
+++ b/addons/audio/kcm_voice.c
@@ -464,9 +464,9 @@ bool al_get_voice_playing(const ALLEGRO_VOICE *voice)
    return voice->attached_stream ? true : false;
 }
 
-/* Function: al_get_voice_has_attached
+/* Function: al_voice_has_attachments
  */
-bool al_get_voice_has_attached(const ALLEGRO_VOICE* voice)
+bool al_voice_has_attachments(const ALLEGRO_VOICE* voice)
 {
    ASSERT(voice);
 

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1537,6 +1537,7 @@ Return true if the voice has something attached to it.
 See also: [al_attach_mixer_to_voice], [al_attach_sample_instance_to_voice],
 [al_attach_audio_stream_to_voice]
 
+Since: 5.2.9
 
 ## Mixers
 
@@ -1755,6 +1756,8 @@ Return true if the mixer has something attached to it.
 
 See also: [al_get_mixer_attached], [al_attach_sample_instance_to_mixer], [al_attach_audio_stream_to_mixer],
 [al_attach_mixer_to_mixer], [al_detach_mixer]
+
+Since: 5.2.9
 
 ### API: al_detach_mixer
 

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1455,7 +1455,7 @@ attaching audio streams directly to voices. Use a mixer inbetween.
 
 Returns true on success, false on failure.
 
-See also: [al_detach_voice], [al_get_voice_has_attached]
+See also: [al_detach_voice], [al_voice_has_attachments]
 
 ### API: al_attach_mixer_to_voice
 
@@ -1464,7 +1464,7 @@ but the depth may be different.
 
 Returns true on success, false on failure.
 
-See also: [al_detach_voice], [al_get_voice_has_attached]
+See also: [al_detach_voice], [al_voice_has_attachments]
 
 ### API: al_attach_sample_instance_to_voice
 
@@ -1478,7 +1478,7 @@ Use a mixer inbetween.
 
 Returns true on success, false on failure.
 
-See also: [al_detach_voice], [al_get_voice_has_attached]
+See also: [al_detach_voice], [al_voice_has_attachments]
 
 ### API: al_get_voice_frequency
 
@@ -1530,9 +1530,9 @@ Returns true on success, false on failure.
 
 See also: [al_get_voice_position].
 
-### API: al_get_voice_has_attached
+### API: al_voice_has_attachments
 
-Return true if the voice has something attached to it.
+Returns true if the voice has something attached to it.
 
 See also: [al_attach_mixer_to_voice], [al_attach_sample_instance_to_voice],
 [al_attach_audio_stream_to_voice]
@@ -1747,12 +1747,12 @@ See also: [al_get_mixer_playing].
 
 Return true if the mixer is attached to something.
 
-See also: [al_get_mixer_has_attached], [al_attach_sample_instance_to_mixer], [al_attach_audio_stream_to_mixer],
+See also: [al_mixer_has_attachments], [al_attach_sample_instance_to_mixer], [al_attach_audio_stream_to_mixer],
 [al_attach_mixer_to_mixer], [al_detach_mixer]
 
-### API: al_get_mixer_has_attached
+### API: al_mixer_has_attachments
 
-Return true if the mixer has something attached to it.
+Returns true if the mixer has something attached to it.
 
 See also: [al_get_mixer_attached], [al_attach_sample_instance_to_mixer], [al_attach_audio_stream_to_mixer],
 [al_attach_mixer_to_mixer], [al_detach_mixer]

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1455,7 +1455,7 @@ attaching audio streams directly to voices. Use a mixer inbetween.
 
 Returns true on success, false on failure.
 
-See also: [al_detach_voice]
+See also: [al_detach_voice], [al_get_voice_has_attached]
 
 ### API: al_attach_mixer_to_voice
 
@@ -1464,7 +1464,7 @@ but the depth may be different.
 
 Returns true on success, false on failure.
 
-See also: [al_detach_voice]
+See also: [al_detach_voice], [al_get_voice_has_attached]
 
 ### API: al_attach_sample_instance_to_voice
 
@@ -1478,7 +1478,7 @@ Use a mixer inbetween.
 
 Returns true on success, false on failure.
 
-See also: [al_detach_voice]
+See also: [al_detach_voice], [al_get_voice_has_attached]
 
 ### API: al_get_voice_frequency
 
@@ -1530,6 +1530,12 @@ Returns true on success, false on failure.
 
 See also: [al_get_voice_position].
 
+### API: al_get_voice_has_attached
+
+Return true if the voice has something attached to it.
+
+See also: [al_attach_mixer_to_voice], [al_attach_sample_instance_to_voice],
+[al_attach_audio_stream_to_voice]
 
 
 ## Mixers
@@ -1740,7 +1746,14 @@ See also: [al_get_mixer_playing].
 
 Return true if the mixer is attached to something.
 
-See also: [al_attach_sample_instance_to_mixer], [al_attach_audio_stream_to_mixer],
+See also: [al_get_mixer_has_attached], [al_attach_sample_instance_to_mixer], [al_attach_audio_stream_to_mixer],
+[al_attach_mixer_to_mixer], [al_detach_mixer]
+
+### API: al_get_mixer_has_attached
+
+Return true if the mixer has something attached to it.
+
+See also: [al_get_mixer_attached], [al_attach_sample_instance_to_mixer], [al_attach_audio_stream_to_mixer],
 [al_attach_mixer_to_mixer], [al_detach_mixer]
 
 ### API: al_detach_mixer


### PR DESCRIPTION
- Adds two new functions (al_mixer_has_attachments, al_voice_has_attachments) that allow checking if the mixer/voice has anything attached to it.
- Corrects al_get_mixer_attached: it previously behaved like current al_mixer_has_attachments, contrary to what the docs say it's supposed to do.
- Updated the docs to match.