### PR TITLE
OSX: Keep an explicit reference to our view.

### DIFF
--- a/src/macosx/osxgl.h
+++ b/src/macosx/osxgl.h
@@ -40,6 +40,9 @@ typedef struct ALLEGRO_DISPLAY_OSX_WIN {
    ALLEGRO_MUTEX *flip_mutex;
    ALLEGRO_COND *flip_cond;
    int num_flips;
+   /* These two store the old window size when restoring from a FS window. */
+   int old_w;
+   int old_h;
 } ALLEGRO_DISPLAY_OSX_WIN;
 
 /* This is our version of ALLEGRO_MOUSE_CURSOR */

--- a/src/macosx/osxgl.h
+++ b/src/macosx/osxgl.h
@@ -26,6 +26,7 @@ typedef struct ALLEGRO_DISPLAY_OSX_WIN {
    NSOpenGLContext* ctx;
    NSOpenGLPixelFormatAttribute attributes[AL_OSX_NUM_PFA];
    ALWindow* win;
+   NSView* view;
    NSCursor* cursor;
    CGDirectDisplayID display_id;
    BOOL show_cursor;


### PR DESCRIPTION
When going fullscreen window, the view gets attached to a new window (of type NSFullScreenWindow) which causes code that fetches the view from our old window to fail. This keeps the view reference in our display, which seems to cause things ot work.

Fixes #1447