### PR TITLE
Implement window borders on Windows and treat window position as referring to the client area.

### DIFF
--- a/include/allegro5/platform/aintwin.h
+++ b/include/allegro5/platform/aintwin.h
@@ -195,6 +195,7 @@ void _al_win_destroy_display_icons(ALLEGRO_DISPLAY *display);
 /* window decorations */
 void _al_win_set_window_position(HWND window, int x, int y);
 void _al_win_get_window_position(HWND window, int *x, int *y);
+bool _al_win_get_window_borders(ALLEGRO_DISPLAY *display, int *left, int *top, int *right, int *bottom);
 bool _al_win_set_window_constraints(ALLEGRO_DISPLAY *display, int min_w, int min_h, int max_w, int max_h);
 bool _al_win_get_window_constraints(ALLEGRO_DISPLAY *display, int *min_w, int *min_h, int *max_w, int *max_h);
 void _al_win_apply_window_constraints(ALLEGRO_DISPLAY *display, bool onoff);

--- a/src/win/d3d_disp.cpp
+++ b/src/win/d3d_disp.cpp
@@ -2919,6 +2919,7 @@ ALLEGRO_DISPLAY_INTERFACE *_al_display_d3d_driver(void)
    vt->set_icons = _al_win_set_display_icons;
    vt->set_window_position = d3d_set_window_position;
    vt->get_window_position = d3d_get_window_position;
+   vt->get_window_borders = _al_win_get_window_borders;
    vt->set_window_constraints = _al_win_set_window_constraints;
    vt->get_window_constraints = _al_win_get_window_constraints;
    vt->apply_window_constraints = _al_win_apply_window_constraints;

--- a/src/win/wgl_disp.c
+++ b/src/win/wgl_disp.c
@@ -1563,6 +1563,7 @@ ALLEGRO_DISPLAY_INTERFACE *_al_display_wgl_driver(void)
    vt.set_icons = _al_win_set_display_icons;
    vt.set_window_position = wgl_set_window_position;
    vt.get_window_position = wgl_get_window_position;
+   vt.get_window_borders = _al_win_get_window_borders;
    vt.set_window_constraints = _al_win_set_window_constraints;
    vt.get_window_constraints = _al_win_get_window_constraints;
    vt.apply_window_constraints = _al_win_apply_window_constraints;


### PR DESCRIPTION
It seems unlike GTK, the menu is counted as part of the border.