### PR TITLE
[macOS] Fix Joystick Infinite Loop

### DIFF
--- a/src/macosx/hidjoy.m
+++ b/src/macosx/hidjoy.m
@@ -298,16 +298,8 @@ static void osx_joy_generate_configure_event(void)
    _al_generate_joystick_event(&event);
 }
 
-static void device_add_callback(
-   void *context,
-   IOReturn result,
-   void *sender,
-   IOHIDDeviceRef ref
-) {
-   (void)context;
-   (void)result;
-   (void)sender;
-
+static void add_joystick_device(IOHIDDeviceRef ref, bool emit_reconfigure_event)
+{
    al_lock_mutex(add_mutex);
 
    ALLEGRO_JOYSTICK_OSX *joy = find_joystick(ref);
@@ -329,13 +321,25 @@ static void device_add_callback(
 
    CFRelease(elements);
 
-
    al_unlock_mutex(add_mutex);
 
-   osx_joy_generate_configure_event();
+   if (emit_reconfigure_event) osx_joy_generate_configure_event();
 
    ALLEGRO_INFO("Found joystick (%d buttons, %d sticks)\n",
       joy->parent.info.num_buttons, joy->parent.info.num_sticks);
+}
+
+static void device_add_callback(
+   void *context,
+   IOReturn result,
+   void *sender,
+   IOHIDDeviceRef ref
+) {
+   (void)context;
+   (void)result;
+   (void)sender;
+
+   add_joystick_device(ref, true);
 }
 
 static void device_remove_callback(

--- a/src/macosx/hidjoy.m
+++ b/src/macosx/hidjoy.m
@@ -358,9 +358,9 @@ static int enumerate_and_create_initial_joystick_devices(IOHIDManagerRef manager
          add_joystick_device(dev, false);
          num_joysticks_enumerated++;
       }
-   }
 
-   CFRelease(devices);
+      CFRelease(devices);
+   }
 
    return num_joysticks_enumerated;
 }


### PR DESCRIPTION
## Problem

Issue https://github.com/liballeg/allegro5/issues/1420

Sometimes when `al_install_joystick()` is called while one or multiple joysticks are already connected, the system can get stuck in an infinite loop.  This happens on the example programs and in my code as well about 1 in 6 times.

I isolated the problem to [this loop](https://github.com/liballeg/allegro5/blob/master/src/macosx/hidjoy.m#L588-L599), which performs polling, waiting for the number of Allegro-recognized devices to match the number of os-recognized devices, while waiting for callbacks.

## Solution

Rather than polling in a loop to check if the devices may have been created, this will create the devices manually and remove the polling loop. At any time, the same callbacks may occur and try to create the devices, but those devices will not be created if they already exist (and we will not potentially be stuck in an infinite loop while doing so). The `device_add` process is protected behind a mutex.