### PR TITLE
al_can_set_keyboard_leds & al_can_get_mouse_cursor_position

### DIFF
--- a/include/allegro5/keyboard.h
+++ b/include/allegro5/keyboard.h
@@ -44,6 +44,7 @@ AL_FUNC(bool,         al_is_keyboard_installed,   (void));
 AL_FUNC(bool,         al_install_keyboard,   (void));
 AL_FUNC(void,         al_uninstall_keyboard, (void));
 
+AL_FUNC(bool,         al_can_set_keyboard_leds,  (void));
 AL_FUNC(bool,         al_set_keyboard_leds,  (int leds));
 
 AL_FUNC(const char *, al_keycode_to_name, (int keycode));

--- a/include/allegro5/mouse.h
+++ b/include/allegro5/mouse.h
@@ -65,6 +65,7 @@ AL_FUNC(bool,           al_set_mouse_axis,      (int axis, int value));
 AL_FUNC(void,           al_get_mouse_state,     (ALLEGRO_MOUSE_STATE *ret_state));
 AL_FUNC(bool,           al_mouse_button_down,   (const ALLEGRO_MOUSE_STATE *state, int button));
 AL_FUNC(int,            al_get_mouse_state_axis, (const ALLEGRO_MOUSE_STATE *state, int axis));
+AL_FUNC(bool, al_can_get_mouse_cursor_position, (void));
 AL_FUNC(bool, al_get_mouse_cursor_position, (int *ret_x, int *ret_y));
 AL_FUNC(bool, al_grab_mouse, (struct ALLEGRO_DISPLAY *display));
 AL_FUNC(bool, al_ungrab_mouse, (void));

--- a/src/keybdnu.c
+++ b/src/keybdnu.c
@@ -198,6 +198,17 @@ static ALLEGRO_KEYBOARD *al_get_keyboard(void)
 
 
 
+/* Function: al_can_set_keyboard_leds
+ */
+bool al_can_set_keyboard_leds(void)
+{
+   ASSERT(new_keyboard_driver);
+
+   return new_keyboard_driver->set_keyboard_leds;
+}
+
+
+
 /* Function: al_set_keyboard_leds
  */
 bool al_set_keyboard_leds(int leds)

--- a/src/mousenu.c
+++ b/src/mousenu.c
@@ -251,6 +251,15 @@ bool al_mouse_button_down(const ALLEGRO_MOUSE_STATE *state, int button)
 }
 
 
+/* Function: al_can_get_mouse_cursor_position
+ */
+bool al_can_get_mouse_cursor_position(void)
+{
+   ALLEGRO_SYSTEM *alsys = al_get_system_driver();
+
+   return alsys->vt->get_cursor_position;
+}
+
 
 /* Function: al_get_mouse_cursor_position
  */


### PR DESCRIPTION
al_set_keyboard_leds & al_get_mouse_cursor_position aren't guaranteed to be available. These functions allow checking for their availability.

Apologies for the pedantic pull request spam, I think I'm done for now.