### PR TITLE
Android: delete local JNI string references and use the jstring type

### DIFF
--- a/include/allegro5/internal/aintern_android.h
+++ b/include/allegro5/internal/aintern_android.h
@@ -78,7 +78,7 @@ jobject _jni_callObjectMethod(JNIEnv *env, jobject object,
          const char *name, const char *sig);
 jobject _jni_callObjectMethodV(JNIEnv *env, jobject object,
          const char *name, const char *sig, ...);
-ALLEGRO_USTR *_jni_getString(JNIEnv *env, jobject object);
+ALLEGRO_USTR *_jni_getString(JNIEnv *env, jstring str_obj);
 ALLEGRO_USTR *_jni_callStringMethod(JNIEnv *env, jobject obj,
          const char *name, const char *sig);
 jobject _jni_callStaticObjectMethodV(JNIEnv *env, jclass class_id,

--- a/src/android/android_joystick.c
+++ b/src/android/android_joystick.c
@@ -17,10 +17,11 @@ static bool initialized;
 
 static char *android_get_joystick_name(JNIEnv *env, jobject activity, int index, char *buffer, size_t buffer_size)
 {
-    jobject str_obj = _jni_callObjectMethodV(env, activity, "getJoystickName", "(I)Ljava/lang/String;", (jint)index);
+    jstring str_obj = (jstring)_jni_callObjectMethodV(env, activity, "getJoystickName", "(I)Ljava/lang/String;", (jint)index);
     ALLEGRO_USTR *s = _jni_getString(env, str_obj);
     _al_sane_strncpy(buffer, al_cstr(s), buffer_size);
     al_ustr_free(s);
+    _jni_callv(env, DeleteLocalRef, str_obj);
 
     return buffer;
 }

--- a/src/android/jni_helpers.c
+++ b/src/android/jni_helpers.c
@@ -76,17 +76,17 @@ jobject _jni_callObjectMethodV(JNIEnv *env, jobject object,
    return ret;
 }
 
-ALLEGRO_USTR *_jni_getString(JNIEnv *env, jobject object)
+ALLEGRO_USTR *_jni_getString(JNIEnv *env, jstring str_obj)
 {
    VERBOSE_DEBUG("GetStringUTFLength");
-   jsize len = _jni_call(env, jsize, GetStringUTFLength, object);
+   jsize len = _jni_call(env, jsize, GetStringUTFLength, str_obj);
 
-   const char *str = _jni_call(env, const char *, GetStringUTFChars, object, NULL);
+   const char *str = _jni_call(env, const char *, GetStringUTFChars, str_obj, NULL);
 
    VERBOSE_DEBUG("al_ustr_new_from_buffer");
    ALLEGRO_USTR *ustr = al_ustr_new_from_buffer(str, len);
 
-   _jni_callv(env, ReleaseStringUTFChars, object, str);
+   _jni_callv(env, ReleaseStringUTFChars, str_obj, str);
 
    return ustr;
 }
@@ -94,8 +94,12 @@ ALLEGRO_USTR *_jni_getString(JNIEnv *env, jobject object)
 ALLEGRO_USTR *_jni_callStringMethod(JNIEnv *env, jobject obj,
    const char *name, const char *sig)
 {
-   jobject str_obj = _jni_callObjectMethod(env, obj, name, sig);
-   return _jni_getString(env, str_obj);
+   jstring str_obj = (jstring)_jni_callObjectMethod(env, obj, name, sig);
+   ALLEGRO_USTR *ustr = _jni_getString(env, str_obj);
+
+   _jni_callv(env, DeleteLocalRef, str_obj);
+
+   return ustr;
 }
 
 jobject _jni_callStaticObjectMethodV(JNIEnv *env, jclass cls,


### PR DESCRIPTION
This patch calls `DeleteLocalRef` to delete local JNI string references and uses the `jstring` type in `_jni_getString()`.