### PR TITLE
Fix #1618: ALLEGRO_FULLSCREEN_WINDOW not working with al_set_display_…

### DIFF
--- a/src/x/xdisplay.c
+++ b/src/x/xdisplay.c
@@ -1388,7 +1388,10 @@ static void xdpy_set_fullscreen_window_default(ALLEGRO_DISPLAY *display, bool on
       _al_mutex_lock(&system->lock);
 
       _al_xwin_reset_size_hints(display);
-      _al_xwin_set_fullscreen_window(display, 2);
+      /* Pass the correct value instead of always toggling:
+       * 0 = disable fullscreen, 1 = enable fullscreen
+       */
+      _al_xwin_set_fullscreen_window(display, onoff ? 1 : 0);
       /* XXX Technically, the user may fiddle with the _NET_WM_STATE_FULLSCREEN
        * property outside of Allegro so this flag may not be in sync with
        * reality.


### PR DESCRIPTION
…flag() on Linux

The issue was in xdpy_set_fullscreen_window_default() function which was always calling _al_xwin_set_fullscreen_window() with value 2 (toggle mode) instead of passing the correct value based on the onoff parameter.

Changed the call to pass:
- 1 when enabling fullscreen window mode (onoff=true)
- 0 when disabling fullscreen window mode (onoff=false)

This matches the behavior of the GTK implementation and the expected X11 _NET_WM_STATE protocol where:
- 0 = remove property
- 1 = add property
- 2 = toggle property

The toggle mode (2) was unreliable because it depended on the current state being synchronized, but the comment even mentions that this flag may not be in sync with reality.