### PR TITLE
Better support for secondary stick in DirectInput driver

### DIFF
--- a/include/allegro5/internal/aintern_wjoydxnu.h
+++ b/include/allegro5/internal/aintern_wjoydxnu.h
@@ -51,13 +51,14 @@ typedef struct
    int num_sliders;  TCHAR name_slider[MAX_SLIDERS][NAME_LEN];
    int num_povs;     TCHAR name_pov[MAX_POVS][NAME_LEN];
    int num_buttons;  TCHAR name_button[MAX_BUTTONS][NAME_LEN];
+   DWORD secondary_stick_axis_one, secondary_stick_axis_two;
 } CAPS_AND_NAMES;
 
 
 /* map a DirectInput axis to an Allegro (stick,axis) pair */
 typedef struct
 {
-   int stick, axis;
+   int stick, axis, j;
 } AXIS_MAPPING;
 
 


### PR DESCRIPTION
As referenced here: https://github.com/liballeg/allegro5/issues/1462#issuecomment-1694014874

This patch fixes detection of the secondary thumbstick. I tested on two devices: a PS4 Dualshock, and a Stadia controller.

The code assumed that Rx, Ry, Rz will always be what maps to the secondary stick. However, that apparently was too hard for controller manufacturers to do. For example, my above mentioned controllers use Z and Rz for the second stick. Short of including a database of controller mappings, this patch introduces a heuristic to guess how to map to a secondary stick.


The idea for the solution came from https://www.gamedev.net/forums/topic/613913-directinput-identifying-second-thumbstick/