### PR TITLE
Android joystick: add trigger buttons

### DIFF
--- a/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroJoystick.java
+++ b/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroJoystick.java
@@ -21,6 +21,8 @@ class AllegroJoystick implements OnGenericMotionListener
    private float axis0_hat_y = 0.0f;
    private float axis1_x = 0.0f;
    private float axis1_y = 0.0f;
+   private float axis_lt = 0.0f;
+   private float axis_rt = 0.0f;
 
    private void handleHat(int index1, float old, float cur, int button1, int button2) {
       if (old == cur)
@@ -61,6 +63,8 @@ class AllegroJoystick implements OnGenericMotionListener
          float ahy = event.getAxisValue(MotionEvent.AXIS_HAT_Y, 0);
          float az = event.getAxisValue(MotionEvent.AXIS_Z, 0);
          float arz = event.getAxisValue(MotionEvent.AXIS_RZ, 0);
+         float alt = event.getAxisValue(MotionEvent.AXIS_BRAKE, 0);
+         float art = event.getAxisValue(MotionEvent.AXIS_GAS, 0);
          if (ax != axis0_x || ay != axis0_y) {
             surface.nativeOnJoystickAxis(index, 0, 0, ax);
             surface.nativeOnJoystickAxis(index, 0, 1, ay);
@@ -78,6 +82,14 @@ class AllegroJoystick implements OnGenericMotionListener
             surface.nativeOnJoystickAxis(index, 1, 1, arz);
             axis1_x = az;
             axis1_y = arz;
+         }
+         if (alt != axis_lt) {
+            surface.nativeOnJoystickAxis(index, 2, 0, alt);
+            axis_lt = alt;
+         }
+         if (art != axis_rt) {
+            surface.nativeOnJoystickAxis(index, 3, 0, art);
+            axis_rt = art;
          }
          return true;
       }

--- a/src/android/android_joystick.c
+++ b/src/android/android_joystick.c
@@ -6,6 +6,10 @@
 
 ALLEGRO_DEBUG_CHANNEL("android")
 
+/* sticks: left & right thumbsticks; left & right triggers */
+#define MAX_STICKS 4
+ALLEGRO_STATIC_ASSERT(android_joystick, _AL_MAX_JOYSTICK_STICKS >= MAX_STICKS);
+
 typedef struct ALLEGRO_JOYSTICK_ANDROID {
    ALLEGRO_JOYSTICK parent;
    ALLEGRO_JOYSTICK_STATE joystate;
@@ -40,7 +44,7 @@ static void android_init_joysticks(int num)
 
        /* Fill in the joystick information fields. */
        android_get_joystick_name(env, activity, i, stick->name, sizeof(stick->name));
-       joy->info.num_sticks = 2;
+       joy->info.num_sticks = MAX_STICKS;
        joy->info.num_buttons = 11;
        joy->info.stick[0].name = "Stick 1";
        joy->info.stick[0].num_axes = 2;
@@ -52,6 +56,14 @@ static void android_init_joysticks(int num)
        joy->info.stick[1].axis[0].name = "X";
        joy->info.stick[1].axis[1].name = "Y";
        joy->info.stick[1].flags = ALLEGRO_JOYFLAG_ANALOGUE;
+       joy->info.stick[2].name = "Left Trigger";
+       joy->info.stick[2].num_axes = 1;
+       joy->info.stick[2].axis[0].name = "Ramp";
+       joy->info.stick[2].flags = ALLEGRO_JOYFLAG_ANALOGUE;
+       joy->info.stick[3].name = "Right Trigger";
+       joy->info.stick[3].num_axes = 1;
+       joy->info.stick[3].axis[0].name = "Ramp";
+       joy->info.stick[3].flags = ALLEGRO_JOYFLAG_ANALOGUE;
 
        for (j = 0; j < joy->info.num_buttons; j++) {
            joy->info.button[j].name = "";

--- a/src/android/android_joystick.c
+++ b/src/android/android_joystick.c
@@ -46,12 +46,12 @@ static void android_init_joysticks(int num)
        android_get_joystick_name(env, activity, i, stick->name, sizeof(stick->name));
        joy->info.num_sticks = MAX_STICKS;
        joy->info.num_buttons = 11;
-       joy->info.stick[0].name = "Stick 1";
+       joy->info.stick[0].name = "Left Thumbstick";
        joy->info.stick[0].num_axes = 2;
        joy->info.stick[0].axis[0].name = "X";
        joy->info.stick[0].axis[1].name = "Y";
        joy->info.stick[0].flags = ALLEGRO_JOYFLAG_ANALOGUE;
-       joy->info.stick[1].name = "Stick 2";
+       joy->info.stick[1].name = "Right Thumbstick";
        joy->info.stick[1].num_axes = 2;
        joy->info.stick[1].axis[0].name = "X";
        joy->info.stick[1].axis[1].name = "Y";


### PR DESCRIPTION
This adds the trigger buttons to the Android joystick. They are mapped as two analog sticks with a single axis each, just like in the Windows XInput driver.

This complements #1483.