### PR TITLE
Android: add a DeleteLocalRef call to android_get_monitor_info()

### DIFF
--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -503,6 +503,8 @@ static bool android_get_monitor_info(int adapter, ALLEGRO_MONITOR_INFO *info)
 
    ALLEGRO_DEBUG("Monitor Info: %d:%d", info->x2, info->y2);
 
+   _jni_callv(env, DeleteLocalRef, rect);
+
    return true;
 }
 


### PR DESCRIPTION
This patch adds a `DeleteLocalRef` call to `android_get_monitor_info()`.