### PR TITLE
Android: make detection of game controllers more robust

### DIFF
--- a/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroActivity.java
+++ b/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroActivity.java
@@ -542,11 +542,14 @@ public class AllegroActivity extends Activity
    private boolean isJoystick(int id) {
          InputDevice input = InputDevice.getDevice(id);
          int sources = input.getSources();
-         if ((sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK) {
-            return true;
-         }
-         return false;
+
+         // the device is a game controller if it has gamepad buttons, control sticks, or both
+         boolean hasAnalogSticks = ((sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK);
+         boolean hasGamepadButtons = ((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD);
+
+         return hasGamepadButtons || hasAnalogSticks;
    }
+
    public void reconfigureJoysticks() {
       joysticks.clear();
 


### PR DESCRIPTION
Currently, Allegro determines that an input device should be recognized as a joystick if its source type matches `SOURCE_JOYSTICK`. The Android documentation states that this source type indicates that the input device has analog control sticks. There is another value, `SOURCE_GAMEPAD`, that indicates that the input device has gamepad buttons. Both should be taken into account when testing if an input device is a game controller. This patch makes the adjustment.

For more information and an example, refer to:

https://developer.android.com/develop/ui/views/touch-and-input/game-controllers/controller-input?hl=en#input