### PR TITLE
osx: fix off-by-one error for hat switches

### DIFF
--- a/src/macosx/hidjoy.m
+++ b/src/macosx/hidjoy.m
@@ -494,12 +494,12 @@ static void value_callback(
    int int_value = IOHIDValueGetIntegerValue(value);
 
    if (joy->dpad == elem){
-      if (int_value > 0 && int_value <= MAX_HAT_DIRECTIONS) {
-         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  (float)hat_mapping[int_value-1].axisV);
-         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, (float)hat_mapping[int_value-1].axisH);
-      } else if (joy->min[joy->dpad_stick][1] > int_value || joy->max[joy->dpad_stick][1] < int_value) {
+      if (joy->min[joy->dpad_stick][1] > int_value || joy->max[joy->dpad_stick][1] < int_value) {
          osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  0);
          osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, 0);
+      } else if (int_value > 0 && int_value <= MAX_HAT_DIRECTIONS) {
+         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  (float)hat_mapping[int_value-1].axisV);
+         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, (float)hat_mapping[int_value-1].axisH);
       }
       goto done;
    }

--- a/src/macosx/hidjoy.m
+++ b/src/macosx/hidjoy.m
@@ -492,14 +492,19 @@ static void value_callback(
    }
 
    int int_value = IOHIDValueGetIntegerValue(value);
+   int min = joy->min[joy->dpad_stick][1];
+   int max = joy->max[joy->dpad_stick][1];
 
    if (joy->dpad == elem){
-      if (joy->min[joy->dpad_stick][1] > int_value || joy->max[joy->dpad_stick][1] < int_value) {
+      if (int_value >= min && int_value <= max) {
+         int index = int_value - min;
+         if (index < MAX_HAT_DIRECTIONS) {
+            osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  (float)hat_mapping[index].axisV);
+            osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, (float)hat_mapping[index].axisH);
+         }
+      } else {
          osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  0);
          osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, 0);
-      } else if (int_value > 0 && int_value <= MAX_HAT_DIRECTIONS) {
-         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  (float)hat_mapping[int_value-1].axisV);
-         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, (float)hat_mapping[int_value-1].axisH);
       }
       goto done;
    }

--- a/src/macosx/hidjoy.m
+++ b/src/macosx/hidjoy.m
@@ -442,7 +442,7 @@ static void osx_joy_generate_button_event(ALLEGRO_JOYSTICK_OSX *joy, int button,
    _al_event_source_emit_event(es, &event);
 }
 
-#define MAX_HAT_DIRECTIONS 9
+#define MAX_HAT_DIRECTIONS 8
 struct HAT_MAPPING {
    int axisV;
    int axisH;
@@ -455,7 +455,6 @@ struct HAT_MAPPING {
    {  1, -1 }, // 5
    {  0, -1 }, // 6
    { -1, -1 }, // 7
-   {  0,  0 }, // 8
 };
 
 static void value_callback(
@@ -495,9 +494,12 @@ static void value_callback(
    int int_value = IOHIDValueGetIntegerValue(value);
 
    if (joy->dpad == elem){
-      if (int_value >= 0 && int_value < MAX_HAT_DIRECTIONS) {
-         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  (float)hat_mapping[int_value].axisV);
-         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, (float)hat_mapping[int_value].axisH);
+      if (int_value > 0 && int_value <= MAX_HAT_DIRECTIONS) {
+         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  (float)hat_mapping[int_value-1].axisV);
+         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, (float)hat_mapping[int_value-1].axisH);
+      } else if (joy->min[joy->dpad_stick][1] > int_value || joy->max[joy->dpad_stick][1] < int_value) {
+         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_vert,  0);
+         osx_joy_generate_axis_event(joy, joy->dpad_stick, joy->dpad_axis_horiz, 0);
       }
       goto done;
    }


### PR DESCRIPTION
FYI, I only have a single device with a hat switch (on my mac, my X360 controller dpad is a hat switch).

I noticed that for cardinal-direction inputs, I was getting a non-zero value for _both_ axises. Diagonal inputs were off too. I realized that it was an off-by-one error in the hat switch mapping.

Here's a spec sheet for how [these values work](https://www.usb.org/sites/default/files/documents/hid1_11.pdf). An excerpt:

> Indicates whether the control has a state in which it
is not sending meaningful data. One possible use of
the null state is for controls that require the user to
physically interact with the control in order for it to
report useful data. For example, some joysticks
have a multidirectional switch (a hat switch).
When a hat switch is not being pressed it is in a
null state. When in a null state, the control will
report a value outside of the specified Logical
Minimum and Logical Maximum (the most
negative value, such as -128 for an 8-bit value). 

In addition to fixing the off-by-one issue, because of the above paragraph I changed how the null state is detected. Now it looks at the min/max range.