### PR TITLE
Misc. fixes

### DIFF
--- a/addons/acodec/voc.c
+++ b/addons/acodec/voc.c
@@ -259,8 +259,6 @@ ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *file)
    size_t bytestoread = 0;
    bool endofvoc = false;
 
-   vocdata = al_malloc(sizeof(AL_VOC_DATA));
-   memset(vocdata, 0, sizeof(*vocdata));
    /*
     * Open file and populate VOC DATA, then create a buffer for the number of
     * samples of the frst block.

--- a/addons/acodec/voc.c
+++ b/addons/acodec/voc.c
@@ -255,6 +255,7 @@ ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *file)
    size_t pos = 0; /* where to write in the buffer */
    size_t read = 0; /*bytes read during last operation */
    char* buffer;
+   size_t buffer_size = 0;
 
    size_t bytestoread = 0;
    bool endofvoc = false;
@@ -276,7 +277,8 @@ ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *file)
    /*
     * Let's allocate at least the first block's bytes;
     */
-   buffer = al_malloc(vocdata->samples * vocdata->sample_size);
+   buffer_size = vocdata->samples * vocdata->sample_size;
+   buffer = al_malloc(buffer_size);
    if (!buffer) {
       return NULL;
    }
@@ -284,7 +286,7 @@ ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *file)
     * We now need to iterate over data blocks till either we hit end of file
     * or we find a terminator block.
     */
-   bytestoread = vocdata->samples * vocdata->sample_size;
+   bytestoread = buffer_size;
    while(!endofvoc && !al_feof(vocdata->file)) {
       uint32_t blocktype = 0;
       uint32_t x = 0, len = 0;
@@ -304,7 +306,8 @@ ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *file)
             READNBYTES(vocdata->file, x, 1, NULL);
             bytestoread += x<<16;
             /* increase subsequently storage */
-            buffer = al_realloc(buffer, sizeof(buffer) + bytestoread);
+            buffer_size += bytestoread;
+            buffer = al_realloc(buffer, buffer_size);
             break;
             }
          case 1:   // we found a NEW data block starter, I assume this is wrong

--- a/addons/acodec/voc.c
+++ b/addons/acodec/voc.c
@@ -277,7 +277,7 @@ ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *file)
    /*
     * Let's allocate at least the first block's bytes;
     */
-   buffer_size = vocdata->samples * vocdata->sample_size;
+   buffer_size = (size_t)vocdata->samples * vocdata->sample_size;
    buffer = al_malloc(buffer_size);
    if (!buffer) {
       return NULL;
@@ -304,7 +304,7 @@ ALLEGRO_SAMPLE *_al_load_voc_f(ALLEGRO_FILE *file)
             bytestoread = 0;
             READNBYTES(vocdata->file, bytestoread, 2, NULL);
             READNBYTES(vocdata->file, x, 1, NULL);
-            bytestoread += x<<16;
+            bytestoread += (size_t)x << 16;
             /* increase subsequently storage */
             buffer_size += bytestoread;
             buffer = al_realloc(buffer, buffer_size);

--- a/addons/primitives/primitives.c
+++ b/addons/primitives/primitives.c
@@ -313,11 +313,11 @@ fail:
  */
 void al_destroy_vertex_buffer(ALLEGRO_VERTEX_BUFFER* buffer)
 {
-   int flags = al_get_display_flags(al_get_current_display());
-   ASSERT(addon_initialized);
-
    if (buffer == 0)
       return;
+
+   int flags = al_get_display_flags(al_get_current_display());
+   ASSERT(addon_initialized);
 
    al_unlock_vertex_buffer(buffer);
 
@@ -335,11 +335,11 @@ void al_destroy_vertex_buffer(ALLEGRO_VERTEX_BUFFER* buffer)
  */
 void al_destroy_index_buffer(ALLEGRO_INDEX_BUFFER* buffer)
 {
-   int flags = al_get_display_flags(al_get_current_display());
-   ASSERT(addon_initialized);
-
    if (buffer == 0)
       return;
+
+   int flags = al_get_display_flags(al_get_current_display());
+   ASSERT(addon_initialized);
 
    al_unlock_index_buffer(buffer);
 

--- a/docs/src/refman/keyboard.txt
+++ b/docs/src/refman/keyboard.txt
@@ -209,6 +209,8 @@ Converts the given keycode to a description of the key.
 
 Returns true if setting the keyboard LED indicators is available.
 
+Since: 5.2.9
+
 See also: [al_set_keyboard_leds]
 
 ## API: al_set_keyboard_leds

--- a/docs/src/refman/mouse.txt
+++ b/docs/src/refman/mouse.txt
@@ -252,6 +252,8 @@ See also: [al_set_mouse_cursor], [al_show_mouse_cursor], [al_hide_mouse_cursor]
 
 Returns true if getting the global mouse cursor position is available.
 
+Since: 5.2.9
+
 See also: [al_get_mouse_cursor_position]
 
 ### API: al_get_mouse_cursor_position


### PR DESCRIPTION
- (#1341) Fixes a memory leak when loading .voc samples.
- (#1341) Fixes incorrect buffer scaling during continuation block loading (previously kept adding to the size of the pointer).
- Bumps the early return for NULL vertex/index buffers up above a few functions that can throw errors.
- Adds "Since 5.2.9" to the docs I sent earlier.