### PR TITLE
Fix opaque black background pixels in explosion sprites.

### DIFF
--- a/demos/shooter/expl.c
+++ b/demos/shooter/expl.c
@@ -64,7 +64,10 @@ void generate_explosions(void)
             lp[0] = pal->rgb[c2].r * 255;
             lp[1] = pal->rgb[c2].g * 255;
             lp[2] = pal->rgb[c2].b * 255;
-            lp[3] = pal->rgb[c2].a * 255;
+            if (c2 > 0)
+               lp[3] = pal->rgb[c2].a * 127;
+            else
+               lp[3] = 0;
          }
       }
 


### PR DESCRIPTION
In the explosion sprites, make black pixels fully transparent, which otherwise block parts of the scene, e.g. stars and ship. Also make all other pixels semi-transparent, which appeared nicer.