### PR TITLE
Fix failure to enter full-screen mode on Linux with native dialog.

### DIFF
--- a/addons/native_dialog/gtk_xgtk.c
+++ b/addons/native_dialog/gtk_xgtk.c
@@ -490,6 +490,9 @@ static bool xgtk_set_display_flag(ALLEGRO_DISPLAY *display, int flag, bool onoff
 
          return true;
       }
+      case ALLEGRO_FULLSCREEN_WINDOW:
+         xgtk_set_fullscreen_window(display, onoff);
+         return true;
    }
    return false;
 }


### PR DESCRIPTION
Since the native dialog addon has started overriding the call to al_set_display_flag, (commit cc5c63cadfe1a49bf3d5d34153f284e4d71c34ad), setting the flag ALLEGRO_FULLSCREEN_WINDOW does nothing and the call returns false.  This appears to be mistake as a function xgtk_set_fullscreen_window is available in the file gtk_xgtk.c

This commit implements processing of the ALLEGRO_FULLSCREEN_WINDOW flag by calling this function.

A possibly relevant issue in the Allegro5 GitHub is https://github.com/liballeg/allegro5/issues/1456