### PR TITLE
Prefill ALLEGRO_AUDIO_STREAMs with data in docstrings/examples/acodec.

### DIFF
--- a/addons/audio/kcm_stream.c
+++ b/addons/audio/kcm_stream.c
@@ -684,6 +684,7 @@ void *_al_kcm_feed_stream(ALLEGRO_THREAD *self, void *vstream)
    ALLEGRO_AUDIO_STREAM *stream = vstream;
    ALLEGRO_EVENT_QUEUE *queue;
    bool finished_event_sent = false;
+   bool prefill = true;
    (void)self;
 
    ALLEGRO_DEBUG("Stream feeder thread started.\n");
@@ -702,10 +703,12 @@ void *_al_kcm_feed_stream(ALLEGRO_THREAD *self, void *vstream)
       char *fragment;
       ALLEGRO_EVENT event;
 
-      al_wait_for_event(queue, &event);
+      if (!prefill)
+         al_wait_for_event(queue, &event);
 
-      if (event.type == ALLEGRO_EVENT_AUDIO_STREAM_FRAGMENT
+      if ((prefill || event.type == ALLEGRO_EVENT_AUDIO_STREAM_FRAGMENT)
           && !stream->is_draining) {
+         prefill = false;
          unsigned long bytes;
          unsigned long bytes_written;
          ALLEGRO_MUTEX *stream_mutex;

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -735,6 +735,20 @@ If you're late with supplying new data, the stream will be silent until new data
 is provided. You must call [al_drain_audio_stream] when you're finished with
 supplying data to the stream.
 
+It is often a good idea to prefill the audio stream with data before
+[ALLEGRO_EVENT_AUDIO_STREAM_FRAGMENT] events arrive. Here is a snippet that will
+fill the stream buffers with silence:
+
+~~~~c
+ALLEGRO_AUDIO_STREAM *stream = al_create_audio_stream(num_buffers,
+   samples_per_buffer, freq, depth, channel_conf);
+void *buf;
+while ((buf = al_get_audio_stream_fragment(stream))) {
+   al_fill_silence(buf, samples_per_buffer, depth, channel_conf);
+   al_set_audio_stream_fragment(stream, buf);
+}
+~~~~
+
 If the stream is created by [al_load_audio_stream] or [al_play_audio_stream]
 then it will also generate an [ALLEGRO_EVENT_AUDIO_STREAM_FINISHED] event if it
 reaches the end of the file and is not set to loop.

--- a/examples/ex_saw.c
+++ b/examples/ex_saw.c
@@ -83,6 +83,7 @@ static void saw(ALLEGRO_AUDIO_STREAM *stream)
 int main(int argc, char **argv)
 {
    ALLEGRO_AUDIO_STREAM *stream;
+   void *buf;
 
    (void)argc;
    (void)argv;
@@ -98,6 +99,12 @@ int main(int argc, char **argv)
 
    stream = al_create_audio_stream(8, SAMPLES_PER_BUFFER, 22050,
       ALLEGRO_AUDIO_DEPTH_UINT8, ALLEGRO_CHANNEL_CONF_1);
+   while ((buf = al_get_audio_stream_fragment(stream))) {
+      al_fill_silence(buf, SAMPLES_PER_BUFFER, ALLEGRO_AUDIO_DEPTH_UINT8,
+         ALLEGRO_CHANNEL_CONF_1);
+      al_set_audio_stream_fragment(stream, buf);
+   }
+
    if (!stream) {
       abort_example("Could not create stream.\n");
    }


### PR DESCRIPTION
The audio system will attempt to grab data from a stream *before* it has sent any events that it needs fragments. This causes a bit of lag, and also log spam as the system complains about having no data.

This change adjusts most places to prefill the streams with data to avoid this issue. It should be safe, and in fact beneficial as we should get a few less sample-worths of lag when using
`al_play/load_audio_stream`.