### PR TITLE
Restore previous GL_UNPACK_ROW_LENGTH

### DIFF
--- a/src/opengl/ogl_lock.c
+++ b/src/opengl/ogl_lock.c
@@ -670,6 +670,9 @@ static void ogl_unlock_region_nonbb_nonfbo(ALLEGRO_BITMAP *bitmap,
    unsigned char *start_ptr;
    GLenum e;
 
+   int previous_unpack_row_length = 0;
+   glGetIntegerv(GL_UNPACK_ROW_LENGTH, &previous_unpack_row_length);
+
    if (bitmap->lock_flags & ALLEGRO_LOCK_WRITEONLY) {
       ALLEGRO_DEBUG("Unlocking non-backbuffer non-FBO WRITEONLY\n");
       start_ptr = ogl_bitmap->lock_buffer;
@@ -689,7 +692,7 @@ static void ogl_unlock_region_nonbb_nonfbo(ALLEGRO_BITMAP *bitmap,
       start_ptr);
 
    if (!(bitmap->lock_flags & ALLEGRO_LOCK_WRITEONLY)) {
-      glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+      glPixelStorei(GL_UNPACK_ROW_LENGTH, previous_unpack_row_length);
    }
 
    e = glGetError();


### PR DESCRIPTION
The first commit here is the actual change. It is possible that the original client GL_UNPACK_ROW_LENGTH might not be 0, so it is set back to the previous unpack value instead. 
The second commit is an attempt at adding a helper function to try to clarify the intent of the reverts. Please let me know if this is not in the preferred style.

I hope this is useful, but I have not worked with opengl or allegro code before, so feel free to decline this.