### PR TITLE
Remove GETTER/SETTER from generated docs

### DIFF
--- a/docs/scripts/make_protos.c
+++ b/docs/scripts/make_protos.c
@@ -32,6 +32,10 @@ int main(int argc, char *argv[])
          do_print = false;
          continue;
       }
+      if (d_match(line, "^(GETTER|SETTER)")) {
+         do_print = false;
+         continue;
+      }
       /* Prototype ends on blank line. */
       /* TODO: Should the above regexp match it? If so it doesn't here... */
       if (line[0] == 0) {


### PR DESCRIPTION
This patch ends prototype scanning during doc generation when a line starts with GETTER or SETTER. This shows up for example here: https://liballeg.org/a5docs/trunk/state.html#al_get_errno