### PR TITLE
[WIP] proof of concept to fix the red flashing during live resize

### DIFF
--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -211,6 +211,7 @@ void _al_osx_keyboard_was_installed(BOOL install) {
 {
    /* This is passed onto the event functions so we know where the event came from */
    ALLEGRO_DISPLAY* dpy_ptr;
+   NSSize frame_size;
 }
 -(void)setAllegroDisplay: (ALLEGRO_DISPLAY*) ptr;
 -(ALLEGRO_DISPLAY*) allegroDisplay;
@@ -243,6 +244,7 @@ void _al_osx_keyboard_was_installed(BOOL install) {
 -(void) exitFullScreenWindowMode;
 -(void) finishExitingFullScreenWindowMode;
 -(void) maximize;
+-(void) setFrameSize: (NSSize) newSize;
 -(NSRect) windowWillUseStandardFrame:
    (NSWindow *) window
    defaultFrame: (NSRect) newFrame;
@@ -639,6 +641,17 @@ void _al_osx_mouse_was_installed(BOOL install) {
    ALLEGRO_DISPLAY_OSX_WIN *dpy = (ALLEGRO_DISPLAY_OSX_WIN*) dpy_ptr;
    [dpy->win performZoom: nil];
 }
+
+-(void) setFrameSize: (NSSize) newSize;
+{
+    frame_size = newSize;
+}
+
+-(void) setRealFrameSize;
+{
+    [super setFrameSize:frame_size];
+}
+
 
 /* Called by NSWindow's zoom: method while determining the frame
  * a window may be zoomed to.
@@ -2028,6 +2041,8 @@ static bool acknowledge_resize_display_win_main_thread(ALLEGRO_DISPLAY *d)
 
    d->w = NSWidth(content);
    d->h = NSHeight(content);
+   ALOpenGLView *view = window.contentView;
+   [view setRealFrameSize];
 
    return true;
 }


### PR DESCRIPTION
I did some more digging about the broken live resize under MacOS. Tracing through a resize in ex_resized2 in lldb the following happened:

- we call al_clear_to_color()
- we call al_draw_bitmap() a few times
- resize happens, this causes MacOS to call setFrameSize on the NSOpenGLView (on the main thread), which in turn calls glViewport() on the main thread (in some internal MacOS code)
    - if this happens during another GL call on the user thread we violate the requirement to serialize all OpenGL calls between threads and MacOS courteously will flash red
    - if this happens outside of another GL call, we get a random glViewport call with a new size in the middle of our drawing and it completely messes up the frame, almost as bad as red (I can actually see this in my game as well, in addition to the red flashes things just wildly jump around sometimes during live resizes)
 - we call al_draw_bitmap() a few more times
 - we call al_flip_display()
 - we handle events and see the ALLEGRO_EVENT_DISPLAY_RESIZE but it is much too late to do anything about it
 - we call al_acknowledge_display(), again, much too late

I think flutter works around this in some complex way involving an off-screen drawable unaffected by the out-of-sync glViewport call, but not really sure. I think SDL works around it by a) not offering live resize and b) somehow not having an OpenGL context on the main thread at all, but I don't fully follow their code either.

This PR isn't done since there is setFrameSize() calls outside of live resize we shouldn't ignore, but as a proof-of-concept this completely avoids any red flickering or messed up frames during live resize.

I think it would be best if we disable live resize entirely as it's a useless feature, but this PR still seems to be needed even then since MacOS still makes that asynchronous glViewport call for its live-zoom effect... I almost feel we use some setting somewhere which makes MacOS auto-resize the GL viewport, but I couldn't find anything obvious. Anyway, if there's no better ideas I'll try and fix the setFrameSize() issue, probably with a hack using the windowWillResize() notification to know when the next setFrameSize() needs to be ignored...
