### PR TITLE
Android: fix corruption of bitmaps created with the `ALLEGRO_NO_PRESERVE_TEXTURE` flag

### DIFF
--- a/src/android/android_display.c
+++ b/src/android/android_display.c
@@ -841,8 +841,7 @@ static void android_acknowledge_drawing_halt(ALLEGRO_DISPLAY *dpy)
       int bitmap_flags = al_get_bitmap_flags(bmp);
 
       if (!bmp->parent &&
-         !(bitmap_flags & ALLEGRO_MEMORY_BITMAP) &&
-         !(bitmap_flags & ALLEGRO_NO_PRESERVE_TEXTURE))
+         !(bitmap_flags & ALLEGRO_MEMORY_BITMAP))
       {
          ALLEGRO_BITMAP_EXTRA_OPENGL *extra = bmp->extra;
          al_remove_opengl_fbo(bmp);
@@ -900,12 +899,16 @@ static void android_acknowledge_drawing_resume(ALLEGRO_DISPLAY *dpy)
       int bitmap_flags = al_get_bitmap_flags(bmp);
 
       if (!bmp->parent &&
-         !(bitmap_flags & ALLEGRO_MEMORY_BITMAP) &&
-         !(bitmap_flags & ALLEGRO_NO_PRESERVE_TEXTURE))
+         !(bitmap_flags & ALLEGRO_MEMORY_BITMAP))
       {
          int format = al_get_bitmap_format(bmp);
          format = _al_pixel_format_is_compressed(format) ? ALLEGRO_PIXEL_FORMAT_ABGR_8888_LE : format;
-         _al_ogl_upload_bitmap_memory(bmp, format, bmp->memory);
+
+         if (!(bitmap_flags & ALLEGRO_NO_PRESERVE_TEXTURE))
+            _al_ogl_upload_bitmap_memory(bmp, format, bmp->memory);
+         else
+            _al_ogl_upload_bitmap_memory(bmp, format, NULL);
+
          bmp->dirty = false;
       }
    }

--- a/src/opengl/ogl_bitmap.c
+++ b/src/opengl/ogl_bitmap.c
@@ -1128,27 +1128,28 @@ void _al_ogl_upload_bitmap_memory(ALLEGRO_BITMAP *bitmap, int format, void *ptr)
    uint8_t *dst;
    uint8_t *src;
 
-   ASSERT(ptr);
    ASSERT(al_get_current_display() == _al_get_bitmap_display(bitmap));
 
    tmp = _al_create_bitmap_params(_al_get_bitmap_display(bitmap), w, h, format,
       al_get_bitmap_flags(bitmap), 0, 0);
    ASSERT(tmp);
 
-   lr = al_lock_bitmap(tmp, format, ALLEGRO_LOCK_WRITEONLY);
-   ASSERT(lr);
+   if (ptr != NULL) {
+      lr = al_lock_bitmap(tmp, format, ALLEGRO_LOCK_WRITEONLY);
+      ASSERT(lr);
 
-   dst = (uint8_t *)lr->data;
-   // we need to flip it
-   src = ((uint8_t *)ptr) + (pixsize * w * (h-1));
+      dst = (uint8_t *)lr->data;
+      // we need to flip it
+      src = ((uint8_t *)ptr) + (pixsize * w * (h-1));
 
-   for (y = 0; y < h; y++) {
-      memcpy(dst, src, pixsize * w);
-      dst += lr->pitch;
-      src -= pixsize * w; // minus because it's flipped
+      for (y = 0; y < h; y++) {
+         memcpy(dst, src, pixsize * w);
+         dst += lr->pitch;
+         src -= pixsize * w; // minus because it's flipped
+      }
+
+      al_unlock_bitmap(tmp);
    }
-
-   al_unlock_bitmap(tmp);
 
    ((ALLEGRO_BITMAP_EXTRA_OPENGL *)bitmap->extra)->texture =
       ((ALLEGRO_BITMAP_EXTRA_OPENGL *)tmp->extra)->texture;


### PR DESCRIPTION
This patch fixes #1492: corruption of bitmaps created with the `ALLEGRO_NO_PRESERVE_TEXTURE` flag when the application loses focus on Android.

Video bitmaps created without the `ALLEGRO_NO_PRESERVE_TEXTURE` flag are already recovered by Allegro. I take a similar approach:

- I recreate the internal textures of the bitmaps - even though they lose their pixel data - when `al_acknowledge_drawing_resume()` is called.

- I change `_al_ogl_upload_bitmap_memory()` so that it accepts `ptr` == NULL. This function was already documented as accepting NULL, but its code demanded otherwise.