### PR TITLE
Fix a race between detaching instances from mixers and reading from them.

### DIFF
--- a/addons/audio/kcm_instance.c
+++ b/addons/audio/kcm_instance.c
@@ -124,23 +124,20 @@ void _al_kcm_detach_from_parent(ALLEGRO_SAMPLE_INSTANCE *spl)
    mixer = spl->parent.u.mixer;
 
    /* Search through the streams and check for this one */
+   maybe_lock_mutex(mixer->ss.mutex);
    for (i = _al_vector_size(&mixer->streams) - 1; i >= 0; i--) {
       ALLEGRO_SAMPLE_INSTANCE **slot = _al_vector_ref(&mixer->streams, i);
 
       if (*slot == spl) {
-         maybe_lock_mutex(mixer->ss.mutex);
-
          _al_vector_delete_at(&mixer->streams, i);
          spl->parent.u.mixer = NULL;
          _al_kcm_stream_set_mutex(spl, NULL);
 
          spl->spl_read = NULL;
-
-         maybe_unlock_mutex(mixer->ss.mutex);
-
          break;
       }
    }
+   maybe_unlock_mutex(mixer->ss.mutex);
 
    al_free(spl->matrix);
    spl->matrix = NULL;


### PR DESCRIPTION
Previously it was possible for the vector size to decrease/increase unpredictably, causing random wrong slots to be deleted instead of the intended one, which sometimes would leave detached instances in the vector.