### PR TITLE
Fix cflags include path in allegro.pc

### DIFF
--- a/misc/allegro.pc.in
+++ b/misc/allegro.pc.in
@@ -11,4 +11,4 @@ Description: Allegro game programming library
 Version: ${version}
 Libs: -L${libdir} -lallegro${suffix}
 Libs.private: @link_with@
-Cflags: -I${includedir}
+Cflags: -I${includedir}/allegro${versuffix}


### PR DESCRIPTION
Include files are installed into /usr/include/allegro5 making a `#include <allegro.h>` fail.

Therefore `pkgconfig --cflags allegro-5` must report `/usr/include/allegro5` instead of `/usr/include`