### PR TITLE
Fix sig 11 crash on macOS when using a Japanese (or possibly other CJK type) keyboard

### DIFF
--- a/src/macosx/keybd.m
+++ b/src/macosx/keybd.m
@@ -277,6 +277,14 @@ void _al_osx_keyboard_handler(int pressed, NSEvent *event, ALLEGRO_DISPLAY* dpy)
          /* https://stackoverflow.com/a/22677690 */
          TISInputSourceRef keyboard_input = TISCopyCurrentKeyboardInputSource();
          CFDataRef layout_data = TISGetInputSourceProperty(keyboard_input, kTISPropertyUnicodeKeyLayoutData);
+         /* https://github.com/microsoft/vscode/issues/23833 */
+         if (!layout_data) {
+            /* TISGetInputSourceProperty returns null with a Japanese keyboard layout.
+             * Using TISCopyCurrentKeyboardLayoutInputSource to fix the NULL return.
+             */
+            keyboard_input = TISCopyCurrentKeyboardLayoutInputSource();
+            layout_data = TISGetInputSourceProperty(keyboard_input, kTISPropertyUnicodeKeyLayoutData);
+         }
          const UCKeyboardLayout *layout = (const UCKeyboardLayout *)CFDataGetBytePtr(layout_data);
 
          CGEventFlags modifier_flags = [event modifierFlags];


### PR DESCRIPTION
Greetings,

I recently attempted to bathe in the nostalgia that is gameflorist/dunedynasty and immediately encountered a signal 11 crash. At first I assumed the problem was dunedynasty, but enough messing about with lldb showed me that it was actually liballegro5 that was crashing. Enough debugging with a -pg build showed me:

frame #2: 0x00000001050cb36c
               liballegro.5.2.10.dylib`_al_osx_keyboard_handler(pressed=<unavailable>,
               event=0x000060000390c300, dpy=0x0000000125832200) at keybd.m:280:69 [opt]

Digging a bit further I found that this is actually a fairly common problem; if you use a CJK type layout (Chinese, Japanese, or Korean) you can trigger it fairly easily. Discussions with suggested code fixes can be seen in places like:

https://github.com/microsoft/node-native-keymap/blob/main/src/keyboard_mac.mm
https://github.com/microsoft/vscode/issues/23833

This PR fixes the issue with relatively the same method. The ~~spice~~ code must flow. 

Cheers