### PR TITLE
Add mouse button constants

### DIFF
--- a/docs/src/refman/events.txt
+++ b/docs/src/refman/events.txt
@@ -218,7 +218,10 @@ mouse.w (int)
 :   w-coordinate
 
 mouse.button (unsigned)
-:   The mouse button which was pressed, numbering from 1.
+:   The mouse button which was pressed, numbering from 1.  As a convenience, the constants
+ALLEGRO_MOUSE_BUTTON_LEFT, ALLEGRO_MOUSE_BUTTON_RIGHT, ALLEGRO_MOUSE_BUTTON_MIDDLE are provided.
+However, depending on the hardware there may be more or fewer mouse buttons. You can check
+[al_get_mouse_num_buttons] if you want to be sure.
 
 mouse.pressure (float)
 :   Pressure, ranging from `0.0` to `1.0`.
@@ -243,7 +246,10 @@ mouse.w (int)
 :   w-coordinate
 
 mouse.button (unsigned)
-:   The mouse button which was released, numbering from 1.
+:   The mouse button which was released, numbering from 1. As a convenience, the constants
+ALLEGRO_MOUSE_BUTTON_LEFT, ALLEGRO_MOUSE_BUTTON_RIGHT, ALLEGRO_MOUSE_BUTTON_MIDDLE are provided.
+However, depending on the hardware there may be more or fewer mouse buttons. You can check
+[al_get_mouse_num_buttons] if you want to be sure.
 
 mouse.pressure (float)
 :   Pressure, ranging from `0.0` to `1.0`.

--- a/docs/src/refman/keyboard.txt
+++ b/docs/src/refman/keyboard.txt
@@ -32,8 +32,8 @@ pressed_keys[key_code] = true;
 ~~~~
 
 These are the list of key codes used by Allegro, which are returned in
-the event.keyboard.keycode field of the ALLEGRO_KEY_DOWN and
-ALLEGRO_KEY_UP events and which you can pass to [al_key_down]:
+the event.keyboard.keycode field of the ALLEGRO_EVENT_KEY_DOWN and
+ALLEGRO_EVENT_KEY_UP events and which you can pass to [al_key_down]:
 
     ALLEGRO_KEY_A ... ALLEGRO_KEY_Z
     ALLEGRO_KEY_0 ... ALLEGRO_KEY_9

--- a/docs/src/refman/mouse.txt
+++ b/docs/src/refman/mouse.txt
@@ -44,7 +44,7 @@ typedef enum ALLEGRO_MOUSE_BUTTON
 
 Since: 5.2.10
 
-See also: [al_get_mouse_num_buttons]
+See also: [al_get_mouse_num_buttons], [al_mouse_button_down]
 
 ## API: al_install_mouse
 
@@ -116,7 +116,12 @@ See also: [ALLEGRO_MOUSE_STATE], [al_get_mouse_state], [al_mouse_button_down]
 ## API: al_mouse_button_down
 
 Return true if the mouse button specified was held down in the state
-specified.  Unlike most things, the first mouse button is numbered 1.
+specified.
+
+Unlike most things, the first mouse button is numbered 1.  As a convenience, the constants
+ALLEGRO_MOUSE_BUTTON_LEFT, ALLEGRO_MOUSE_BUTTON_RIGHT, ALLEGRO_MOUSE_BUTTON_MIDDLE are provided.
+However, depending on the hardware there may be more or fewer mouse buttons. You can check
+[al_get_mouse_num_buttons] if you want to be sure.
 
 See also: [ALLEGRO_MOUSE_STATE], [al_get_mouse_state], [al_get_mouse_state_axis]
 

--- a/docs/src/refman/mouse.txt
+++ b/docs/src/refman/mouse.txt
@@ -23,6 +23,29 @@ Public fields (read only):
 
 See also: [al_get_mouse_state], [al_get_mouse_state_axis], [al_mouse_button_down]
 
+## Mouse button constants
+
+Unlike other indexes, the first mouse button is numbered 1 when returned in
+the event.mouse.button field of ALLEGRO_EVENT_MOUSE_BUTTON_UP and
+ALLEGRO_EVENT_MOUSE_BUTTON_DOWN events.
+
+As a convenience, the following ALLEGRO_MOUSE_BUTTON constants are provided below.
+However, depending on the hardware there may be more or fewer mouse buttons. You
+can check [al_get_mouse_num_buttons] if you want to be sure.
+
+~~~~c
+typedef enum ALLEGRO_MOUSE_BUTTON
+{
+   ALLEGRO_MOUSE_BUTTON_LEFT = 1,
+   ALLEGRO_MOUSE_BUTTON_RIGHT = 2,
+   ALLEGRO_MOUSE_BUTTON_MIDDLE = 3
+} ALLEGRO_MOUSE_BUTTON;
+~~~~
+
+Since: 5.2.10
+
+See also: [al_get_mouse_num_buttons]
+
 ## API: al_install_mouse
 
 Install a mouse driver.

--- a/include/allegro5/mouse.h
+++ b/include/allegro5/mouse.h
@@ -53,6 +53,14 @@ struct ALLEGRO_MOUSE_STATE
 };
 
 
+typedef enum ALLEGRO_MOUSE_BUTTON
+{
+   ALLEGRO_MOUSE_BUTTON_LEFT = 1,
+   ALLEGRO_MOUSE_BUTTON_RIGHT = 2,
+   ALLEGRO_MOUSE_BUTTON_MIDDLE = 3,
+} ALLEGRO_MOUSE_BUTTON;
+
+
 AL_FUNC(bool,           al_is_mouse_installed,  (void));
 AL_FUNC(bool,           al_install_mouse,       (void));
 AL_FUNC(void,           al_uninstall_mouse,     (void));


### PR DESCRIPTION
Mouse button numbering can be confusing. Adding constants could help.

This PR adds `ALLEGRO_MOUSE_BUTTON_LEFT`, `ALLEGRO_MOUSE_BUTTON_RIGHT`, and `ALLEGRO_MOUSE_BUTTON_MIDDLE`.  This would make code like the following available:

```c
switch (event.mouse.button)
{
   case ALLEGRO_MOUSE_BUTTON_LEFT:
      printf("left button pressed!\n");
   break;

   case ALLEGRO_MOUSE_BUTTON_RIGHT:
      printf("right button pressed!\n");
   break;

   case ALLEGRO_MOUSE_BUTTON_MIDDLE:
      printf("middle button pressed!\n");
   break;
}
```
Additions/revisions to the mouse and events documentation are included as well as disclaimers about the possibility of more/fewer mouse buttons.  Also, a typo is fixed in `docs/src/refman/keyboard.txt`.

## Some questions

- Do I need to "make" the docs?
- `ALLEGRO_MOUSE_BUTTON_UNDEF` is not included, should it be?
- There may be other example programs that could be updated to include the constants. Should we worry about including that?