### PR TITLE
Fix undesirable deadzone when using analog Joysticks on Windows

### DIFF
--- a/src/win/wjoydxnu.cpp
+++ b/src/win/wjoydxnu.cpp
@@ -850,7 +850,7 @@ static BOOL CALLBACK joystick_enum_callback(LPCDIDEVICEINSTANCE lpddi, LPVOID pv
       },
 
       /* the data */
-      2000,                     // dwData
+      0,                    // dwData
    };
 
    DIPROPDWORD property_buffersize =


### PR DESCRIPTION
This has been discussed in issue #1538 and also [https://www.allegro.cc/forums/thread/618893/1054088](url)

The large deadzone had been hardcoded on windows by default. While there might be some benefit for a deadzone when using thumbsticks (low quality analogue sticks that don't centre well), for high precision flight yokes & steering wheels it is undesirable.

The hardcoded deadzone has now been removed. If users want to set a deadzone, they can do so by adding game code that ignores joystick position values below a certain range. 

Fixes #1538 

