### PR TITLE
[osx] Configure NSAlert to be on top

### DIFF
--- a/addons/native_dialog/osx_dialog.m
+++ b/addons/native_dialog/osx_dialog.m
@@ -186,6 +186,7 @@ int _al_show_native_message_box(ALLEGRO_DISPLAY *display,
       [box setMessageText:[NSString stringWithUTF8String: al_cstr(fd->title)]];
       [box setInformativeText:[NSString stringWithUTF8String: al_cstr(fd->mb_text)]];
       [box setAlertStyle: NSWarningAlertStyle];
+      [[box window] setLevel: NSFloatingWindowLevel];
       for (i = 0; i < [buttons count]; ++i)
          [box addButtonWithTitle: [buttons objectAtIndex: i]];
       


### PR DESCRIPTION
This fixes a bug where the alert dialog shows below the current allegro window.

This is only an an issue if the alert is made by another process - in the more normal case where a allegro app calls native alert itself it already shows correctly. My app is effected because one allegro app launches another to do a task, and that second process is doing the alert (which is never seen by the user unless they think to move the first app's window out of the way)