### PR TITLE
Make al_destroy_event_queue(NULL) do nothing

### DIFF
--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -26,7 +26,7 @@ that the basic API only supports on such audio stream playing at once.
 ### API: ALLEGRO_SAMPLE_ID
 
 An ALLEGRO_SAMPLE_ID represents a sample being played via [al_play_sample].
-It can be used to later sALLEGRO_BITMAP_WRAPtop the sample with [al_stop_sample]. The underlying
+It can be used to later stop the sample with [al_stop_sample]. The underlying
 ALLEGRO_SAMPLE_INSTANCE can be extracted using [al_lock_sample_id].
 
 ### API: al_install_audio

--- a/docs/src/refman/events.txt
+++ b/docs/src/refman/events.txt
@@ -662,6 +662,8 @@ Destroy the event queue specified.  All event sources currently
 registered with the queue will be automatically unregistered before
 the queue is destroyed.
 
+This function does nothing if `queue` is NULL. (since 5.2.9)
+
 See also: [al_create_event_queue], [ALLEGRO_EVENT_QUEUE]
 
 ## API: al_register_event_source

--- a/src/events.c
+++ b/src/events.c
@@ -119,26 +119,26 @@ ALLEGRO_EVENT_QUEUE *al_create_event_queue(void)
  */
 void al_destroy_event_queue(ALLEGRO_EVENT_QUEUE *queue)
 {
-   ASSERT(queue);
+   if (queue) {
+      _al_unregister_destructor(_al_dtor_list, queue->dtor_item);
 
-   _al_unregister_destructor(_al_dtor_list, queue->dtor_item);
+      /* Unregister any event sources registered with this queue.  */
+      while (_al_vector_is_nonempty(&queue->sources)) {
+         ALLEGRO_EVENT_SOURCE** slot = _al_vector_ref_back(&queue->sources);
+         al_unregister_event_source(queue, *slot);
+      }
 
-   /* Unregister any event sources registered with this queue.  */
-   while (_al_vector_is_nonempty(&queue->sources)) {
-      ALLEGRO_EVENT_SOURCE **slot = _al_vector_ref_back(&queue->sources);
-      al_unregister_event_source(queue, *slot);
+      ASSERT(_al_vector_is_empty(&queue->sources));
+      _al_vector_free(&queue->sources);
+
+      ASSERT(queue->events_head == queue->events_tail);
+      _al_vector_free(&queue->events);
+
+      _al_cond_destroy(&queue->cond);
+      _al_mutex_destroy(&queue->mutex);
+
+      al_free(queue);
    }
-
-   ASSERT(_al_vector_is_empty(&queue->sources));
-   _al_vector_free(&queue->sources);
-
-   ASSERT(queue->events_head == queue->events_tail);
-   _al_vector_free(&queue->events);
-
-   _al_cond_destroy(&queue->cond);
-   _al_mutex_destroy(&queue->mutex);
-
-   al_free(queue);
 }
 
 


### PR DESCRIPTION
Most if not all other al_destroy_XXX functions do nothing if NULL is passed to them, while destroying a null event queue currently causes an assert to fail or simply throws an error on runtime. Unless there's a specific reason for this I'm not aware of, I think having it behave like the other destroy functions would be preferable.