### PR TITLE
Add a workaround for #1350

### DIFF
--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -231,6 +231,15 @@ max_page_size = 0
 # Uncomment if you want only the characters in the cache_text entry to ever be drawn
 # skip_cache_misses = true
 
+[osx]
+
+# If set to false, then Allegro will send ALLEGRO_EVENT_DISPLAY_HALT_DRAWING
+# and ALLEGRO_EVENT_DISPLAY_RESUME_DRAWING events when the user resizes a
+# window. Drawing while resizing ("live resizing") has historically been buggy,
+# so setting this to false allows you to opt out of this behavior and detect
+# when the resize happens.
+allow_live_resize = true
+
 [compatibility]
 
 # Prior to 5.2.4 on Windows you had to manually resize the display when

--- a/demos/skater/src/framework.c
+++ b/demos/skater/src/framework.c
@@ -336,6 +336,7 @@ void run_framework(void)
          
          case ALLEGRO_EVENT_DISPLAY_RESUME_DRAWING:
             background_mode = false;
+            al_acknowledge_drawing_resume(screen);
             break;
             
          case ALLEGRO_EVENT_DISPLAY_SWITCH_OUT:

--- a/examples/ex_camera.c
+++ b/examples/ex_camera.c
@@ -474,6 +474,7 @@ int main(int argc, char **argv)
    ALLEGRO_TIMER *timer;
    ALLEGRO_EVENT_QUEUE *queue;
    int redraw = 0;
+   bool halt_drawing = false;
    char const *skybox_name = NULL;
 
    if (argc > 1) {
@@ -489,6 +490,7 @@ int main(int argc, char **argv)
    al_install_keyboard();
    al_install_mouse();
 
+   al_set_config_value(al_get_system_config(), "osx", "allow_live_resize", "false");
    al_set_new_display_option(ALLEGRO_SAMPLE_BUFFERS, 1, ALLEGRO_SUGGEST);
    al_set_new_display_option(ALLEGRO_SAMPLES, 8, ALLEGRO_SUGGEST);
    al_set_new_display_option(ALLEGRO_DEPTH_SIZE, 16, ALLEGRO_SUGGEST);
@@ -566,12 +568,20 @@ int main(int argc, char **argv)
       else if (event.type == ALLEGRO_EVENT_MOUSE_BUTTON_UP) {
          ex.button[event.mouse.button] = 0;
       }
+      else if (event.type == ALLEGRO_EVENT_DISPLAY_HALT_DRAWING) {
+         halt_drawing = true;
+         al_acknowledge_drawing_halt(display);
+      }
+      else if (event.type == ALLEGRO_EVENT_DISPLAY_RESUME_DRAWING) {
+         halt_drawing = false;
+         al_acknowledge_drawing_resume(display);
+      }
       else if (event.type == ALLEGRO_EVENT_MOUSE_AXES) {
          ex.mouse_dx += event.mouse.dx;
          ex.mouse_dy += event.mouse.dy;
       }
 
-      if (redraw  && al_is_event_queue_empty(queue)) {
+      if (!halt_drawing && redraw && al_is_event_queue_empty(queue)) {
          draw_scene();
 
          al_flip_display();

--- a/examples/ex_resize2.c
+++ b/examples/ex_resize2.c
@@ -20,6 +20,7 @@ int main(int argc, char **argv)
    ALLEGRO_EVENT event;
    ALLEGRO_FONT *font;
    bool redraw;
+   bool halt_drawing;
 
    (void)argc;
    (void)argv;
@@ -31,6 +32,7 @@ int main(int argc, char **argv)
    al_init_image_addon();
    al_init_font_addon();
 
+   al_set_config_value(al_get_system_config(), "osx", "allow_live_resize", "false");
    al_set_new_display_flags(ALLEGRO_RESIZABLE |
       ALLEGRO_GENERATE_EXPOSE_EVENTS);
    display = al_create_display(640, 480);
@@ -51,8 +53,9 @@ int main(int argc, char **argv)
    al_register_event_source(queue, al_get_keyboard_event_source());
 
    redraw = true;
+   halt_drawing = false;
    while (true) {
-      if (redraw && al_is_event_queue_empty(queue)) {
+      if (!halt_drawing && redraw && al_is_event_queue_empty(queue)) {
          al_clear_to_color(al_map_rgb(255, 0, 0));
          al_draw_scaled_bitmap(bmp,
             0, 0, al_get_bitmap_width(bmp), al_get_bitmap_height(bmp),
@@ -80,6 +83,14 @@ int main(int argc, char **argv)
       }
       if (event.type == ALLEGRO_EVENT_DISPLAY_EXPOSE) {
          redraw = true;
+      }
+      if (event.type == ALLEGRO_EVENT_DISPLAY_HALT_DRAWING) {
+         halt_drawing = true;
+         al_acknowledge_drawing_halt(display);
+      }
+      if (event.type == ALLEGRO_EVENT_DISPLAY_RESUME_DRAWING) {
+         halt_drawing = false;
+         al_acknowledge_drawing_resume(display);
       }
       if (event.type == ALLEGRO_EVENT_KEY_DOWN &&
             event.keyboard.keycode == ALLEGRO_KEY_ESCAPE) {

--- a/src/macosx/osxgl.h
+++ b/src/macosx/osxgl.h
@@ -34,6 +34,10 @@ typedef struct ALLEGRO_DISPLAY_OSX_WIN {
    BOOL in_fullscreen;
    BOOL single_buffer;
    CGDisplayModeRef original_mode;
+   BOOL send_halt_events;
+   ALLEGRO_MUTEX *halt_mutex;
+   ALLEGRO_COND *halt_cond;
+   BOOL halt_event_acknowledged;
    /* For new (10.14+) vsyncing. */
    CVDisplayLinkRef display_link;
    ALLEGRO_MUTEX *flip_mutex;


### PR DESCRIPTION
Elias investigated the issue in #1418, showing that there was some concurrent OpenGL usage between OS's internals and user code. That specific workaround did not work for me on my Mac, so as an alternative, in this commit we add an option to bypass live resize altogether. In short, the user opts into drawing halt/resume events via a config option, and ceases to draw while live resize is underway. This isn't ideal, but at least is a way to prevent the crashing behavior until we find some better idea.