### PR TITLE
[osx] use CLOCK_REALTIME for init_timeout

### DIFF
--- a/src/unix/utime.c
+++ b/src/unix/utime.c
@@ -108,7 +108,7 @@ void _al_unix_init_timeout(ALLEGRO_TIMEOUT *timeout, double seconds)
 
    ASSERT(ut);
 
-   _al_clock_gettime(CLOCK_ID, &now);
+   _al_clock_gettime(CLOCK_REALTIME, &now);
 
    if (seconds <= 0.0) {
       ut->abstime.tv_sec = now.tv_sec;


### PR DESCRIPTION
#1511 changed osx clocks to use CLOCK_MONOTONIC_RAW, but that is an issue for the timeout structure because pthread expects an absolute system time. This resulted in timed event calls returning instantly.

See https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_cond_timedwait.html#:~:text=Timed%20Wait%20Semantics