### PR TITLE
don't truncate buffer size to int

### DIFF
--- a/addons/primitives/prim_opengl.c
+++ b/addons/primitives/prim_opengl.c
@@ -671,8 +671,9 @@ int _al_draw_indexed_buffer_opengl(ALLEGRO_BITMAP* target, ALLEGRO_BITMAP* textu
 #endif
 }
 
+#include <stdio.h>
 #ifdef ALLEGRO_CFG_OPENGL
-static bool create_buffer_common(ALLEGRO_BUFFER_COMMON* common, GLenum type, const void* initial_data, int size, int flags)
+static bool create_buffer_common(ALLEGRO_BUFFER_COMMON* common, GLenum type, const void* initial_data, GLsizeiptr size, int flags)
 {
    GLuint vbo;
    GLenum usage;

--- a/addons/primitives/prim_opengl.c
+++ b/addons/primitives/prim_opengl.c
@@ -671,7 +671,6 @@ int _al_draw_indexed_buffer_opengl(ALLEGRO_BITMAP* target, ALLEGRO_BITMAP* textu
 #endif
 }
 
-#include <stdio.h>
 #ifdef ALLEGRO_CFG_OPENGL
 static bool create_buffer_common(ALLEGRO_BUFFER_COMMON* common, GLenum type, const void* initial_data, GLsizeiptr size, int flags)
 {


### PR DESCRIPTION
Simple fix to allow larger VBOs, a bit related to https://github.com/liballeg/allegro5/issues/1473