### PR TITLE
Android: add the possibility to request a specific OpenGL ES version

### DIFF
--- a/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroEGL.java
+++ b/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroEGL.java
@@ -236,7 +236,7 @@ class AllegroEGL
 
          major = minMajor;
          minor = minMinor;
-         wantedVersion = versionCode(major, minor);
+         wantedVersion = minVersion;
       }
 
       Log.d(TAG, "egl_createContext: requesting OpenGL ES " + major + "." + minor);

--- a/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroSurface.java
+++ b/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroSurface.java
@@ -47,9 +47,11 @@ class AllegroSurface extends SurfaceView implements SurfaceHolder.Callback
       egl.egl_getConfigAttribs(index, ret);
    }
 
-   int egl_createContext(int configIndex, boolean programmable_pipeline)
+   int egl_createContext(int configIndex, boolean programmable_pipeline,
+      int major, int minor, boolean isRequiredMajor, boolean isRequiredMinor)
    {
-      return egl.egl_createContext(configIndex, programmable_pipeline);
+      return egl.egl_createContext(configIndex, programmable_pipeline,
+         major, minor, isRequiredMajor, isRequiredMinor);
    }
 
    boolean egl_createSurface()


### PR DESCRIPTION
On Android, Allegro requested at most an OpenGL ES 2.0 context. This patch adds the possibility to request a specific OpenGL ES version - including 3.x - with `al_set_new_display_option`, [as stated in the documentation](https://liballeg.org/a5docs/trunk/display.html#al_set_new_display_option). Hints `ALLEGRO_REQUIRE` and `ALLEGRO_SUGGEST` are taken into account. This fixes #1476.