### PR TITLE
Addition of a few const qualifiers on primitive and bitmap functions

### DIFF
--- a/addons/primitives/allegro5/allegro_primitives.h
+++ b/addons/primitives/allegro5/allegro_primitives.h
@@ -182,7 +182,7 @@ ALLEGRO_PRIM_FUNC(ALLEGRO_VERTEX_BUFFER*, al_create_vertex_buffer, (ALLEGRO_VERT
 ALLEGRO_PRIM_FUNC(void, al_destroy_vertex_buffer, (ALLEGRO_VERTEX_BUFFER* buffer));
 ALLEGRO_PRIM_FUNC(void*, al_lock_vertex_buffer, (ALLEGRO_VERTEX_BUFFER* buffer, int offset, int length, int flags));
 ALLEGRO_PRIM_FUNC(void, al_unlock_vertex_buffer, (ALLEGRO_VERTEX_BUFFER* buffer));
-ALLEGRO_PRIM_FUNC(int, al_get_vertex_buffer_size, (ALLEGRO_VERTEX_BUFFER* buffer));
+ALLEGRO_PRIM_FUNC(int, al_get_vertex_buffer_size, (const ALLEGRO_VERTEX_BUFFER* buffer));
 
 /*
  * Index buffers
@@ -191,7 +191,7 @@ ALLEGRO_PRIM_FUNC(ALLEGRO_INDEX_BUFFER*, al_create_index_buffer, (int index_size
 ALLEGRO_PRIM_FUNC(void, al_destroy_index_buffer, (ALLEGRO_INDEX_BUFFER* buffer));
 ALLEGRO_PRIM_FUNC(void*, al_lock_index_buffer, (ALLEGRO_INDEX_BUFFER* buffer, int offset, int length, int flags));
 ALLEGRO_PRIM_FUNC(void, al_unlock_index_buffer, (ALLEGRO_INDEX_BUFFER* buffer));
-ALLEGRO_PRIM_FUNC(int, al_get_index_buffer_size, (ALLEGRO_INDEX_BUFFER* buffer));
+ALLEGRO_PRIM_FUNC(int, al_get_index_buffer_size, (const ALLEGRO_INDEX_BUFFER* buffer));
 
 /*
 * Utilities for high level primitives.

--- a/addons/primitives/allegro5/internal/aintern_prim.h
+++ b/addons/primitives/allegro5/internal/aintern_prim.h
@@ -69,7 +69,7 @@ bool      _al_prim_is_point_in_triangle(const float* point, const float* v0, con
 bool      _al_prim_intersect_segment(const float* v0, const float* v1, const float* p0, const float* p1, float* point, float* t0, float* t1);
 bool      _al_prim_are_points_equal(const float* point_a, const float* point_b);
 
-int _al_bitmap_region_is_locked(ALLEGRO_BITMAP* bmp, int x1, int y1, int x2, int y2);
+int _al_bitmap_region_is_locked(const ALLEGRO_BITMAP* bmp, int x1, int y1, int x2, int y2);
 int _al_draw_buffer_common_soft(ALLEGRO_VERTEX_BUFFER* vertex_buffer, ALLEGRO_BITMAP* texture, ALLEGRO_INDEX_BUFFER* index_buffer, int start, int end, int type);
 
 #ifdef __cplusplus

--- a/addons/primitives/primitives.c
+++ b/addons/primitives/primitives.c
@@ -144,7 +144,7 @@ int al_draw_indexed_prim(const void* vtxs, const ALLEGRO_VERTEX_DECL* decl,
    return ret;
 }
 
-int _al_bitmap_region_is_locked(ALLEGRO_BITMAP* bmp, int x1, int y1, int w, int h)
+int _al_bitmap_region_is_locked(const ALLEGRO_BITMAP* bmp, int x1, int y1, int w, int h)
 {
    ASSERT(bmp);
    
@@ -582,7 +582,7 @@ int al_draw_indexed_buffer(ALLEGRO_VERTEX_BUFFER* vertex_buffer,
 
 /* Function: al_get_vertex_buffer_size
  */
-int al_get_vertex_buffer_size(ALLEGRO_VERTEX_BUFFER* buffer)
+int al_get_vertex_buffer_size(const ALLEGRO_VERTEX_BUFFER* buffer)
 {
    ASSERT(buffer);
    return buffer->common.size;
@@ -590,7 +590,7 @@ int al_get_vertex_buffer_size(ALLEGRO_VERTEX_BUFFER* buffer)
 
 /* Function: al_get_index_buffer_size
  */
-int al_get_index_buffer_size(ALLEGRO_INDEX_BUFFER* buffer)
+int al_get_index_buffer_size(const ALLEGRO_INDEX_BUFFER* buffer)
 {
    ASSERT(buffer);
    return buffer->common.size;

--- a/include/allegro5/bitmap.h
+++ b/include/allegro5/bitmap.h
@@ -56,10 +56,10 @@ AL_FUNC(void, al_get_new_bitmap_wrap, (ALLEGRO_BITMAP_WRAP *u, ALLEGRO_BITMAP_WR
 AL_FUNC(void, al_set_new_bitmap_wrap, (ALLEGRO_BITMAP_WRAP u, ALLEGRO_BITMAP_WRAP v));
 #endif
 
-AL_FUNC(int, al_get_bitmap_width, (ALLEGRO_BITMAP *bitmap));
-AL_FUNC(int, al_get_bitmap_height, (ALLEGRO_BITMAP *bitmap));
-AL_FUNC(int, al_get_bitmap_format, (ALLEGRO_BITMAP *bitmap));
-AL_FUNC(int, al_get_bitmap_flags, (ALLEGRO_BITMAP *bitmap));
+AL_FUNC(int, al_get_bitmap_width, (const ALLEGRO_BITMAP *bitmap));
+AL_FUNC(int, al_get_bitmap_height, (const ALLEGRO_BITMAP *bitmap));
+AL_FUNC(int, al_get_bitmap_format, (const ALLEGRO_BITMAP *bitmap));
+AL_FUNC(int, al_get_bitmap_flags, (const ALLEGRO_BITMAP *bitmap));
 
 #if defined(ALLEGRO_UNSTABLE) || defined(ALLEGRO_INTERNAL_UNSTABLE) || defined(ALLEGRO_SRC)
 AL_FUNC(int, al_get_bitmap_depth, (ALLEGRO_BITMAP *bitmap));
@@ -94,10 +94,10 @@ AL_FUNC(void, al_get_clipping_rectangle, (int *x, int *y, int *w, int *h));
 
 /* Sub bitmaps */
 AL_FUNC(ALLEGRO_BITMAP *, al_create_sub_bitmap, (ALLEGRO_BITMAP *parent, int x, int y, int w, int h));
-AL_FUNC(bool, al_is_sub_bitmap, (ALLEGRO_BITMAP *bitmap));
+AL_FUNC(bool, al_is_sub_bitmap, (const ALLEGRO_BITMAP *bitmap));
 AL_FUNC(ALLEGRO_BITMAP *, al_get_parent_bitmap, (ALLEGRO_BITMAP *bitmap));
-AL_FUNC(int, al_get_bitmap_x, (ALLEGRO_BITMAP *bitmap));
-AL_FUNC(int, al_get_bitmap_y, (ALLEGRO_BITMAP *bitmap));
+AL_FUNC(int, al_get_bitmap_x, (const ALLEGRO_BITMAP *bitmap));
+AL_FUNC(int, al_get_bitmap_y, (const ALLEGRO_BITMAP *bitmap));
 AL_FUNC(void, al_reparent_bitmap, (ALLEGRO_BITMAP *bitmap,
    ALLEGRO_BITMAP *parent, int x, int y, int w, int h));
 

--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -288,7 +288,7 @@ void al_convert_mask_to_alpha(ALLEGRO_BITMAP *bitmap, ALLEGRO_COLOR mask_color)
 
 /* Function: al_get_bitmap_width
  */
-int al_get_bitmap_width(ALLEGRO_BITMAP *bitmap)
+int al_get_bitmap_width(const ALLEGRO_BITMAP *bitmap)
 {
    return bitmap->w;
 }
@@ -297,7 +297,7 @@ int al_get_bitmap_width(ALLEGRO_BITMAP *bitmap)
 
 /* Function: al_get_bitmap_height
  */
-int al_get_bitmap_height(ALLEGRO_BITMAP *bitmap)
+int al_get_bitmap_height(const ALLEGRO_BITMAP *bitmap)
 {
    return bitmap->h;
 }
@@ -306,7 +306,7 @@ int al_get_bitmap_height(ALLEGRO_BITMAP *bitmap)
 
 /* Function: al_get_bitmap_format
  */
-int al_get_bitmap_format(ALLEGRO_BITMAP *bitmap)
+int al_get_bitmap_format(const ALLEGRO_BITMAP *bitmap)
 {
    if (bitmap->parent)
       return bitmap->parent->_format;
@@ -327,7 +327,7 @@ int _al_get_bitmap_memory_format(ALLEGRO_BITMAP *bitmap)
 
 /* Function: al_get_bitmap_flags
  */
-int al_get_bitmap_flags(ALLEGRO_BITMAP *bitmap)
+int al_get_bitmap_flags(const ALLEGRO_BITMAP *bitmap)
 {
    if (bitmap->parent)
       return bitmap->parent->_flags;
@@ -630,7 +630,7 @@ void al_reparent_bitmap(ALLEGRO_BITMAP *bitmap, ALLEGRO_BITMAP *parent,
 
 /* Function: al_is_sub_bitmap
  */
-bool al_is_sub_bitmap(ALLEGRO_BITMAP *bitmap)
+bool al_is_sub_bitmap(const ALLEGRO_BITMAP *bitmap)
 {
    return (bitmap->parent != NULL);
 }
@@ -647,7 +647,7 @@ ALLEGRO_BITMAP *al_get_parent_bitmap(ALLEGRO_BITMAP *bitmap)
 
 /* Function: al_get_bitmap_x
  */
-int al_get_bitmap_x(ALLEGRO_BITMAP *bitmap)
+int al_get_bitmap_x(const ALLEGRO_BITMAP *bitmap)
 {
    ASSERT(bitmap);
    return bitmap->xofs;
@@ -656,7 +656,7 @@ int al_get_bitmap_x(ALLEGRO_BITMAP *bitmap)
 
 /* Function: al_get_bitmap_y
  */
-int al_get_bitmap_y(ALLEGRO_BITMAP *bitmap)
+int al_get_bitmap_y(const ALLEGRO_BITMAP *bitmap)
 {
    ASSERT(bitmap);
    return bitmap->yofs;

--- a/src/tri_soft.c
+++ b/src/tri_soft.c
@@ -802,9 +802,9 @@ void _al_draw_soft_triangle(
    /*
    ALLEGRO_VERTEX copy_v1, copy_v2; <- may be needed for clipping later on
    */
-   ALLEGRO_VERTEX* vtx1 = v1;
-   ALLEGRO_VERTEX* vtx2 = v2;
-   ALLEGRO_VERTEX* vtx3 = v3;
+   const ALLEGRO_VERTEX* vtx1 = v1;
+   const ALLEGRO_VERTEX* vtx2 = v2;
+   const ALLEGRO_VERTEX* vtx3 = v3;
    ALLEGRO_BITMAP *target = al_get_target_bitmap();
    int need_unlock = 0;
    ALLEGRO_LOCKED_REGION *lr;


### PR DESCRIPTION
I thought of doing this edit when I tried passing pointers to const-qualified Allegro objects, but the function signature didn't allow for that.

This is a first step towards propagating as many const-qualifiers to the API level as appropriate.