### PR TITLE
Try fixing some oddities with Shift + Alt on Windows.

### DIFF
--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -711,9 +711,10 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
       }
       case WM_SYSKEYDOWN: {
          int vcode = wParam;
+         int scode = (lParam >> 16) & 0xff;
          bool extended = (lParam >> 24) & 0x1;
          bool repeated  = (lParam >> 30) & 0x1;
-         _al_win_kbd_handle_key_press(0, vcode, extended, repeated, win_display);
+         _al_win_kbd_handle_key_press(scode, vcode, extended, repeated, win_display);
          break;
       }
       case WM_KEYDOWN: {
@@ -731,7 +732,13 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
          int vcode = wParam;
          int scode = (lParam >> 16) & 0xff;
          bool extended = (lParam >> 24) & 0x1;
-         _al_win_kbd_handle_key_release(scode, vcode, extended, win_display);
+         bool previous = (lParam >> 30) & 0x1;
+
+         /* The docs say that previous should always be 1, but it's not in practice.
+          * The events with previous = 0 seem malformed? I can get them reliably by
+          * pressing + holding Shift and then tapping Alt. */
+         if (previous)
+            _al_win_kbd_handle_key_release(scode, vcode, extended, win_display);
          break;
       }
       case WM_SYSCOMMAND: {


### PR DESCRIPTION
There were two issues.

1. Holding Shift + tapping Alt would send spurious Control(!?) key up messages. I can reliably identify them by checking whether the repeat(aka previous) flag is set. MSDN says it always should be 1, but it's 0 for these weird events.

2. Holding Alt + tapping Shift would set weird KEY_CHAR events. This evidently can be fixed by sending the scan code to our event decoder from WM_SYSKEYDOWN messages. I'm not sure why we didn't before.

Fixes #1348