### PR TITLE
Fix iPhone build broken by fbb3f0c.

### DIFF
--- a/src/opengl/extensions.c
+++ b/src/opengl/extensions.c
@@ -36,7 +36,7 @@
    #include "allegro5/internal/aintern_xsystem.h"
 #endif
 
-#if defined ALLEGRO_MACOSX || defined __APPLE__
+#if defined __APPLE__ && !defined ALLEGRO_IPHONE
 #include <OpenGL/glu.h>
 #elif !defined ALLEGRO_CFG_OPENGLES
 #include <GL/glu.h>


### PR DESCRIPTION
Building for iPhone was failing on `src/opengl/extensions.c`. I traced the failure back to a change in commit fbb3f0c.

In order to keep that workaround functioning, I changed the `#if defined ALLEGRO_MACOSX || defined __APPLE__` to `#if defined __APPLE__ && !defined ALLEGRO_IPHONE`.

This fix ensures the proper OpenGL header is included if we are building for MacOS (including the SDL port which disables the `ALLEGRO_MACOSX` platform definition) and it is not included if we are building for iPhone.