### PR TITLE
Add "al_get_render_state"

### DIFF
--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -2046,9 +2046,9 @@ See also: [al_set_render_state]
 Returns one of several render attributes; see [ALLEGRO_RENDER_STATE]
 for details.
 
-This function will return 0 when there is no current display.
+This function will return -1 when there is no current display.
 
-Since: 5.2.11
+Since: 5.2.10
 
 See also: [al_set_render_state], [ALLEGRO_RENDER_STATE], [ALLEGRO_RENDER_FUNCTION],
 [ALLEGRO_WRITE_MASK_FLAGS]

--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -2040,6 +2040,20 @@ Since: 5.1.2
 
 See also: [al_set_render_state]
 
+
+### API: al_get_render_state
+
+Returns one of several render attributes; see [ALLEGRO_RENDER_STATE]
+for details.
+
+This function will return 0 when there is no current display.
+
+Since: 5.2.11
+
+See also: [al_set_render_state], [ALLEGRO_RENDER_STATE], [ALLEGRO_RENDER_FUNCTION],
+[ALLEGRO_WRITE_MASK_FLAGS]
+
+
 ### API: al_set_render_state
 
 Set one of several render attributes; see [ALLEGRO_RENDER_STATE]
@@ -2049,7 +2063,7 @@ This function does nothing if the target bitmap is a memory bitmap.
 
 Since: 5.1.2
 
-See also: [ALLEGRO_RENDER_STATE], [ALLEGRO_RENDER_FUNCTION],
+See also: [al_get_render_state], [ALLEGRO_RENDER_STATE], [ALLEGRO_RENDER_FUNCTION],
 [ALLEGRO_WRITE_MASK_FLAGS]
 
 

--- a/include/allegro5/render_state.h
+++ b/include/allegro5/render_state.h
@@ -46,6 +46,7 @@ typedef enum ALLEGRO_WRITE_MASK_FLAGS {
    ALLEGRO_MASK_RGBA = (ALLEGRO_MASK_RGB | ALLEGRO_MASK_ALPHA)
 } ALLEGRO_WRITE_MASK_FLAGS;
 
+AL_FUNC(int, al_get_render_state, (ALLEGRO_RENDER_STATE state));
 AL_FUNC(void, al_set_render_state, (ALLEGRO_RENDER_STATE state, int value));
 
 #ifdef __cplusplus

--- a/src/display.c
+++ b/src/display.c
@@ -609,7 +609,7 @@ int al_get_render_state(ALLEGRO_RENDER_STATE state)
    ALLEGRO_DISPLAY *display = al_get_current_display();
 
    if (!display)
-      return 0;
+      return -1;
 
    switch (state) {
       case ALLEGRO_ALPHA_TEST:
@@ -631,8 +631,8 @@ int al_get_render_state(ALLEGRO_RENDER_STATE state)
          return display->render_state.alpha_test_value;
          break;
       default:
-         ALLEGRO_WARN("unknown state to retrieve: %d\n", state);
-         return 0;
+         ALLEGRO_ERROR("Unknown state to retrieve: %d\n", state);
+         return -1;
          break;
    }
 }
@@ -666,7 +666,7 @@ void al_set_render_state(ALLEGRO_RENDER_STATE state, int value)
          display->render_state.alpha_test_value = value;
          break;
       default:
-         ALLEGRO_WARN("unknown state to change: %d\n", state);
+         ALLEGRO_WARN("Unknown state to change: %d\n", state);
          break;
    }
 

--- a/src/display.c
+++ b/src/display.c
@@ -602,6 +602,41 @@ void al_acknowledge_drawing_resume(ALLEGRO_DISPLAY *display)
    }
 }
 
+/* Function: al_get_render_state
+ */
+int al_get_render_state(ALLEGRO_RENDER_STATE state)
+{
+   ALLEGRO_DISPLAY *display = al_get_current_display();
+
+   if (!display)
+      return 0;
+
+   switch (state) {
+      case ALLEGRO_ALPHA_TEST:
+         return display->render_state.alpha_test;
+         break;
+      case ALLEGRO_WRITE_MASK:
+         return display->render_state.write_mask;
+         break;
+      case ALLEGRO_DEPTH_TEST:
+         return display->render_state.depth_test;
+         break;
+      case ALLEGRO_DEPTH_FUNCTION:
+         return display->render_state.depth_function;
+         break;
+      case ALLEGRO_ALPHA_FUNCTION:
+         return display->render_state.alpha_function;
+         break;
+      case ALLEGRO_ALPHA_TEST_VALUE:
+         return display->render_state.alpha_test_value;
+         break;
+      default:
+         ALLEGRO_WARN("unknown state to retrieve: %d\n", state);
+         return 0;
+         break;
+   }
+}
+
 /* Function: al_set_render_state
  */
 void al_set_render_state(ALLEGRO_RENDER_STATE state, int value)


### PR DESCRIPTION
During some debugging, I noticed I didn't have access to the current render state, which would be helpful. This would be particularly useful in instances where different parts of a game system manage render state differently, and checking for possible leaky render state. The values for it seem to be stored in `ALLEGRO_DISPLAY`.

## Some points to be aware of in this PR:
- In the refman/, not sure what "Since 5.2.11" to put it under.
- Not sure about a return value or behavior when there is no current `display`. This implementation just has it return `0` with no warning or anything.