### PR TITLE
Fix for #1434.

### DIFF
--- a/src/unix/utime.c
+++ b/src/unix/utime.c
@@ -33,12 +33,34 @@ struct timespec _al_unix_initial_time;
 
 
 
+/* clock_gettime() doesn't exist in MacOSX versions < 10.12. Use
+ * gettimeofday() if building for MacOSX and targeting version < 10.12.
+ */
+#if defined(ALLEGRO_MACOSX) && MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+#include <mach/mach_time.h>
+int _internal_clock_gettime(clockid_t clock_id, struct timespec* t)
+{
+   struct timeval now;
+
+   (void)clock_id;
+   gettimeofday(&now, NULL);
+   t->tv_sec = now.tv_sec;
+   t->tv_nsec = now.tv_usec * 1000;
+   return 0;
+}
+#define _al_clock_gettime _internal_clock_gettime
+#else
+#define _al_clock_gettime clock_gettime
+#endif
+
+
+
 /* _al_unix_init_time:
  *  Called by the system driver to mark the beginning of time.
  */
 void _al_unix_init_time(void)
 {
-   clock_gettime(CLOCK_REALTIME, &_al_unix_initial_time);
+   _al_clock_gettime(CLOCK_REALTIME, &_al_unix_initial_time);
 }
 
 
@@ -48,7 +70,7 @@ double _al_unix_get_time(void)
    struct timespec now;
    double time;
 
-   clock_gettime(CLOCK_REALTIME, &now);
+   _al_clock_gettime(CLOCK_REALTIME, &now);
    time = (double) (now.tv_sec - _al_unix_initial_time.tv_sec)
       + (double) (now.tv_nsec - _al_unix_initial_time.tv_nsec) * 1.0e-9;
    return time;
@@ -79,7 +101,7 @@ void _al_unix_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
 
    ASSERT(ut);
 
-   clock_gettime(CLOCK_REALTIME, &now);
+   _al_clock_gettime(CLOCK_REALTIME, &now);
 
    if (seconds <= 0.0) {
       ut->abstime.tv_sec = now.tv_sec;


### PR DESCRIPTION
Use `gettimeofday()` instead of `clock_gettime()` when building for MacOSX with a target version < 10.12.