### PR TITLE
Fix for #1435.

### DIFF
--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -22,7 +22,7 @@ static NSArray * remove_mime_types(NSArray * array)
    NSMutableArray * work_array = [array mutableCopy];
 
    for(NSInteger i = work_array.count - 1; i >= 0; i--){
-      if([work_array[i] rangeOfString:@"/"].location != NSNotFound){
+      if([[work_array objectAtIndex: i] rangeOfString:@"/"].location != NSNotFound){
          [work_array removeObjectAtIndex: i];
       }
    }


### PR DESCRIPTION
When opening the native file dialog on MacOSX 10.6, the program soft locks. This bug was introduced in b5bfadaf2ee15b0675054abd817056b172a5e236. This commit fixes this bug by using `objectAtIndex` instead of direct indexing.