### PR TITLE
Don't set WM_TOPMOST on Windows.

### DIFF
--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -868,10 +868,6 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
             d->flags &= ~ALLEGRO_MINIMIZED;
 
          if (LOWORD(wParam) != WA_INACTIVE) {
-            // Make fullscreen windows TOPMOST again
-            if (d->flags & ALLEGRO_FULLSCREEN_WINDOW) {
-               SetWindowPos(win_display->window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-            }
             if (d->vt->switch_in)
                d->vt->switch_in(d);
             _al_win_fix_modifiers();
@@ -888,11 +884,6 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
             return 0;
          }
          else {
-            // Remove TOPMOST flag from fullscreen windows so we can alt-tab. Also must raise the new activated window
-            if (d->flags & ALLEGRO_FULLSCREEN_WINDOW) {
-               SetWindowPos(win_display->window, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-               SetWindowPos(GetForegroundWindow(), HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-            }
             if (d->flags & ALLEGRO_FULLSCREEN) {
                d->vt->switch_out(d);
             }
@@ -1348,17 +1339,14 @@ bool _al_win_set_display_flag(ALLEGRO_DISPLAY *display, int flag, bool onoff)
          al_resize_display(display, display->w, display->h);
 
          if (onoff) {
-            // Re-set the TOPMOST flag and move to position
-            SetWindowPos(win_display->window, HWND_TOPMOST, mi.x1, mi.y1, 0, 0, SWP_NOSIZE);
+            // Move to position
+            SetWindowPos(win_display->window, HWND_TOP, mi.x1, mi.y1, 0, 0, SWP_NOSIZE);
          }
          else {
             int pos_x = 0;
             int pos_y = 0;
             WINDOWINFO wi;
             int bw, bh;
-
-            // Unset the topmost flag
-            SetWindowPos(win_display->window, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
 
             // Center the window
             _al_win_get_window_center(win_display, display->w, display->h, &pos_x, &pos_y);


### PR DESCRIPTION
This sometimes breaks toggling ALLEGRO_FULLSCREEN_WINDOW with OpenGL.

It doesn't appear to do anything, and we don't appear to set it in the first place when the window is first created as
ALLEGRO_FULLSCREEN_WINDOW.