### PR TITLE
add al_get_window_borders() and implement for X11

### DIFF
--- a/docs/src/refman/display.txt
+++ b/docs/src/refman/display.txt
@@ -552,13 +552,27 @@ See also: [al_resize_display], [ALLEGRO_EVENT]
 
 Gets the position of a non-fullscreen display.
 
-See also: [al_set_window_position]
+See also: [al_set_window_position], [al_get_window_borders]
 
 ### API: al_set_window_position
 
 Sets the position on screen of a non-fullscreen display.
 
-See also: [al_get_window_position]
+See also: [al_get_window_position], [al_get_window_borders]
+
+### API: al_get_window_borders
+
+If that information is available returns TRUE and fills in the size of
+the window borders. You can pass NULL for borders you do not want to
+retrieve.
+
+If the border information is not available returns FALSE.
+
+Note: Currently only the X11 version will report window borders.
+
+See also: [al_set_window_position], [al_get_window_position]
+
+Since: 5.2.9
 
 ### API: al_get_window_constraints
 

--- a/examples/ex_windows.c
+++ b/examples/ex_windows.c
@@ -49,9 +49,10 @@ int main(int argc, char **argv)
       log_printf("Monitor %d: %d %d - %d %d\n", i, info[i].x1, info[i].y1, info[i].x2, info[i].y2);
    }
 
+   // center the first window
    ALLEGRO_MONITOR_INFO init_info = info[0];
-   x = init_info.x1 + ((init_info.x2 - init_info.x1) / 3) - (W / 2);
-   y = init_info.y1 + ((init_info.y2 - init_info.y1) / 2) - (H / 2);
+   x = (init_info.x1 + init_info.x2 - W) / 2;
+   y = (init_info.y1 + init_info.y2 - H) / 2;
    jump_x[0] = x;
    jump_y[0] = y;
    jump_adapter[0] = 0;
@@ -62,11 +63,11 @@ int main(int argc, char **argv)
    al_set_new_display_flags(ALLEGRO_RESIZABLE);
    displays[0] = al_create_display(W, H);
 
-   x = init_info.x1 + (2 * (init_info.x2 - init_info.x1) / 3) - (W / 2);
-   jump_x[1] = x;
-   jump_y[1] = y;
+   // use the default position for the second window
+   jump_x[1] = INT_MAX;
+   jump_y[1] = INT_MAX;
    jump_adapter[1] = 0;
-   al_set_new_window_position(x, y);
+   al_set_new_window_position(INT_MAX, INT_MAX);
    al_set_new_window_title("Window 2");
 
    displays[1] = al_create_display(W, H);
@@ -102,7 +103,14 @@ int main(int argc, char **argv)
             dw = al_get_display_width(displays[i]);
             dh = al_get_display_height(displays[i]);
             al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 - 30, ALLEGRO_ALIGN_CENTRE, "Location: %d %d", dx, dy);
-            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 - 15, ALLEGRO_ALIGN_CENTRE, "Last jumped to: %d %d (adapter %d)", jump_x[i], jump_y[i], jump_adapter[i]);
+            if (jump_x[i] != INT_MAX && jump_y[i] != INT_MAX) {
+               al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 - 15, ALLEGRO_ALIGN_CENTRE,
+                  "Last jumped to: %d %d (adapter %d)", jump_x[i], jump_y[i], jump_adapter[i]);
+            }
+            else {
+               al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 - 15, ALLEGRO_ALIGN_CENTRE,
+                  "Last placed to default position (adapter %d)", jump_adapter[i]);
+            }
             al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 0, ALLEGRO_ALIGN_CENTRE, "Size: %dx%d", dw, dh);
             int bl = 0, bt = 0;
             bool b = al_get_window_borders(displays[i], &bl, NULL, &bt, NULL);

--- a/examples/ex_windows.c
+++ b/examples/ex_windows.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
             }
             al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 0, ALLEGRO_ALIGN_CENTRE, "Size: %dx%d", dw, dh);
             int bl = 0, bt = 0;
-            bool b = al_get_window_borders(displays[i], &bl, NULL, &bt, NULL);
+            bool b = al_get_window_borders(displays[i], &bl, &bt, NULL, NULL);
             if (b)
                al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 15, ALLEGRO_ALIGN_CENTRE, "Borders: left=%d top=%d", bl, bt);
             else

--- a/examples/ex_windows.c
+++ b/examples/ex_windows.c
@@ -32,6 +32,7 @@ int main(int argc, char **argv)
    }
 
    al_install_mouse();
+   al_install_keyboard();
    al_init_font_addon();
    open_log();
 
@@ -56,6 +57,7 @@ int main(int argc, char **argv)
    jump_adapter[0] = 0;
 
    al_set_new_window_position(x, y);
+   al_set_new_window_title("Window 1");
 
    al_set_new_display_flags(ALLEGRO_RESIZABLE);
    displays[0] = al_create_display(W, H);
@@ -65,6 +67,7 @@ int main(int argc, char **argv)
    jump_y[1] = y;
    jump_adapter[1] = 0;
    al_set_new_window_position(x, y);
+   al_set_new_window_title("Window 2");
 
    displays[1] = al_create_display(W, H);
 
@@ -80,6 +83,7 @@ int main(int argc, char **argv)
    al_register_event_source(events, al_get_display_event_source(displays[0]));
    al_register_event_source(events, al_get_display_event_source(displays[1]));
    al_register_event_source(events, al_get_timer_event_source(timer));
+   al_register_event_source(events, al_get_keyboard_event_source());
 
    bool redraw = true;
    al_start_timer(timer);
@@ -97,10 +101,17 @@ int main(int argc, char **argv)
             al_get_window_position(displays[i], &dx, &dy);
             dw = al_get_display_width(displays[i]);
             dh = al_get_display_height(displays[i]);
-            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 - 15, ALLEGRO_ALIGN_CENTRE, "Location: %d %d", dx, dy);
-            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2, ALLEGRO_ALIGN_CENTRE, "Last jumped to: %d %d (adapter %d)", jump_x[i], jump_y[i], jump_adapter[i]);
-            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 15, ALLEGRO_ALIGN_CENTRE, "Size: %dx%d", dw, dh);
-            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 30, ALLEGRO_ALIGN_CENTRE, "Click me to jump!");
+            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 - 30, ALLEGRO_ALIGN_CENTRE, "Location: %d %d", dx, dy);
+            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 - 15, ALLEGRO_ALIGN_CENTRE, "Last jumped to: %d %d (adapter %d)", jump_x[i], jump_y[i], jump_adapter[i]);
+            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 0, ALLEGRO_ALIGN_CENTRE, "Size: %dx%d", dw, dh);
+            int bl = 0, bt = 0;
+            bool b = al_get_window_borders(displays[i], &bl, NULL, &bt, NULL);
+            if (b)
+               al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 15, ALLEGRO_ALIGN_CENTRE, "Borders: left=%d top=%d", bl, bt);
+            else
+               al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 15, ALLEGRO_ALIGN_CENTRE, "Borders: unknown");
+            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 30, ALLEGRO_ALIGN_CENTRE, "Click left to jump!");
+            al_draw_textf(myfont, al_map_rgb(0, 0, 0), dw / 2, dh / 2 + 45, ALLEGRO_ALIGN_CENTRE, "Click right to swap!");
 
             al_flip_display();
          }
@@ -112,17 +123,36 @@ int main(int argc, char **argv)
          break;
       }
       else if (event.type == ALLEGRO_EVENT_MOUSE_BUTTON_DOWN) {
-         int a = rand() % adapter_count;
-         int w = info[a].x2 - info[a].x1;
-         int h = info[a].y2 - info[a].y1;
-         int margin = 20;
-         int i = event.mouse.display == displays[0] ? 0 : 1;
-         x = margin + info[a].x1 + (rand() % (w - W - 2 * margin));
-         y = margin + info[a].y1 + (rand() % (h - H - 2 * margin));
-         jump_x[i] = x;
-         jump_y[i] = y;
-         jump_adapter[i] = a;
-         al_set_window_position(event.mouse.display, x, y);
+         if (event.mouse.button == 1) {
+            int a = rand() % adapter_count;
+            int w = info[a].x2 - info[a].x1;
+            int h = info[a].y2 - info[a].y1;
+            int margin = 20;
+            int i = event.mouse.display == displays[0] ? 0 : 1;
+            x = margin + info[a].x1 + (rand() % (w - W - 2 * margin));
+            y = margin + info[a].y1 + (rand() % (h - H - 2 * margin));
+            jump_x[i] = x;
+            jump_y[i] = y;
+            jump_adapter[i] = a;
+            log_printf("moving window %d to %d/%d\n", 1 + i, x, y);
+            al_set_window_position(event.mouse.display, x, y);
+         }
+         else {
+            log_printf("swapping windows\n");
+            al_get_window_position(displays[0], jump_x + 1, jump_y + 1);
+            al_get_window_position(displays[1], jump_x, jump_y);
+            al_set_window_position(displays[0], jump_x[0], jump_y[0]);
+            al_set_window_position(displays[1], jump_x[1], jump_y[1]);
+         }
+      }
+      else if (event.type == ALLEGRO_EVENT_KEY_DOWN) {
+         if (event.keyboard.keycode == ALLEGRO_KEY_SPACE) {
+            al_get_window_position(event.keyboard.display, &x, &y);
+            int i = event.mouse.display == displays[0] ? 0 : 1;
+            jump_x[i] = x;
+            jump_y[i] = y;
+            al_set_window_position(event.keyboard.display, x, y);
+         }
       }
       else if (event.type == ALLEGRO_EVENT_TIMER) {
          redraw = true;

--- a/include/allegro5/display.h
+++ b/include/allegro5/display.h
@@ -161,7 +161,7 @@ AL_FUNC(void, al_set_new_window_position, (int x, int y));
 AL_FUNC(void, al_get_new_window_position, (int *x, int *y));
 AL_FUNC(void, al_set_window_position, (ALLEGRO_DISPLAY *display, int x, int y));
 AL_FUNC(void, al_get_window_position, (ALLEGRO_DISPLAY *display, int *x, int *y));
-AL_FUNC(bool, al_get_window_borders, (ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom));
+AL_FUNC(bool, al_get_window_borders, (ALLEGRO_DISPLAY *display, int *left, int *top, int *right, int *bottom));
 AL_FUNC(bool, al_set_window_constraints, (ALLEGRO_DISPLAY *display, int min_w, int min_h, int max_w, int max_h));
 AL_FUNC(bool, al_get_window_constraints, (ALLEGRO_DISPLAY *display, int *min_w, int *min_h, int *max_w, int *max_h));
 AL_FUNC(void, al_apply_window_constraints, (ALLEGRO_DISPLAY *display, bool onoff));

--- a/include/allegro5/display.h
+++ b/include/allegro5/display.h
@@ -161,6 +161,7 @@ AL_FUNC(void, al_set_new_window_position, (int x, int y));
 AL_FUNC(void, al_get_new_window_position, (int *x, int *y));
 AL_FUNC(void, al_set_window_position, (ALLEGRO_DISPLAY *display, int x, int y));
 AL_FUNC(void, al_get_window_position, (ALLEGRO_DISPLAY *display, int *x, int *y));
+AL_FUNC(bool, al_get_window_borders, (ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom));
 AL_FUNC(bool, al_set_window_constraints, (ALLEGRO_DISPLAY *display, int min_w, int min_h, int max_w, int max_h));
 AL_FUNC(bool, al_get_window_constraints, (ALLEGRO_DISPLAY *display, int *min_w, int *min_h, int *max_w, int *max_h));
 AL_FUNC(void, al_apply_window_constraints, (ALLEGRO_DISPLAY *display, bool onoff));

--- a/include/allegro5/internal/aintern_display.h
+++ b/include/allegro5/internal/aintern_display.h
@@ -56,7 +56,7 @@ struct ALLEGRO_DISPLAY_INTERFACE
 
    void (*set_window_position)(ALLEGRO_DISPLAY *display, int x, int y);
    void (*get_window_position)(ALLEGRO_DISPLAY *display, int *x, int *y);
-   bool (*get_window_borders)(ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom);
+   bool (*get_window_borders)(ALLEGRO_DISPLAY *display, int *left, int *top, int *right, int *bottom);
    bool (*set_window_constraints)(ALLEGRO_DISPLAY *display, int min_w, int min_h, int max_w, int max_h);
    bool (*get_window_constraints)(ALLEGRO_DISPLAY *display,  int *min_w, int *min_h, int *max_w, int *max_h);
    bool (*set_display_flag)(ALLEGRO_DISPLAY *display, int flag, bool onoff);

--- a/include/allegro5/internal/aintern_display.h
+++ b/include/allegro5/internal/aintern_display.h
@@ -56,6 +56,7 @@ struct ALLEGRO_DISPLAY_INTERFACE
 
    void (*set_window_position)(ALLEGRO_DISPLAY *display, int x, int y);
    void (*get_window_position)(ALLEGRO_DISPLAY *display, int *x, int *y);
+   bool (*get_window_borders)(ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom);
    bool (*set_window_constraints)(ALLEGRO_DISPLAY *display, int min_w, int min_h, int max_w, int max_h);
    bool (*get_window_constraints)(ALLEGRO_DISPLAY *display,  int *min_w, int *min_h, int *max_w, int *max_h);
    bool (*set_display_flag)(ALLEGRO_DISPLAY *display, int flag, bool onoff);

--- a/include/allegro5/internal/aintern_xdisplay.h
+++ b/include/allegro5/internal/aintern_xdisplay.h
@@ -61,6 +61,7 @@ struct ALLEGRO_DISPLAY_XGLX
 
    /* Desktop position. */
    int x, y;
+   bool need_initial_position_adjust;
    int border_left, border_right, border_top, border_bottom;
    bool borders_known;
 

--- a/include/allegro5/internal/aintern_xdisplay.h
+++ b/include/allegro5/internal/aintern_xdisplay.h
@@ -61,6 +61,8 @@ struct ALLEGRO_DISPLAY_XGLX
 
    /* Desktop position. */
    int x, y;
+   int border_left, border_right, border_top, border_bottom;
+   bool borders_known;
 
    /* al_set_mouse_xy implementation */
    bool mouse_warp;

--- a/include/allegro5/internal/aintern_xwindow.h
+++ b/include/allegro5/internal/aintern_xwindow.h
@@ -10,6 +10,7 @@ void _al_xwin_set_icons(ALLEGRO_DISPLAY *d,
    int num_icons, ALLEGRO_BITMAP *bitmaps[]);
 void _al_xwin_maximize(ALLEGRO_DISPLAY *d, bool maximized);
 void _al_xwin_check_maximized(ALLEGRO_DISPLAY *display);
+void _al_xwin_get_borders(ALLEGRO_DISPLAY *display);
 
 #endif
 

--- a/src/display.c
+++ b/src/display.c
@@ -405,10 +405,10 @@ void al_get_window_position(ALLEGRO_DISPLAY *display, int *x, int *y)
 
 /* Function: al_get_window_borders
  */
-bool al_get_window_borders(ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom)
+bool al_get_window_borders(ALLEGRO_DISPLAY *display, int *left, int *top, int *right, int *bottom)
 {
    if (display && display->vt && display->vt->get_window_borders) {
-      return display->vt->get_window_borders(display, left, right, top, bottom);
+      return display->vt->get_window_borders(display, left, top, right, bottom);
    }
    else {
       return false;

--- a/src/display.c
+++ b/src/display.c
@@ -406,7 +406,7 @@ void al_get_window_position(ALLEGRO_DISPLAY *display, int *x, int *y)
  */
 bool al_get_window_borders(ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom)
 {
-   if (display && display->vt && display->vt->get_window_position) {
+   if (display && display->vt && display->vt->get_window_borders) {
       return display->vt->get_window_borders(display, left, right, top, bottom);
    }
    else {

--- a/src/display.c
+++ b/src/display.c
@@ -402,6 +402,18 @@ void al_get_window_position(ALLEGRO_DISPLAY *display, int *x, int *y)
    }
 }
 
+/* Function: al_get_window_position
+ */
+bool al_get_window_borders(ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom)
+{
+   if (display && display->vt && display->vt->get_window_position) {
+      return display->vt->get_window_borders(display, left, right, top, bottom);
+   }
+   else {
+      return false;
+   }
+}
+
 
 /* Function: al_set_window_constraints
  */

--- a/src/display.c
+++ b/src/display.c
@@ -402,7 +402,8 @@ void al_get_window_position(ALLEGRO_DISPLAY *display, int *x, int *y)
    }
 }
 
-/* Function: al_get_window_position
+
+/* Function: al_get_window_borders
  */
 bool al_get_window_borders(ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom)
 {

--- a/src/x/xdisplay.c
+++ b/src/x/xdisplay.c
@@ -1299,7 +1299,7 @@ static void xdpy_get_window_position(ALLEGRO_DISPLAY *display, int *x, int *y)
 }
 
 
-static bool xdpy_get_window_borders(ALLEGRO_DISPLAY *display, int *left, int *right, int *top, int *bottom)
+static bool xdpy_get_window_borders(ALLEGRO_DISPLAY *display, int *left, int *top, int *right, int *bottom)
 {
    ALLEGRO_DISPLAY_XGLX *glx = (ALLEGRO_DISPLAY_XGLX *)display;
    if (!glx->borders_known) return false;

--- a/src/x/xwindow.c
+++ b/src/x/xwindow.c
@@ -417,8 +417,16 @@ void _al_xwin_get_borders(ALLEGRO_DISPLAY *display) {
          glx->border_top = (int)((long *)property)[2];
          glx->border_bottom = (int)((long *)property)[3];
          glx->borders_known = true;
+         ALLEGRO_DEBUG("_NET_FRAME_EXTENTS: %d %d %d %d\n", glx->border_left, glx->border_top,
+            glx->border_right, glx->border_bottom);
+      }
+      else {
+         ALLEGRO_DEBUG("Unexpected _NET_FRAME_EXTENTS format: nitems=%lu\n", nitems);
       }
       XFree(property);
+   }
+   else {
+      ALLEGRO_DEBUG("Could not read _NET_FRAME_EXTENTS\n");
    }
 }
 

--- a/src/x/xwindow.c
+++ b/src/x/xwindow.c
@@ -396,4 +396,30 @@ XID al_get_x_window_id(ALLEGRO_DISPLAY *display)
    return ((ALLEGRO_DISPLAY_XGLX*)display)->window;
 }
 
+
+// Note: this only seems to work after the window has been mapped
+void _al_xwin_get_borders(ALLEGRO_DISPLAY *display) {
+   ALLEGRO_DISPLAY_XGLX *glx = (ALLEGRO_DISPLAY_XGLX *)display;
+   ALLEGRO_SYSTEM_XGLX *system = (void *)al_get_system_driver();
+   Display *x11 = system->x11display;
+
+   Atom type;
+   int format;
+   unsigned long nitems, bytes_after;
+   unsigned char *property;
+   Atom frame_extents = X11_ATOM(_NET_FRAME_EXTENTS);
+   if (XGetWindowProperty(x11, glx->window,
+         frame_extents, 0, 16, 0, XA_CARDINAL,
+         &type, &format, &nitems, &bytes_after, &property) == Success) {
+      if (type != None && nitems == 4) {
+         glx->border_left = (int)((long *)property)[0];
+         glx->border_right = (int)((long *)property)[1];
+         glx->border_top = (int)((long *)property)[2];
+         glx->border_bottom = (int)((long *)property)[3];
+         glx->borders_known = true;
+      }
+      XFree(property);
+   }
+}
+
 /* vim: set sts=3 sw=3 et: */


### PR DESCRIPTION
Fixes https://github.com/liballeg/allegro5/issues/1496

I added a function to query window borders (like SDL_GetWindowBordersSize) and made al_set_window_position and al_get_window_position both use *outer* window coordinates for X11.

Also added a swap button and move-to-same-place key to ex_windows to test the changes.

I initially thought just using outer coordinates is fine as https://liballeg.org/a5docs/trunk/display.html#al_set_window_position and https://liballeg.org/a5docs/trunk/display.html#al_get_window_position do not specify if they mean inner or outer coordinates. However https://liballeg.org/a5docs/trunk/display.html#al_set_new_window_position specifically mentions the "top left pixel of the client area". So considering that, I'd be fine with changing the PR to use inner coordinates everywhere, should be easy to change now. Also for what it's worth, SDL uses inner coordinates for everything (but provides SDL_GetWindowBordersSize to easily convert between inner and outer).