### PR TITLE
Android: add boundary checking to Key.alKey()

### DIFF
--- a/android/gradle_project/allegro/src/main/java/org/liballeg/android/Key.java
+++ b/android/gradle_project/allegro/src/main/java/org/liballeg/android/Key.java
@@ -429,7 +429,10 @@ final class Key
 
    /* Return Allegro key code for Android key code. */
    static int alKey(int keyCode) {
-      return keyMap[keyCode];
+      if (keyCode < keyMap.length)
+         return keyMap[keyCode];
+      else
+         return ALLEGRO_KEY_UNKNOWN;
    }
 }
 


### PR DESCRIPTION
This patch adds boundary checking to `Key.alKey()`. The input `keyCode` [is not guaranteed to be in the [0,255] range](https://developer.android.com/reference/android/view/KeyEvent) (e.g., Android TV).