### PR TITLE
Add u/v coordinates to high level primitives, excluding ribbons and splines

### DIFF
--- a/addons/primitives/high_primitives.c
+++ b/addons/primitives/high_primitives.c
@@ -331,8 +331,8 @@ void al_draw_filled_triangle(float x1, float y1, float x2, float y2,
 {
    ALLEGRO_VERTEX vtx[3];
 
-   float min_x = min(x1, min(x2, x3));
-   float min_y = min(y1, min(y2, y3));
+   float min_x = fmin(x1, fmin(x2, x3));
+   float min_y = fmin(y1, fmin(y2, y3));
 
    vtx[0].x = x1; vtx[0].y = y1; vtx[0].u = x1 - min_x; vtx[0].v = y1 - min_y;
    vtx[1].x = x2; vtx[1].y = y2; vtx[1].u = x2 - min_x; vtx[1].v = y2 - min_y;


### PR DESCRIPTION
The U/V coordinates utilize the prim's local coordinates, though (0,0) varies depending on the shape.
- For shapes such as rectangles and triangles, (0,0) is the top left of the circumscribed rectangle. For non filled primitives, this does not offset the u/v by the thickness value. This was done to preserve alignment when drawing a filled rectangle and non filled rectangle in the same location.
- For ellipses, circles, and pie slices, (0,0) is the center of the primitive.
- For lines, (0,0) is the top left, though treated like a rotated rectangle.

The following image shows how the u/v coordinates appear (note that the shader scales the coordinates down to 0-1 for visibility):
- Top row: `al_draw_rectangle`, `al_draw_filled_rectangle`, `al_draw_filled_pieslice`
- Middle row: `al_draw_line` (0 and non zero thickness), `al_draw_triangle` (0 and non zero thickness), `al_draw_filled_triangle`, `al_draw_pieslice` (0 and nonzero thickness)
- Bottom row: `al_draw_filled_ellipse`, `al_draw_ellipse`, `al_draw_rounded_rectangle`, `al_draw_filled_rounded_rectangle`

<img width="1000" height="678" alt="image" src="https://github.com/user-attachments/assets/e9ca56fb-ca07-4582-a861-1534e2a65b5a" />

This impacts #1676 , though ribbons and splines still need to be implemented before closing.
