### PR TITLE
Add support for OpenGL 3 displays on macos

### DIFF
--- a/src/opengl/ogl_shader.c
+++ b/src/opengl/ogl_shader.c
@@ -124,7 +124,22 @@ static bool glsl_attach_shader_source(ALLEGRO_SHADER *shader,
       if ((*handle) == 0) {
          return false;
       }
+#ifdef ALLEGRO_MACOSX
+      {
+         const char *version_string = glGetString(GL_SHADING_LANGUAGE_VERSION);
+         int version[2];
+         sscanf(version_string, "%d.%d", &version[0], &version[1]);
+         char version_line[] = "#version XXXXXXXXXX";
+         ASSERT(version[0] < 10 && version[1] < 100);
+         snprintf(version_line, sizeof(version_line), "#version %d%d\n", version[0], version[1]);
+
+         const char *sources[] = {version_line, source};
+
+         glShaderSource(*handle, 2, sources, NULL);
+      }
+#else
       glShaderSource(*handle, 1, &source, NULL);
+#endif
       glCompileShader(*handle);
       glGetShaderiv(*handle, GL_COMPILE_STATUS, &status);
       if (status == 0) {

--- a/src/shader.c
+++ b/src/shader.c
@@ -415,14 +415,26 @@ char const *al_get_default_shader_source(ALLEGRO_SHADER_PLATFORM platform,
    ALLEGRO_SHADER_TYPE type)
 {
    (void)type;
+   bool use_gl3_shader = false;
+#ifdef ALLEGRO_MACOSX
+   {
+      /* Apple's glsl implementation supports either 1.20 shaders, or strictly
+       * versioned 3.2+ shaders which do not use deprecated features.
+       */
+      const char * shader_language = glGetString(GL_SHADING_LANGUAGE_VERSION);
+      if (strcmp(shader_language, "1.20") != 0) {
+         use_gl3_shader = true;
+      }
+   }
+#endif
    switch (resolve_platform(al_get_current_display(), platform)) {
       case ALLEGRO_SHADER_GLSL:
 #ifdef ALLEGRO_CFG_SHADER_GLSL
          switch (type) {
             case ALLEGRO_VERTEX_SHADER:
-               return default_glsl_vertex_source;
+               return use_gl3_shader ? default_glsl_vertex_source_gl3 : default_glsl_vertex_source;
             case ALLEGRO_PIXEL_SHADER:
-               return default_glsl_pixel_source;
+               return use_gl3_shader ? default_glsl_pixel_source_gl3 : default_glsl_pixel_source;
          }
 #endif
          break;
@@ -430,9 +442,9 @@ char const *al_get_default_shader_source(ALLEGRO_SHADER_PLATFORM platform,
 #ifdef ALLEGRO_CFG_SHADER_GLSL
          switch (type) {
             case ALLEGRO_VERTEX_SHADER:
-               return default_glsl_vertex_source;
+               return use_gl3_shader ? default_glsl_vertex_source_gl3 : default_glsl_vertex_source;
             case ALLEGRO_PIXEL_SHADER:
-               return default_glsl_minimal_pixel_source;
+               return use_gl3_shader ? default_glsl_minimal_pixel_source_gl3 : default_glsl_minimal_pixel_source;
          }
 #endif
          break;

--- a/src/shader.c
+++ b/src/shader.c
@@ -418,11 +418,13 @@ char const *al_get_default_shader_source(ALLEGRO_SHADER_PLATFORM platform,
    bool use_gl3_shader = false;
 #ifdef ALLEGRO_MACOSX
    {
+      ALLEGRO_DISPLAY *display = al_get_current_display();
+
+
       /* Apple's glsl implementation supports either 1.20 shaders, or strictly
        * versioned 3.2+ shaders which do not use deprecated features.
        */
-      const char * shader_language = glGetString(GL_SHADING_LANGUAGE_VERSION);
-      if (strcmp(shader_language, "1.20") != 0) {
+      if (display && (display->flags & ALLEGRO_OPENGL_3_0)) {
          use_gl3_shader = true;
       }
    }

--- a/src/shader_source.inc
+++ b/src/shader_source.inc
@@ -98,6 +98,90 @@ static const char *default_glsl_minimal_pixel_source =
    "  gl_FragColor = c;\n"
    "}\n";
 
+static const char *default_glsl_vertex_source_gl3 =
+   "in vec4 " ALLEGRO_SHADER_VAR_POS ";\n"
+   "in vec4 " ALLEGRO_SHADER_VAR_COLOR ";\n"
+   "in vec2 " ALLEGRO_SHADER_VAR_TEXCOORD ";\n"
+   "uniform mat4 " ALLEGRO_SHADER_VAR_PROJVIEW_MATRIX ";\n"
+   "uniform bool " ALLEGRO_SHADER_VAR_USE_TEX_MATRIX ";\n"
+   "uniform mat4 " ALLEGRO_SHADER_VAR_TEX_MATRIX ";\n"
+   "out vec4 varying_color;\n"
+   "out vec2 varying_texcoord;\n"
+   "void main()\n"
+   "{\n"
+   "  varying_color = " ALLEGRO_SHADER_VAR_COLOR ";\n"
+   "  if (" ALLEGRO_SHADER_VAR_USE_TEX_MATRIX ") {\n"
+   "    vec4 uv = " ALLEGRO_SHADER_VAR_TEX_MATRIX " * vec4(" ALLEGRO_SHADER_VAR_TEXCOORD ", 0, 1);\n"
+   "    varying_texcoord = vec2(uv.x, uv.y);\n"
+   "  }\n"
+   "  else\n"
+   "    varying_texcoord = " ALLEGRO_SHADER_VAR_TEXCOORD";\n"
+   "  gl_Position = " ALLEGRO_SHADER_VAR_PROJVIEW_MATRIX " * " ALLEGRO_SHADER_VAR_POS ";\n"
+   "}\n";
+
+static const char *default_glsl_pixel_source_gl3 =
+   "#ifdef GL_ES\n"
+   "precision lowp float;\n"
+   "#endif\n"
+   "uniform sampler2D " ALLEGRO_SHADER_VAR_TEX ";\n"
+   "uniform bool " ALLEGRO_SHADER_VAR_USE_TEX ";\n"
+   "uniform bool " ALLEGRO_SHADER_VAR_ALPHA_TEST ";\n"
+   "uniform int " ALLEGRO_SHADER_VAR_ALPHA_FUNCTION ";\n"
+   "uniform float " ALLEGRO_SHADER_VAR_ALPHA_TEST_VALUE ";\n"
+   "in vec4 varying_color;\n"
+   "in vec2 varying_texcoord;\n"
+   "layout(location = 0) out vec4 diffuseColor;\n"
+   "\n"
+   "bool alpha_test_func(float x, int op, float compare);\n"
+   "\n"
+   "void main()\n"
+   "{\n"
+   "  vec4 c;\n"
+   "  if (" ALLEGRO_SHADER_VAR_USE_TEX ")\n"
+   "    c = varying_color * texture(" ALLEGRO_SHADER_VAR_TEX ", varying_texcoord);\n"
+   "  else\n"
+   "    c = varying_color;\n"
+   "  if (!" ALLEGRO_SHADER_VAR_ALPHA_TEST " || alpha_test_func(c.a, " ALLEGRO_SHADER_VAR_ALPHA_FUNCTION ", "
+                          ALLEGRO_SHADER_VAR_ALPHA_TEST_VALUE "))\n"
+   "    diffuseColor = c;\n"
+   "  else\n"
+   "    discard;\n"
+   "}\n"
+   "\n"
+   "bool alpha_test_func(float x, int op, float compare)\n"
+   "{\n"
+   // Note: These must be aligned with the ALLEGRO_RENDER_FUNCTION enum values.
+   "  if (op == 0) return false;\n" // ALLEGRO_RENDER_NEVER
+   "  else if (op == 1) return true;\n" // ALLEGRO_RENDER_ALWAYS
+   "  else if (op == 2) return x < compare;\n" // ALLEGRO_RENDER_LESS
+   "  else if (op == 3) return x == compare;\n" // ALLEGRO_RENDER_EQUAL
+   "  else if (op == 4) return x <= compare;\n" // ALLEGRO_RENDER_LESS_EQUAL
+   "  else if (op == 5) return x > compare;\n" // ALLEGRO_RENDER_GREATER
+   "  else if (op == 6) return x != compare;\n" // ALLEGRO_RENDER_NOT_EQUAL
+   "  else if (op == 7) return x >= compare;\n" // ALLEGRO_RENDER_GREATER_EQUAL
+   "  return false;\n"
+   "}\n";
+
+static const char *default_glsl_minimal_pixel_source_gl3 =
+   "#ifdef GL_ES\n"
+   "precision lowp float;\n"
+   "#endif\n"
+   "uniform sampler2D " ALLEGRO_SHADER_VAR_TEX ";\n"
+   "uniform bool " ALLEGRO_SHADER_VAR_USE_TEX ";\n"
+   "in vec4 varying_color;\n"
+   "in vec2 varying_texcoord;\n"
+   "layout(location = 0) out vec4 diffuseColor;\n"
+   "\n"
+   "void main()\n"
+   "{\n"
+   "  vec4 c;\n"
+   "  if (" ALLEGRO_SHADER_VAR_USE_TEX ")\n"
+   "    c = varying_color * texture2D(" ALLEGRO_SHADER_VAR_TEX ", varying_texcoord);\n"
+   "  else\n"
+   "    c = varying_color;\n"
+   "  diffuseColor = c;\n"
+   "}\n";
+
 #endif /* ALLEGRO_CFG_SHADER_GLSL */
 
 


### PR DESCRIPTION
When creating a mac display wth the ALLEGRO_OPENGL_3_0 flag, set the pixel attribute NSOpenGLPFAOpenGLProfile to NSOpenGLProfileVersion3_2Core to enable modern OpenGL. This conflicts with NSOpenGLPFAWindow, so that is dropped.

Fix checking for ALLEGRO_RENDER_METHOD in the required options to enable NSOpenGLPFAAccelerated. I'm not sure if that makes a difference, but the old code was using the option as a value and not a bit offset.

Duplicate the shaders in GLSL 3.3+ syntax (adding a _gl3 suffix to the static variables). Check the shader language version, and select the _gl3 versions when using a version != 1.20 on macos.

When compiling the shaders on macos, check for the supported shader version. If != 1.20, insert a #version line based on the value returned by the OpenGL context.

[https://github.com/liballeg/allegro5/issues/1443]