### PR TITLE
Sort the usages for MacOS gamepads.

### DIFF
--- a/include/allegro5/joystick.h
+++ b/include/allegro5/joystick.h
@@ -24,7 +24,7 @@
 #endif
 
 /* internal values */
-#define _AL_MAX_JOYSTICK_AXES      5
+#define _AL_MAX_JOYSTICK_AXES      6
 #define _AL_MAX_JOYSTICK_STICKS    16
 #ifdef ALLEGRO_ANDROID
 #define _AL_MAX_JOYSTICK_BUTTONS   36

--- a/python/generate_python_ctypes.py
+++ b/python/generate_python_ctypes.py
@@ -295,8 +295,8 @@ class Allegro:
                     n = 0
                     ftype = mob.group(1)
                     if ftype.startswith("struct"):
-                        if ftype == "struct {float axis[5];}":
-                            t = "c_float * 5"
+                        if ftype == "struct {float axis[6];}":
+                            t = "c_float * 6"
                         else:
                             print("Error: Can't parse " + ftype + " yet.")
                             t = None


### PR DESCRIPTION
The ideas is taken from GLFW, which does the same thing in a slightly different way.

Fixes #1663