### PR TITLE
Fix improper display boundary for cursors on OSX

### DIFF
--- a/examples/ex_mouse_events.c
+++ b/examples/ex_mouse_events.c
@@ -75,6 +75,11 @@ int main(int argc, char **argv)
       abort_example("Error creating display\n");
    }
 
+   // Resize the display - this is to excercise the resizing code wrt.
+   // the cursor display boundary, which requires some special care on some
+   // platforms (such as OSX).
+   al_resize_display(display, 640*1.5, 480*1.5);
+
    al_hide_mouse_cursor(display);
 
    cursor = al_load_bitmap("data/cursor.tga");

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -323,14 +323,12 @@ void _al_osx_mouse_was_installed(BOOL install) {
 - (void) reshape
 {
    [super reshape];
-   if ([NSOpenGLContext currentContext] != nil) {
-      ALLEGRO_DISPLAY_OSX_WIN* dpy =  (ALLEGRO_DISPLAY_OSX_WIN*) dpy_ptr;
 
-      if (dpy->tracking) {
-         [self removeTrackingArea: dpy->tracking];
-         dpy->tracking = create_tracking_area(self);
-         [self addTrackingArea: dpy->tracking];
-      }
+   ALLEGRO_DISPLAY_OSX_WIN* dpy =  (ALLEGRO_DISPLAY_OSX_WIN*) dpy_ptr;
+   if (dpy->tracking) {
+      [self removeTrackingArea: dpy->tracking];
+      dpy->tracking = create_tracking_area(self);
+      [self addTrackingArea: dpy->tracking];
    }
 }
 


### PR DESCRIPTION
`reshape` is called whenever the window's NSView changes size, and its job is to set the cursor tracking area. However, it was checking [NSOpenGLContext currentContext] existed before updating the tracking area. For some reason it was nil by the time `al_resize_display` is called.

The logic for updating the tracking area doesn't seem to need this context, so it should be safe to delete this guard.

ex_mouse_events is updated to resize the display. Without this patch, such a change to this example presents the bug: the ALLEGRO_EVENT_MOUSE_ENTER_DISPLAY / ALLEGRO_EVENT_MOUSE_LEAVE_DISPLAY events are fired only for the lower-left quadrant of the display.

Fixes #1282