### PR TITLE
Sdl examples macos

### DIFF
--- a/examples/ex_glext.c
+++ b/examples/ex_glext.c
@@ -12,7 +12,7 @@
 
 #include "common.c"
 
-#ifdef __APPLE_CC__
+#ifdef __APPLE__
 #include <OpenGL/glu.h>
 #else
 #include <GL/glu.h>

--- a/examples/ex_glext.c
+++ b/examples/ex_glext.c
@@ -12,7 +12,7 @@
 
 #include "common.c"
 
-#ifdef ALLEGRO_MACOSX
+#ifdef __APPLE_CC__
 #include <OpenGL/glu.h>
 #else
 #include <GL/glu.h>


### PR DESCRIPTION
In ex_glext we use ALLEGRO_MACOSX to check whether we need to use Apple's OpenGL include path - but this fails when building the SDL version under MacOS as ALLEGRO_SDL will be defined and not ALLEGRO_MACOSX. Using \_\_APPLE__ for MacOS specific code is suggested here: https://developer.apple.com/library/archive/documentation/Porting/Conceptual/PortingUnix/compiling/compiling.html