### PR TITLE
Rework how rate-limiting of resize events works on Windows.

### DIFF
--- a/include/allegro5/platform/aintwin.h
+++ b/include/allegro5/platform/aintwin.h
@@ -91,6 +91,15 @@ struct ALLEGRO_DISPLAY_WIN
     */
    bool ignore_resize;
 
+   /* DefWindowProc for WM_ENTERSIZEMOVE enters a modal loop, which also
+    * ends up blocking the loop in d3d_display_thread_proc (which is
+    * where we are called from, if using D3D).  Rather than batching up
+    * intermediate resize events which the user cannot acknowledge in the
+    * meantime anyway, make it so only a single resize event is generated
+    * at WM_EXITSIZEMOVE.
+    */
+   bool d3d_ignore_resize;
+
    /* Size to reset to when al_set_display_flag(FULLSCREEN_WINDOW, false)
     * is called.
     */

--- a/include/allegro5/platform/aintwin.h
+++ b/include/allegro5/platform/aintwin.h
@@ -85,11 +85,6 @@ struct ALLEGRO_DISPLAY_WIN
    volatile bool end_thread;    /* The display thread should end */
    volatile bool thread_ended;  /* The display thread has ended */
 
-   /* For internal use by drivers, when this has been set to true
-    * after al_resize_display called you can call acknowledge_resize
-    */
-   bool can_acknowledge;
-
    /* For internal use by the windows driver. When this is set and a Windows
     * window resize event is received by the window procedure, the event is
     * ignored and this value is set to false.
@@ -179,6 +174,7 @@ HWND _al_win_create_faux_fullscreen_window(LPCTSTR devname, ALLEGRO_DISPLAY *dis
                                            int x1, int y1, int width, int height,
                                            int refresh_rate, int flags);
 int  _al_win_init_window(void);
+void  _al_win_shutdown_window(void);
 HWND _al_win_create_hidden_window(void);
 void _al_win_post_create_window(ALLEGRO_DISPLAY *display);
 

--- a/src/win/d3d_disp.cpp
+++ b/src/win/d3d_disp.cpp
@@ -1818,7 +1818,6 @@ static ALLEGRO_DISPLAY *d3d_create_display_locked(int w, int h)
    win_display->mouse_selected_hcursor = 0;
    win_display->mouse_cursor_shown = false;
    win_display->hide_mouse_on_move = false;
-   win_display->can_acknowledge = false;
 
    SetForegroundWindow(win_display->window);
    _al_win_grab_input(win_display);
@@ -2237,8 +2236,6 @@ static bool d3d_resize_helper(ALLEGRO_DISPLAY *d, int width, int height)
       win_display->toggle_h = height;
       return true;
    }
-
-   win_display->can_acknowledge = false;
 
    if (d->flags & ALLEGRO_FULLSCREEN) {
       /* Don't generate ALLEGRO_EVENT_DISPLAY_LOST events when destroying a

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -999,7 +999,6 @@ static bool create_display_internals(ALLEGRO_DISPLAY_WGL *wgl_disp)
    win_disp->mouse_selected_hcursor = 0;
    win_disp->mouse_cursor_shown = false;
    win_disp->hide_mouse_on_move = false;
-   win_disp->can_acknowledge = false;
 
    _al_win_grab_input(win_disp);
 
@@ -1370,8 +1369,6 @@ static bool wgl_resize_helper(ALLEGRO_DISPLAY *d, int width, int height)
       win_disp->toggle_h = height;
       return true;
    }
-
-   win_disp->can_acknowledge = false;
 
    if (d->flags & ALLEGRO_FULLSCREEN) {
       ALLEGRO_BITMAP *target_bmp;

--- a/src/win/wsystem.c
+++ b/src/win/wsystem.c
@@ -230,6 +230,8 @@ static void win_shutdown(void)
    _al_d3d_shutdown_display();
 #endif
 
+   _al_win_shutdown_window();
+
    _al_win_shutdown_time();
 
    if (using_higher_res_timer) {


### PR DESCRIPTION
Before, we'd spawn bespoke threads every 50ms. One issue with this design was that destroying a display before that 50ms elapsed caused crashes, which happened in the menu code.

The new code has a persistent thread that periodically sends those resize events. More importantly, we make sure that thread is aware of displays being destroyed.

Fixes #1381