### PR TITLE
Make AltGr (right Alt) have the ALLEGRO_KEYMOD_ALTGR modifier on X11.

### DIFF
--- a/src/x/xkeyboard.c
+++ b/src/x/xkeyboard.c
@@ -276,7 +276,7 @@ static int modifier_flags[8][3] = {
    {ALLEGRO_KEYMOD_NUMLOCK, Mod2Mask, 1},
    {ALLEGRO_KEYMOD_SCROLLLOCK, Mod3Mask, 1},
    {ALLEGRO_KEYMOD_LWIN | ALLEGRO_KEYMOD_RWIN, Mod4Mask, 0}, /* Should we use only one? */
-   {ALLEGRO_KEYMOD_MENU, Mod5Mask, 0} /* AltGr */
+   {ALLEGRO_KEYMOD_ALTGR, Mod5Mask, 0} /* AltGr */
 };
 
 /* Table of key names. */


### PR DESCRIPTION
For some unknown reason, it was mapped to ALLEGRO_KEYMOD_MENU which is a different key altogether.