### PR TITLE
Fix initial window position on Windows.

### DIFF
--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -203,9 +203,6 @@ HWND _al_win_create_window(ALLEGRO_DISPLAY *display, int width, int height, int 
       width+lsize+rsize,
       height+tsize+bsize,
       SWP_NOZORDER | SWP_NOMOVE);
-   SetWindowPos(my_window, 0, pos_x-lsize, pos_y-tsize,
-      0, 0,
-      SWP_NOZORDER | SWP_NOSIZE);
 
    if (flags & ALLEGRO_FRAMELESS) {
       SetWindowLong(my_window, GWL_STYLE, WS_VISIBLE);


### PR DESCRIPTION
The existing code, for some reason, would offset the initial window position by the offset of the drawable part of the window within its frame. This makes little sense. This was easy to see via ex_windows where the initial jump position + display window positions were different by some value (e.g. [10, 33])