### PR TITLE
Fixes #1434 and #1435.

### DIFF
--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -22,7 +22,7 @@ static NSArray * remove_mime_types(NSArray * array)
    NSMutableArray * work_array = [array mutableCopy];
 
    for(NSInteger i = work_array.count - 1; i >= 0; i--){
-      if([work_array[i] rangeOfString:@"/"].location != NSNotFound){
+      if([[work_array objectAtIndex: i] rangeOfString:@"/"].location != NSNotFound){
          [work_array removeObjectAtIndex: i];
       }
    }

--- a/src/unix/utime.c
+++ b/src/unix/utime.c
@@ -32,13 +32,33 @@ ALLEGRO_STATIC_ASSERT(utime,
 struct timespec _al_unix_initial_time;
 
 
+/* implement clock_gettime() for MacOS < 10.12 */
+#if defined(ALLEGRO_MACOSX) && MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+#include <mach/mach_time.h>
+int _internal_clock_gettime(clockid_t clock_id, struct timespec* t)
+{
+    mach_timebase_info_data_t timebase;
+    mach_timebase_info(&timebase);
+    uint64_t time;
+    time = mach_absolute_time();
+    double nseconds = ((double)time * (double)timebase.numer)/((double)timebase.denom);
+    double seconds = ((double)time * (double)timebase.numer)/((double)timebase.denom * 1e9);
+    t->tv_sec = seconds;
+    t->tv_nsec = nseconds;
+    return 0;
+}
+#define _al_clock_gettime _internal_clock_gettime
+#else
+#define _al_clock_gettime clock_gettime
+#endif
+
 
 /* _al_unix_init_time:
  *  Called by the system driver to mark the beginning of time.
  */
 void _al_unix_init_time(void)
 {
-   clock_gettime(CLOCK_REALTIME, &_al_unix_initial_time);
+   _al_clock_gettime(CLOCK_REALTIME, &_al_unix_initial_time);
 }
 
 
@@ -48,7 +68,7 @@ double _al_unix_get_time(void)
    struct timespec now;
    double time;
 
-   clock_gettime(CLOCK_REALTIME, &now);
+   _al_clock_gettime(CLOCK_REALTIME, &now);
    time = (double) (now.tv_sec - _al_unix_initial_time.tv_sec)
       + (double) (now.tv_nsec - _al_unix_initial_time.tv_nsec) * 1.0e-9;
    return time;
@@ -79,7 +99,7 @@ void _al_unix_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
 
    ASSERT(ut);
 
-   clock_gettime(CLOCK_REALTIME, &now);
+   _al_clock_gettime(CLOCK_REALTIME, &now);
 
    if (seconds <= 0.0) {
       ut->abstime.tv_sec = now.tv_sec;


### PR DESCRIPTION
When targeting MacOSX versions < 10.12, running the binary on any version of MacOSX < 10.12 resulted in a crash. The first commit adds a code path for using `mach_absolute_time()` in place of `clock_gettime()` when building for MacOSX with a target version < 10.12.

Also, when opening the native file dialog on MacOSX 10.6 the program soft locks. This bug was introduced in b5bfadaf2ee15b0675054abd817056b172a5e236. The second commit fixes this bug by using `objectAtIndex` instead of direct indexing.

