### PR TITLE
Fixed reinitialization of the window resize event thread

### DIFF
--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -1046,6 +1046,8 @@ int _al_win_init_window(void)
 
    resize_event_thread_mutex = al_create_mutex();
    _al_vector_init(&resizing_displays, sizeof(ALLEGRO_DISPLAY_WIN *));
+   end_resize_event_thread = false;
+   resize_event_thread_ended = false;
    _beginthread(resize_event_thread_proc, 0, 0);
 
    return true;


### PR DESCRIPTION
This merge fixes a problem that occurs when initializing and running allegro multiple times in the same application session on Windows, i.e. during unit testing.

Vars end_resize_event_thread and resize_event_thread_ended were uninitialized in _al_win_init_window(). This prevented the resize event thread from running a second time because (end_resize_event_thread == true) as soon as it began.