### PR TITLE
FIx Building on MacOS with SDK versions < 12.0

### DIFF
--- a/addons/audio/aqueue.m
+++ b/addons/audio/aqueue.m
@@ -183,7 +183,11 @@ static void _aqueue_list_audio_output_devices(void)
    
    propertyAddress.mSelector = kAudioHardwarePropertyDevices;
    propertyAddress.mScope = kAudioObjectPropertyScopeGlobal;
-   propertyAddress.mElement = kAudioObjectPropertyElementMain;
+   #if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 120000)
+      propertyAddress.mElement = kAudioObjectPropertyElementMain;
+   #else
+      propertyAddress.mElement = kAudioObjectPropertyElementMaster;
+   #endif
    
    if (AudioObjectGetPropertyDataSize(kAudioObjectSystemObject, &propertyAddress, 0, NULL, &propertySize) != noErr) {
       return;
@@ -203,7 +207,11 @@ static void _aqueue_list_audio_output_devices(void)
       propertySize = sizeof(deviceName);
       deviceAddress.mSelector = kAudioDevicePropertyDeviceName;
       deviceAddress.mScope = kAudioObjectPropertyScopeGlobal;
-      deviceAddress.mElement = kAudioObjectPropertyElementMain;
+      #if (__MAC_OS_X_VERSION_MAX_ALLOWED >= 120000)
+         deviceAddress.mElement = kAudioObjectPropertyElementMain;
+      #else
+         deviceAddress.mElement = kAudioObjectPropertyElementMaster;
+      #endif
       if (AudioObjectGetPropertyData(deviceIDs[idx], &deviceAddress, 0, NULL, &propertySize, deviceName) != noErr) {
          continue;
       }


### PR DESCRIPTION
As described in the commit message, Apple renamed `kAudioObjectPropertyElementMaster` to `kAudioObjectPropertyElementMain` in the MacOS v12.0 SDK. This change made building Allegro with older SDKs fail.

This pull request includes a commit that allows Allegro to be built with SDKs < v12.0 by using the old variable name if the SDK being used is < v12.0.