### PR TITLE
Docs entries for new functions

### DIFF
--- a/docs/src/refman/keyboard.txt
+++ b/docs/src/refman/keyboard.txt
@@ -205,6 +205,12 @@ See also: [ALLEGRO_KEYBOARD_STATE]
 
 Converts the given keycode to a description of the key.
 
+## API: al_can_set_keyboard_leds
+
+Returns true if setting the keyboard LED indicators is available.
+
+See also: [al_set_keyboard_leds]
+
 ## API: al_set_keyboard_leds
 
 Overrides the state of the keyboard LED indicators. Set `leds` to a
@@ -213,6 +219,8 @@ indicators (`ALLEGRO_KEYMOD_NUMLOCK`, `ALLEGRO_KEYMOD_CAPSLOCK` and
 `ALLEGRO_KEYMOD_SCROLLLOCK` are supported) or to -1 to return to default
 behavior. False is returned if the current keyboard driver cannot set LED
 indicators.
+
+See also: [al_can_set_keyboard_leds]
 
 ## API: al_get_keyboard_event_source
 

--- a/docs/src/refman/mouse.txt
+++ b/docs/src/refman/mouse.txt
@@ -248,6 +248,12 @@ Returns true on success, false on failure.
 
 See also: [al_set_mouse_cursor], [al_show_mouse_cursor], [al_hide_mouse_cursor]
 
+### API: al_can_get_mouse_cursor_position
+
+Returns true if getting the global mouse cursor position is available.
+
+See also: [al_get_mouse_cursor_position]
+
 ### API: al_get_mouse_cursor_position
 
 On platforms where this information is available, this function returns the
@@ -256,6 +262,8 @@ not normally use this function, as the information is not useful except
 for special scenarios as moving a window.
 
 Returns true on success, false on failure.
+
+See also: [al_can_get_mouse_cursor_position]
 
 ### API: al_hide_mouse_cursor
 


### PR DESCRIPTION
It seems I forgot to include the docs entries for al_can_set_keyboard_leds and al_can_set_mouse_cursor_position.