### PR TITLE
Fix the drawable area mouse hiding state being out of sync.

### DIFF
--- a/include/allegro5/platform/aintwin.h
+++ b/include/allegro5/platform/aintwin.h
@@ -65,6 +65,16 @@ struct ALLEGRO_DISPLAY_WIN
    HWND window;
    HCURSOR mouse_selected_hcursor;
    bool mouse_cursor_shown;
+   /*
+    * We want to show the cursor when the user moves the mouse to the
+    * title-bar (to, e.g. close the window). This variable tracks
+    * whether or not we should re-hide the cursor when we enter the
+    * drawable area.
+    *
+    * This is almost always false, unless we actually programmatically
+    * hid the cursor inside wwindow.c.
+    */
+   bool hide_mouse_on_move;
 
    UINT adapter;
 

--- a/src/win/d3d_disp.cpp
+++ b/src/win/d3d_disp.cpp
@@ -1817,6 +1817,7 @@ static ALLEGRO_DISPLAY *d3d_create_display_locked(int w, int h)
 
    win_display->mouse_selected_hcursor = 0;
    win_display->mouse_cursor_shown = false;
+   win_display->hide_mouse_on_move = false;
    win_display->can_acknowledge = false;
 
    SetForegroundWindow(win_display->window);

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -998,6 +998,7 @@ static bool create_display_internals(ALLEGRO_DISPLAY_WGL *wgl_disp)
 
    win_disp->mouse_selected_hcursor = 0;
    win_disp->mouse_cursor_shown = false;
+   win_disp->hide_mouse_on_move = false;
    win_disp->can_acknowledge = false;
 
    _al_win_grab_input(win_disp);

--- a/src/win/wmcursor.c
+++ b/src/win/wmcursor.c
@@ -261,6 +261,7 @@ bool _al_win_show_mouse_cursor(ALLEGRO_DISPLAY *display)
 
    tmp_cursor.hcursor = win_display->mouse_selected_hcursor;
    win_display->mouse_cursor_shown = true;
+   win_display->hide_mouse_on_move = false;
    _al_win_set_mouse_cursor(display, (ALLEGRO_MOUSE_CURSOR *)tmp_cursor_ptr);
 
    return true;

--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -50,7 +50,6 @@ ALLEGRO_DEBUG_CHANNEL("wwindow")
 static WNDCLASS window_class;
 
 static bool resize_postponed = false;
-static bool we_hid_the_mouse = false;
 
 
 UINT _al_win_msg_call_proc = 0;
@@ -610,8 +609,8 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
             int mx = GET_X_LPARAM(lParam);
             int my = GET_Y_LPARAM(lParam);
 
-            if (win_display->mouse_cursor_shown && we_hid_the_mouse) {
-               we_hid_the_mouse = false;
+            if (win_display->mouse_cursor_shown && win_display->hide_mouse_on_move) {
+               win_display->hide_mouse_on_move = false;
                win_display->display.vt->hide_mouse_cursor((void*)win_display);
             }
 
@@ -705,8 +704,8 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
       }
       case WM_NCMOUSEMOVE: {
          if (!win_display->mouse_cursor_shown) {
-            we_hid_the_mouse = true;
             win_display->display.vt->show_mouse_cursor((void*)win_display);
+            win_display->hide_mouse_on_move = true;
          }
          break;
       }


### PR DESCRIPTION
We do this by tracking this state next to the usual one and properly resetting it when needed.

Fixes #1388