### PR TITLE
Use correct pointer type. This fixes flood fill crash on 64-bit builds.

### DIFF
--- a/src/flood.c
+++ b/src/flood.c
@@ -53,7 +53,7 @@ static int flooder(BITMAP *bmp, int x, int y, int src_color, int dest_color)
 {
    FLOODED_LINE *p;
    int left = 0, right = 0;
-   unsigned long addr;
+   uintptr_t addr;
    int c;
 
    /* helper for doing checks in each color depth */


### PR DESCRIPTION
@connorjclark sent a patch in to my [Allegro Legacy](https://github.com/NewCreature/Allegro-Legacy) project which I found should also be applied to Allegro to fix a crash in the `floodfill()` routine when compiled on 64-bit systems.