### PR TITLE
[OSX] Do not wait for main thread when appending to native text log

### DIFF
--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -352,7 +352,7 @@ void _al_append_native_text_log(ALLEGRO_NATIVE_DIALOG *textlog)
         NSString *text = [NSString stringWithUTF8String: al_cstr(textlog->tl_pending_text)];
         [view performSelectorOnMainThread:@selector(appendText:)
                                withObject:text
-                            waitUntilDone:YES];
+                            waitUntilDone:NO];
         
         al_ustr_truncate(textlog->tl_pending_text, 0);
     }


### PR DESCRIPTION
I tracked down a huge FPS drop in my application to this line. The application was doing tons of logging to a native text log, and each one (on OSX) waits for the main thread to ack the message. The FPS difference was something like 1000 -> 30.

I don't see a reason to wait for this message to be ack'd, and things still seem to function just the same.

I did not confirm if other platforms have the same problem.