### PR TITLE
add `[compatability] osx_tell_dock_outside_bundle`

### DIFF
--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -238,3 +238,8 @@ max_page_size = 0
 # automatically, but may break old code that handled this eventuality.
 # Set this to false for such code.
 automatic_menu_display_resize = true
+
+# On OSX outside an app bundle, on system init allegro manually promotes the process
+# to a graphical application. This may be undesirable for console applications. Set
+# this to false to disable this behavior.
+osx_tell_dock_outside_bundle = true

--- a/include/allegro5/platform/aintosx.h
+++ b/include/allegro5/platform/aintosx.h
@@ -117,6 +117,7 @@ typedef struct HID_DEVICE_COLLECTION HID_DEVICE_COLLECTION;
 #endif
 
 int _al_osx_bootstrap_ok(void);
+void _al_osx_tell_dock(void);
 
 void _al_osx_keyboard_handler(int pressed, NSEvent *event, ALLEGRO_DISPLAY*);
 void _al_osx_keyboard_modifiers(unsigned int new_mods, ALLEGRO_DISPLAY*);

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -1301,6 +1301,8 @@ static ALLEGRO_DISPLAY* create_display_fs(int w, int h)
       osx_run_fullscreen_display(dpy);
    });
    [pool drain];
+
+   _al_osx_tell_dock();
    return &dpy->parent;
 }
 #if 0
@@ -1696,6 +1698,7 @@ static ALLEGRO_DISPLAY* create_display_win(int w, int h) {
 
    [pool drain];
 
+   _al_osx_tell_dock();
    return display;
 }
 


### PR DESCRIPTION
This old behavior is undesirable for purely-console applications, as it makes OSX flicker the screen / current app loses focus.

Default is to keep doing this, but now there is a new option to suppress it.

_____

Discussed on Discord: https://discord.com/channels/993415281244393504/1013128461319159932/1130312994564358244

```
connorclark — Today at 6:40 PM
I have a console application that uses allegro 5. On init, for OSX we get a flash of a window gaining focus. This comes from the init sequence calling osx_tell_dock, signaling the process as a graphical app:  TransformProcessType(&psn, kProcessTransformToForegroundApplication).

Is there anything part of the allegro 5 api that can be used to signal that we are not a graphical app, such that this al_init call could know not to do this? 
Perhaps we could move this to the create_display code for OSX.
SiegeLord — Today at 6:59 PM
That seems like a good idea
If that's impossible for some reason, we could add a config option to disable this behavior
Well, probably need a config option anyway... so perhaps best to just do that to start
connorclark — Today at 7:07 PM
I just tried moving it there, and it seems to work well.

This config would be on the flags given to initialize?
SiegeLord — Today at 7:08 PM
No, allegro5.cfg
connorclark — Today at 7:08 PM
To be clear, you're wanting to preserve the (osx-only) behavior that a console application is viewable in the dock?
SiegeLord — Today at 7:08 PM
Yeah, I think so since that's not uncommon to do
Like console as opossed to in a bundle
Not console as in no windows
I'm... not sure what you'd want that, maybe that's a always a bug?
Or maybe that's useful sometimes?
```
