### PR TITLE
Fixes #1431.

### DIFF
--- a/addons/native_dialog/menu.c
+++ b/addons/native_dialog/menu.c
@@ -792,7 +792,6 @@ bool al_set_display_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu)
       _al_vector_delete_at(&display_menus, i);
 
       if (automatic_menu_display_resize && menu_height > 0) {
-         display->extra_resize_height = 0;
          al_resize_display(display, al_get_display_width(display), al_get_display_height(display));
       }
    }
@@ -826,7 +825,6 @@ bool al_set_display_menu(ALLEGRO_DISPLAY *display, ALLEGRO_MENU *menu)
          /* Temporarily disable the constraints so we don't send a RESIZE_EVENT. */
          bool old_constraints = display->use_constraints;
          display->use_constraints = false;
-         display->extra_resize_height = menu_height;
          al_resize_display(display, al_get_display_width(display), al_get_display_height(display));
          display->use_constraints = old_constraints;
       }

--- a/include/allegro5/internal/aintern_display.h
+++ b/include/allegro5/internal/aintern_display.h
@@ -158,11 +158,6 @@ struct ALLEGRO_DISPLAY
 
    /* Issue #725 */
    bool use_constraints;
-
-   /* On Windows, menus take up the display's height so whenever doing a
-    * manual resize we need to add this number to the height for things
-    * to work correctly. See issue #860. */
-   int extra_resize_height;
 };
 
 int  _al_score_display_settings(ALLEGRO_EXTRA_DISPLAY_SETTINGS *eds, ALLEGRO_EXTRA_DISPLAY_SETTINGS *ref);

--- a/src/display.c
+++ b/src/display.c
@@ -71,7 +71,6 @@ ALLEGRO_DISPLAY *al_create_display(int w, int h)
    display->max_w = 0;
    display->max_h = 0;
    display->use_constraints = false;
-   display->extra_resize_height = 0;
 
    display->vertex_cache = 0;
    display->num_cache_vertices = 0;
@@ -237,10 +236,10 @@ bool al_resize_display(ALLEGRO_DISPLAY *display, int width, int height)
    ASSERT(display);
    ASSERT(display->vt);
 
-   ALLEGRO_INFO("Requested display resize %dx%d+%d\n", width, height, display->extra_resize_height);
+   ALLEGRO_INFO("Requested display resize %dx%d\n", width, height);
 
    if (display->vt->resize_display) {
-      return display->vt->resize_display(display, width, height + display->extra_resize_height);
+      return display->vt->resize_display(display, width, height);
    }
    return false;
 }


### PR DESCRIPTION
This commit fixes #1431 by eliminating the `extra_resize_height` variable and its use in the code. As mentioned in #1431, 6bc85cc implemented a change to the resizing behavior which conflicted with part of 75fdcaa, leading to extra height being added to the display when attaching a menu.