### PR TITLE
add al_set_audio_output_device for audio output device selection

### DIFF
--- a/addons/audio/allegro5/allegro_audio.h
+++ b/addons/audio/allegro5/allegro_audio.h
@@ -368,6 +368,8 @@ ALLEGRO_KCM_AUDIO_FUNC(void, al_fill_silence, (void *buf, unsigned int samples,
 ALLEGRO_KCM_AUDIO_FUNC(int, al_get_num_audio_output_devices, (void));
 ALLEGRO_KCM_AUDIO_FUNC(const ALLEGRO_AUDIO_DEVICE *, al_get_audio_output_device, (int index));
 ALLEGRO_KCM_AUDIO_FUNC(const char *, al_get_audio_device_name, (const ALLEGRO_AUDIO_DEVICE * device));
+ALLEGRO_KCM_AUDIO_FUNC(const bool, al_set_audio_output_device, (const ALLEGRO_AUDIO_DEVICE* device));
+
 
 /* Simple audio layer */
 ALLEGRO_KCM_AUDIO_FUNC(bool, al_reserve_samples, (int reserve_samples));

--- a/addons/audio/allegro5/internal/aintern_audio.h
+++ b/addons/audio/allegro5/internal/aintern_audio.h
@@ -86,7 +86,7 @@ struct ALLEGRO_AUDIO_DRIVER {
    void           (*deallocate_recorder)(struct ALLEGRO_AUDIO_RECORDER *);
 
    _AL_LIST*      (*get_output_devices)(void);
-   bool           (*set_output_device)(ALLEGRO_AUDIO_DEVICE*);
+   int            (*set_output_device)(ALLEGRO_AUDIO_DEVICE*);
 };
 
 extern ALLEGRO_AUDIO_DRIVER *_al_kcm_driver;

--- a/addons/audio/allegro5/internal/aintern_audio.h
+++ b/addons/audio/allegro5/internal/aintern_audio.h
@@ -86,6 +86,7 @@ struct ALLEGRO_AUDIO_DRIVER {
    void           (*deallocate_recorder)(struct ALLEGRO_AUDIO_RECORDER *);
 
    _AL_LIST*      (*get_output_devices)(void);
+   bool           (*set_output_device)(ALLEGRO_AUDIO_DEVICE*);
 };
 
 extern ALLEGRO_AUDIO_DRIVER *_al_kcm_driver;

--- a/addons/audio/alsa.c
+++ b/addons/audio/alsa.c
@@ -1021,7 +1021,8 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_alsa_driver =
    alsa_allocate_recorder,
    alsa_deallocate_recorder,
 
-   alsa_get_output_devices
+   alsa_get_output_devices,
+   NULL,
 };
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/audio/aqueue.m
+++ b/addons/audio/aqueue.m
@@ -129,6 +129,16 @@ static void property_listener(void *inClientData, AudioSessionPropertyID inID, U
 }
 #endif
 
+static int _aqueue_set_audio_output_device(ALLEGRO_AUDIO_DEVICE* output_device) {
+   AudioObjectPropertyAddress  propertyAddress;
+   propertyAddress.mSelector = kAudioHardwarePropertyDefaultOutputDevice;
+   propertyAddress.mScope = kAudioDevicePropertyScopeOutput;
+   propertyAddress.mElement = kAudioObjectPropertyElementMaster;
+
+   return AudioObjectSetPropertyData(kAudioObjectSystemObject, &propertyAddress, 0, NULL, 
+                              sizeof(AudioDeviceID), output_device->identifier) != noErr;
+}
+
 static bool _aqueue_device_has_scope(AudioObjectID deviceID, AudioObjectPropertyScope scope)
 {
     AudioObjectPropertyAddress propertyAddress = {
@@ -679,5 +689,6 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_aqueue_driver = {
    _aqueue_deallocate_recorder,
 
    _aqueue_get_output_devices,
+   _aqueue_set_audio_output_device,
 };
 

--- a/addons/audio/audio.c
+++ b/addons/audio/audio.c
@@ -233,7 +233,9 @@ const ALLEGRO_AUDIO_DEVICE* al_get_audio_output_device(int index)
    return NULL;
 }
 
-const bool al_set_audio_output_device(const ALLEGRO_AUDIO_DEVICE* device)
+/* Function: al_set_audio_output_device
+ */
+const bool al_set_audio_output_device(const ALLEGRO_AUDIO_DEVICE *device)
 {
    if (!al_is_audio_installed()) return false;
    if (_al_kcm_driver->set_output_device) return _al_kcm_driver->set_output_device(device) == 0;
@@ -242,7 +244,7 @@ const bool al_set_audio_output_device(const ALLEGRO_AUDIO_DEVICE* device)
 
 /* Function: al_get_audio_device_name
  */
-const char* al_get_audio_device_name(const ALLEGRO_AUDIO_DEVICE * device)
+const char* al_get_audio_device_name(const ALLEGRO_AUDIO_DEVICE *device)
 {
    return device ? device->name : NULL;
 }

--- a/addons/audio/audio.c
+++ b/addons/audio/audio.c
@@ -233,6 +233,12 @@ const ALLEGRO_AUDIO_DEVICE* al_get_audio_output_device(int index)
    return NULL;
 }
 
+const bool al_set_audio_output_device(const ALLEGRO_AUDIO_DEVICE* device)
+{
+   if (!al_is_audio_installed()) return false;
+   return _al_kcm_driver->set_output_device(device);
+}
+
 /* Function: al_get_audio_device_name
  */
 const char* al_get_audio_device_name(const ALLEGRO_AUDIO_DEVICE * device)

--- a/addons/audio/audio.c
+++ b/addons/audio/audio.c
@@ -236,7 +236,8 @@ const ALLEGRO_AUDIO_DEVICE* al_get_audio_output_device(int index)
 const bool al_set_audio_output_device(const ALLEGRO_AUDIO_DEVICE* device)
 {
    if (!al_is_audio_installed()) return false;
-   return _al_kcm_driver->set_output_device(device);
+   if (_al_kcm_driver->set_output_device) return _al_kcm_driver->set_output_device(device) == 0;
+   return false;
 }
 
 /* Function: al_get_audio_device_name

--- a/addons/audio/openal.c
+++ b/addons/audio/openal.c
@@ -663,7 +663,8 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_openal_driver = {
    NULL,
    NULL,
 
-   NULL
+   NULL,
+   NULL,
 };
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/audio/opensl.c
+++ b/addons/audio/opensl.c
@@ -722,5 +722,6 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_opensl_driver = {
    NULL,
    NULL,
 
-   NULL
+   NULL,
+   NULL,
 };

--- a/addons/audio/oss.c
+++ b/addons/audio/oss.c
@@ -623,7 +623,8 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_oss_driver =
    NULL,
    NULL,
 
-   NULL
+   NULL,
+   NULL,
 };
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/audio/pulseaudio.c
+++ b/addons/audio/pulseaudio.c
@@ -575,7 +575,8 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_pulseaudio_driver =
    pulseaudio_allocate_recorder,
    pulseaudio_deallocate_recorder,
 
-   pulseaudio_get_output_devices
+   pulseaudio_get_output_devices,
+   NULL,
 };
 
 /* vim: set sts=3 sw=3 et: */

--- a/addons/audio/sdl_audio.c
+++ b/addons/audio/sdl_audio.c
@@ -269,4 +269,5 @@ ALLEGRO_AUDIO_DRIVER _al_kcm_sdl_driver =
    sdl_deallocate_recorder,
 
    sdl_get_output_devices,
+   NULL,
 };

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1412,7 +1412,11 @@ Get the user friendly display name of the device.
 
 Since: 5.2.8
 
+### API: al_set_audio_output_device
 
+Select the audio output device to use.  Currently only implemented on Windows and MacOS/iOS.
+
+Since: 5.2.10
 
 ## Voices
 

--- a/examples/ex_audio_simple.c
+++ b/examples/ex_audio_simple.c
@@ -96,11 +96,11 @@ Restart:
 
    {
       int count = al_get_num_audio_output_devices(); // returns -1 for unsupported backends
-      printf("audio device count: %d\n", count);
+      log_printf("audio device count: %d\n", count);
       for (int i = 0; i < count; i++)
       {
          const ALLEGRO_AUDIO_DEVICE* device = al_get_audio_output_device(i);
-         printf(" --- audio device: %s\n", al_get_audio_device_name(device));
+         log_printf(" --- audio device: %s\n", al_get_audio_device_name(device));
       }
    }
 

--- a/examples/ex_audio_simple.c
+++ b/examples/ex_audio_simple.c
@@ -94,8 +94,19 @@ Restart:
       }
    }
 
+   {
+      int count = al_get_num_audio_output_devices(); // returns -1 for unsupported backends
+      printf("audio device count: %d\n", count);
+      for (int i = 0; i < count; i++)
+      {
+         const ALLEGRO_AUDIO_DEVICE* device = al_get_audio_output_device(i);
+         printf(" --- audio device: %s\n", al_get_audio_device_name(device));
+      }
+   }
+
    log_printf(
       "Press digits to play sounds.\n"
+      "Press F1-F12 keys to select audio output device\n"
       "Space to stop sounds.\n"
       "Add Alt to play sounds repeatedly.\n"
       "'p' to pan the last played sound.\n"
@@ -112,6 +123,17 @@ Restart:
             al_stop_samples();
             if (music) {
                al_set_audio_stream_playing(music, false);
+            }
+         }
+
+         if (event.keyboard.keycode >= ALLEGRO_KEY_F1 && event.keyboard.keycode <= ALLEGRO_KEY_F12) {
+            int device_index = (event.keyboard.keycode - ALLEGRO_KEY_F1 + 12) % 12;
+            const ALLEGRO_AUDIO_DEVICE* device = al_get_audio_output_device(device_index);
+
+            if (device) {
+               log_printf("Selected device #%d %s\n", device_index, al_get_audio_device_name(device));
+
+               al_set_audio_output_device(device);
             }
          }
 
@@ -207,6 +229,9 @@ Restart:
          y += dy;
          al_draw_text(font, al_map_rgb_f(1., 0.5, 0.5), 12, y,
             ALLEGRO_ALIGN_LEFT, "1-9 - play the sounds");
+         y += dy;
+         al_draw_text(font, al_map_rgb_f(1., 0.5, 0.5), 12, y,
+            ALLEGRO_ALIGN_LEFT, "F1 - F12 select audio output device");
          y += dy;
          al_draw_text(font, al_map_rgb_f(1., 0.5, 0.5), 12, y,
             ALLEGRO_ALIGN_LEFT, "SPACE - stop all sounds");


### PR DESCRIPTION
 Currently only implemented on dsound and aqueue backend. I also extended ex_audio_simple for easy testing.