### PR TITLE
Repair audio playmode return value

### DIFF
--- a/addons/audio/kcm_stream.c
+++ b/addons/audio/kcm_stream.c
@@ -475,18 +475,19 @@ bool al_set_audio_stream_playmode(ALLEGRO_AUDIO_STREAM *stream,
    else if (val == ALLEGRO_PLAYMODE_LOOP) {
       /* Only streams creating by al_load_audio_stream() support
        * looping. */
-      if (!stream->feeder)
+      if (!stream->feeder) {
          ret = false;
-
-      stream->spl.loop = _ALLEGRO_PLAYMODE_STREAM_ONEDIR;
-      ret = true;
+      } else {
+         stream->spl.loop = _ALLEGRO_PLAYMODE_STREAM_ONEDIR;
+         ret = true;
+      }
    }
    if (ret) {
       stream->is_draining = false;
    }
 
    // XXX _al_set_error
-   return false;
+   return ret;
 }
 
 


### PR DESCRIPTION
This commit modifies two parts of the `al_set_audio_stream_playmode` function:
- The return boolean is actually returned rather than discarded.
- The loop-without-feeder prevention is re-enabled for playmode `ALLEGRO_PLAYMODE_LOOP`. Now only audio streams created by `al_load_audio_stream` should allow the LOOP playmode.