### PR TITLE
Android: map predictive back gestures to ALLEGRO_KEY_BACK in a backwards compatible way

### DIFF
--- a/android/gradle_project/allegro/build.gradle
+++ b/android/gradle_project/allegro/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 33
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }

--- a/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroActivity.java
+++ b/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroActivity.java
@@ -25,6 +25,9 @@ import android.view.InputDevice;
 import java.util.Vector;
 import android.os.Build;
 import android.view.View;
+import android.view.KeyEvent;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 
 public class AllegroActivity extends Activity
 {
@@ -338,6 +341,22 @@ public class AllegroActivity extends Activity
 
       requestWindowFeature(Window.FEATURE_NO_TITLE);
       this.getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+
+      if(Build.VERSION.SDK_INT >= 33) {
+         // handle the back button / gesture on API level 33+
+         getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+            OnBackInvokedDispatcher.PRIORITY_DEFAULT, new OnBackInvokedCallback() {
+               @Override
+               public void onBackInvoked() {
+                  // these will be mapped to ALLEGRO_KEY_BACK
+                  KeyEvent keyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK);
+                  KeyEvent keyUp = new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK);
+                  dispatchKeyEvent(keyDown);
+                  dispatchKeyEvent(keyUp);
+               }
+            }
+         );
+      }
 
       Log.d("AllegroActivity", "onCreate end");
    }

--- a/android/gradle_project/app/build.gradle
+++ b/android/gradle_project/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 33
     defaultConfig {
         applicationId "org.liballeg.${APP_ID}"
         minSdkVersion 15
-        targetSdkVersion 26
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }

--- a/android/gradle_project/app/src/main/AndroidManifest.xml
+++ b/android/gradle_project/app/src/main/AndroidManifest.xml
@@ -3,12 +3,13 @@
       package="org.liballeg.app"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <application android:label="${APP_ID}">
         <activity android:name=".MainActivity"
                   android:launchMode="singleTask"
                   android:screenOrientation="unspecified"
-                  android:configChanges="screenLayout|uiMode|orientation|screenSize">
+                  android:configChanges="screenLayout|uiMode|orientation|screenSize"
+                  android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/gradle_project/app/src/main/AndroidManifest.xml
+++ b/android/gradle_project/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
       android:versionCode="1"
       android:versionName="1.0">
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <application android:label="${APP_ID}">
+    <application android:label="${APP_ID}"
+                 android:enableOnBackInvokedCallback="true">
         <activity android:name=".MainActivity"
                   android:launchMode="singleTask"
                   android:screenOrientation="unspecified"


### PR DESCRIPTION
Google is introducing [predictive back gestures](https://developer.android.com/guide/navigation/predictive-back-gesture) in Android 13. This is a breaking change that affects Allegro. Previously, we could intercept back events using `KeyEvent.KEYCODE_BACK`. This is no longer the case.

Any Allegro apps that target API level 33 and that opt in to the predictive back gestures no longer work. I tested this myself and saw that key up/key down events with `ALLEGRO_KEY_BACK` are no longer triggered when a back gesture is performed. Since [predictive back gestures will become mandatory](https://developer.android.com/guide/navigation/predictive-back-gesture#update-custom), we must update the code.

This update handles the back button / gesture on API level 33+ in a backwards compatible way. Back events are intercepted using the new `OnBackInvokedCallback` API. These events are mapped to `ALLEGRO_KEY_BACK` as before, so that [existing Allegro apps will continue to work as usual](https://github.com/liballeg/allegro5/blob/4aa54e6c994af21bc63d8b593673ab3df62390f8/examples/ex_android.c#L169), despite the breaking change in Android.

This fixes #1419 and updates the target API level to 33.