### PR TITLE
Handle DSERR_NODRIVER when reporting error in DirectSound driver

### DIFF
--- a/addons/audio/dsound.cpp
+++ b/addons/audio/dsound.cpp
@@ -123,6 +123,9 @@ static char *ds_get_error(HRESULT hr)
       case DSERR_NOAGGREGATION:
          strcpy(ds_err_str, "DSERR_NOAGGREGATION");
          break;
+      case DSERR_NODRIVER:
+         strcpy(ds_err_str, "DSERR_NODRIVER");
+         break;
       case DSERR_OUTOFMEMORY:
          strcpy(ds_err_str, "DSERR_OUTOFMEMORY");
          break;


### PR DESCRIPTION
Hey. It looks that `DSERR_NODRIVER` DirectSound error is not reported in corresponding driver. This tiny PR fixes that.