### PR TITLE
Android: fix a concurrency issue related to `al_acknowledge_drawing_halt()`

### DIFF
--- a/include/allegro5/internal/aintern_android.h
+++ b/include/allegro5/internal/aintern_android.h
@@ -24,6 +24,7 @@ typedef struct ALLEGRO_DISPLAY_ANDROID {
    bool first_run;
    bool resize_acknowledge;
    bool resize_acknowledge2;
+   bool halt_acknowledge;
    bool resumed;
    bool failed;
    bool is_destroy_display;


### PR DESCRIPTION
This patch fixes the concurrency issue described in #1517.