### PR TITLE
Android: trigger keyboard events of Android game keys with or without an active joystick

### DIFF
--- a/android/gradle_project/allegro/src/main/java/org/liballeg/android/KeyListener.java
+++ b/android/gradle_project/allegro/src/main/java/org/liballeg/android/KeyListener.java
@@ -139,21 +139,17 @@ class KeyListener implements View.OnKeyListener
       if (index >= 0) {
          code = getCode(keyCode, event, index);
       }
-      if (code == -1) {
-         return onKeyboardKey(v, keyCode, event);
-      }
-      else if (code == -2) {
-         return true;
-      }
-      if (event.getAction() == KeyEvent.ACTION_DOWN) {
-         if (event.getRepeatCount() == 0) {
-            nativeOnJoystickButton(index, code, true);
+      if (code >= 0) {
+         if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            if (event.getRepeatCount() == 0) {
+               nativeOnJoystickButton(index, code, true);
+            }
+         }
+         else {
+            nativeOnJoystickButton(index, code, false);
          }
       }
-      else {
-         nativeOnJoystickButton(index, code, false);
-      }
-      return true;
+      return onKeyboardKey(v, keyCode, event);
    }
 
    private void volumeChange(int inc)


### PR DESCRIPTION
Allegro defines 18 "Android game keys" in keycodes.h. Keyboard events of 10 of them will not be triggered after a successful call to `al_install_joystick()`, leading to inconsistent behavior. This patch makes events get triggered for these keys as well, regardless if a joystick has been installed or not. It makes behavior consistent and fixes #1479.