### PR TITLE
Android: map ALLEGRO_TEMP_PATH to the application cache

### DIFF
--- a/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroActivity.java
+++ b/android/gradle_project/allegro/src/main/java/org/liballeg/android/AllegroActivity.java
@@ -117,6 +117,11 @@ public class AllegroActivity extends Activity
       return getFilesDir().getAbsolutePath();
    }
 
+   String getTempDir()
+   {
+      return getCacheDir().getAbsolutePath();
+   }
+
    String getApkPath()
    {
       return getApplicationInfo().sourceDir;

--- a/src/android/android_system.c
+++ b/src/android/android_system.c
@@ -50,6 +50,7 @@ struct system_data_t {
    ALLEGRO_USTR *user_lib_name;
    ALLEGRO_USTR *resources_dir;
    ALLEGRO_USTR *data_dir;
+   ALLEGRO_USTR *temp_dir;
    ALLEGRO_USTR *apk_path;
    ALLEGRO_USTR *model;
    ALLEGRO_USTR *manufacturer;
@@ -220,11 +221,13 @@ JNI_FUNC(bool, AllegroActivity, nativeOnCreate, (JNIEnv *env, jobject obj))
    system_data.user_lib_name = _jni_callStringMethod(env, system_data.activity_object, "getUserLibName", "()Ljava/lang/String;");
    system_data.resources_dir = _jni_callStringMethod(env, system_data.activity_object, "getResourcesDir", "()Ljava/lang/String;");
    system_data.data_dir = _jni_callStringMethod(env, system_data.activity_object, "getPubDataDir", "()Ljava/lang/String;");
+   system_data.temp_dir = _jni_callStringMethod(env, system_data.activity_object, "getTempDir", "()Ljava/lang/String;");
    system_data.apk_path = _jni_callStringMethod(env, system_data.activity_object, "getApkPath", "()Ljava/lang/String;");
    system_data.model = _jni_callStringMethod(env, system_data.activity_object, "getModel", "()Ljava/lang/String;");
    system_data.manufacturer = _jni_callStringMethod(env, system_data.activity_object, "getManufacturer", "()Ljava/lang/String;");
    ALLEGRO_DEBUG("resources_dir: %s", al_cstr(system_data.resources_dir));
    ALLEGRO_DEBUG("data_dir: %s", al_cstr(system_data.data_dir));
+   ALLEGRO_DEBUG("temp_dir: %s", al_cstr(system_data.temp_dir));
    ALLEGRO_DEBUG("apk_path: %s", al_cstr(system_data.apk_path));
    ALLEGRO_DEBUG("model: %s", al_cstr(system_data.model));
    ALLEGRO_DEBUG("manufacturer: %s", al_cstr(system_data.manufacturer));
@@ -563,6 +566,10 @@ ALLEGRO_PATH *_al_android_get_path(int id)
          break;
 
       case ALLEGRO_TEMP_PATH:
+         /* path to the application cache */
+         path = al_create_path_for_directory(al_cstr(system_data.temp_dir));
+         break;
+
       case ALLEGRO_USER_DATA_PATH:
       case ALLEGRO_USER_HOME_PATH:
       case ALLEGRO_USER_SETTINGS_PATH:


### PR DESCRIPTION
In Allegro 5.2.9 for Android, `ALLEGRO_TEMP_PATH` is a synonym of `ALLEGRO_USER_DATA_PATH` and of other paths (see the code snippet below). Currently, `ALLEGRO_TEMP_PATH` is mapped to the app-specific directory for persistent files located in internal storage - it relies on `getFilesDir()`. On Android, the app's cache directory is meant to be used for temporary storage instead ([see docs](https://developer.android.com/training/data-storage/app-specific#internal-create-cache)).

This patch modifies `ALLEGRO_TEMP_PATH` so that it is mapped to the internal cache. No additional permissions are required.

https://github.com/liballeg/allegro5/blob/9ced31b85310c307c19b0edab6b151e05aea4d3e/src/android/android_system.c#L565-L572