### PR TITLE
Allow passing const arrays to spline functions

### DIFF
--- a/addons/primitives/allegro5/allegro_primitives.h
+++ b/addons/primitives/allegro5/allegro_primitives.h
@@ -227,8 +227,8 @@ ALLEGRO_PRIM_FUNC(void, al_draw_arc, (float cx, float cy, float r, float start_t
 ALLEGRO_PRIM_FUNC(void, al_draw_elliptical_arc, (float cx, float cy, float rx, float ry, float start_theta, float delta_theta, ALLEGRO_COLOR color, float thickness));
 ALLEGRO_PRIM_FUNC(void, al_draw_pieslice, (float cx, float cy, float r, float start_theta, float delta_theta, ALLEGRO_COLOR color, float thickness));
 
-ALLEGRO_PRIM_FUNC(void, al_calculate_spline, (float* dest, int stride, float points[8], float thickness, int num_segments));
-ALLEGRO_PRIM_FUNC(void, al_draw_spline, (float points[8], ALLEGRO_COLOR color, float thickness));
+ALLEGRO_PRIM_FUNC(void, al_calculate_spline, (float* dest, int stride, const float points[8], float thickness, int num_segments));
+ALLEGRO_PRIM_FUNC(void, al_draw_spline, (const float points[8], ALLEGRO_COLOR color, float thickness));
 
 ALLEGRO_PRIM_FUNC(void, al_calculate_ribbon, (float* dest, int dest_stride, const float *points, int points_stride, float thickness, int num_segments));
 ALLEGRO_PRIM_FUNC(void, al_draw_ribbon, (const float *points, int points_stride, ALLEGRO_COLOR color, float thickness, int num_segments));

--- a/addons/primitives/high_primitives.c
+++ b/addons/primitives/high_primitives.c
@@ -1001,7 +1001,7 @@ void al_draw_filled_rounded_rectangle(float x1, float y1, float x2, float y2,
 
 /* Function: al_calculate_spline
  */
-void al_calculate_spline(float* dest, int stride, float points[8],
+void al_calculate_spline(float* dest, int stride, const float points[8],
    float thickness, int num_segments)
 {
    /* Derivatives of x(t) and y(t). */
@@ -1080,7 +1080,7 @@ void al_calculate_spline(float* dest, int stride, float points[8],
 
 /* Function: al_draw_spline
  */
-void al_draw_spline(float points[8], ALLEGRO_COLOR color, float thickness)
+void al_draw_spline(const float points[8], ALLEGRO_COLOR color, float thickness)
 {
    int ii;
    float scale = get_scale();


### PR DESCRIPTION
The two spline functions currently require a mutable pointer to be passed despite not actually modifying it in any way, meaning a pointless cast is required when using them with const arrays, at least in c++. None of the other primitive functions need a mutable pointer, so I assume this is just an oversight.