### PR TITLE
Remove _LARGEFILE_SOURCE64 usage

### DIFF
--- a/src/file_stdio.c
+++ b/src/file_stdio.c
@@ -20,9 +20,6 @@
 #ifndef _LARGEFILE_SOURCE
    #define _LARGEFILE_SOURCE
 #endif
-#ifndef _LARGEFILE_SOURCE64
-   #define _LARGEFILE_SOURCE64
-#endif
 #ifndef _FILE_OFFSET_BITS
    #define _FILE_OFFSET_BITS 64
 #endif

--- a/src/fshook_stdio.c
+++ b/src/fshook_stdio.c
@@ -35,7 +35,6 @@ ALLEGRO_DEBUG_CHANNEL("fshook")
 /* Enable large file support in gcc/glibc. */
 #if defined ALLEGRO_HAVE_FTELLO && defined ALLEGRO_HAVE_FSEEKO
    #define _LARGEFILE_SOURCE
-   #define _LARGEFILE_SOURCE64
    #define _FILE_OFFSET_BITS 64
 #endif
 


### PR DESCRIPTION
I have been looking on the web for examples of `_LARGEFILE_SOURCE64`. I currently believe that it was only ever a typo of [`_LARGEFILE64_SOURCE`](https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html#index-_005fLARGEFILE64_005fSOURCE). I have not located any actual occurrences of it in a C standard library implementation’s header files, or where it definitely would not have been a typo.

Allegro is one of the few distinct examples on the web containing `_LARGEFILE_SOURCE64`. But given the `enable large file support in gcc/glibc` comments above where it appears, I believe Allegro intended to use `_LARGEFILE64_SOURCE` instead.

However, I believe it is likely safe to remove rather than correct the macro in Allegro source code. I have not found usage of the functions or types enabled by this macro; I would expect there to be compiler warnings and/or errors (due to implicit function declarations and unknown types) otherwise.

It also seems likely that
```
#define _LARGEFILE_SOURCE
#define _FILE_OFFSET_BITS 64
```
and using `fseeko()`/`ftello()` is already enough to enable LFS on 32-bit Linux in Allegro.