### PR TITLE
Fix memory leak in xdpy_set_system_mouse_cursor()

### DIFF
--- a/include/allegro5/internal/aintern_xdisplay.h
+++ b/include/allegro5/internal/aintern_xdisplay.h
@@ -55,6 +55,7 @@ struct ALLEGRO_DISPLAY_XGLX
    Cursor invisible_cursor;
    Cursor current_cursor;
    bool cursor_hidden;
+   bool is_system_cursor;
 
    /* Icon for this window. */
    Pixmap icon, icon_mask;

--- a/src/x/xcursor.c
+++ b/src/x/xcursor.c
@@ -123,14 +123,18 @@ static bool xdpy_set_mouse_cursor(ALLEGRO_DISPLAY *display,
    Display *xdisplay = system->x11display;
    Window xwindow = glx->window;
 
+   _al_mutex_lock(&system->lock);
+   if (glx->is_system_cursor && glx->current_cursor) {
+      XFreeCursor(xdisplay, glx->current_cursor);
+   }
+
    glx->current_cursor = xcursor->cursor;
    glx->is_system_cursor = false;
 
    if (!glx->cursor_hidden) {
-      _al_mutex_lock(&system->lock);
       XDefineCursor(xdisplay, xwindow, glx->current_cursor);
-      _al_mutex_unlock(&system->lock);
    }
+   _al_mutex_unlock(&system->lock);
 
    return true;
 }

--- a/src/x/xcursor.c
+++ b/src/x/xcursor.c
@@ -102,6 +102,7 @@ void _al_xwin_destroy_mouse_cursor(ALLEGRO_MOUSE_CURSOR *cursor)
          if (!glx->cursor_hidden)
             XUndefineCursor(sysx->x11display, glx->window);
          glx->current_cursor = None;
+         glx->is_system_cursor = true;
       }
    }
 
@@ -123,6 +124,7 @@ static bool xdpy_set_mouse_cursor(ALLEGRO_DISPLAY *display,
    Window xwindow = glx->window;
 
    glx->current_cursor = xcursor->cursor;
+   glx->is_system_cursor = false;
 
    if (!glx->cursor_hidden) {
       _al_mutex_lock(&system->lock);
@@ -204,8 +206,11 @@ static bool xdpy_set_system_mouse_cursor(ALLEGRO_DISPLAY *display,
 
    _al_mutex_lock(&system->lock);
 
+   if (glx->is_system_cursor && glx->current_cursor) {
+      XFreeCursor(xdisplay, glx->current_cursor);
+   }
    glx->current_cursor = XCreateFontCursor(xdisplay, cursor_shape);
-   /* XXX: leak? */
+   glx->is_system_cursor = true;
 
    if (!glx->cursor_hidden) {
       XDefineCursor(xdisplay, xwindow, glx->current_cursor);

--- a/src/x/xdisplay.c
+++ b/src/x/xdisplay.c
@@ -532,6 +532,7 @@ static ALLEGRO_DISPLAY_XGLX *xdpy_create_display_locked(
 
    d->invisible_cursor = None; /* Will be created on demand. */
    d->current_cursor = None; /* Initially, we use the root cursor. */
+   d->is_system_cursor = true;
    d->cursor_hidden = false;
 
    d->icon = None;


### PR DESCRIPTION
Currently, Allegro does not delete the system cursor when a new one is created in X11.

This fix frees the system cursor whenever a new cursor is set by keeping track of whether the current cursor is a system cursor or a user set one.

See [here](https://canary.discord.com/channels/993415281244393504/1060574341584125982/1319443549993046078) for more information about this.