### PR TITLE
MacOS: Don't use usage numbers as button ids on OSX.

### DIFF
--- a/allegro5.cfg
+++ b/allegro5.cfg
@@ -252,3 +252,7 @@ automatic_menu_display_resize = true
 # to a graphical application. This may be undesirable for console applications. Set
 # this to false to disable this behavior.
 osx_tell_dock_outside_bundle = true
+
+# To restore behavior of older code versions, specify this value to the
+# Allegro version that had the desired old behavior.
+# joystick_version = 5.2.9

--- a/include/allegro5/internal/aintern_system.h
+++ b/include/allegro5/internal/aintern_system.h
@@ -72,6 +72,7 @@ AL_VAR(_AL_DTOR_LIST *, _al_dtor_list);
 AL_FUNC(void *, _al_open_library, (const char *filename));
 AL_FUNC(void *, _al_import_symbol, (void *library, const char *symbol));
 AL_FUNC(void, _al_close_library, (void *library));
+AL_FUNC(uint32_t, _al_get_joystick_compat_version, (void));
 
 #ifdef __cplusplus
 }

--- a/src/joynu.c
+++ b/src/joynu.c
@@ -300,6 +300,22 @@ void al_get_joystick_state(ALLEGRO_JOYSTICK *joy, ALLEGRO_JOYSTICK_STATE *ret_st
    new_joystick_driver->get_joystick_state(joy, ret_state);
 }
 
+
+
+uint32_t _al_get_joystick_compat_version(void)
+{
+   ALLEGRO_CONFIG *system_config = al_get_system_config();
+   const char* compat_version = al_get_config_value(system_config, "compatibility", "joystick_version");
+   if (!compat_version || strlen(compat_version) == 0)
+      return al_get_allegro_version();
+   int version = 0;
+   int sub_version = 0;
+   int wip_version = 0;
+   /* Ignore the release number, we don't expect that to make a difference */
+   sscanf(compat_version, "%2d.%2d.%2d", &version, &sub_version, &wip_version);
+   return AL_ID(version, sub_version, wip_version, 0);
+}
+
 /*
  * Local Variables:
  * c-basic-offset: 3


### PR DESCRIPTION
Add a compatibility config option, "[compatibility] joystick_version=xx.yy.zz" if it is necessary to restore the old behavior.

Fixes #1527

@connorjclark does this work for you?