### PR TITLE
Fix undefined behavior caused by returning uninitialized D3D_STATE

### DIFF
--- a/src/win/d3d_disp.cpp
+++ b/src/win/d3d_disp.cpp
@@ -3036,7 +3036,7 @@ struct D3D_STATE
 
 static D3D_STATE setup_state(LPDIRECT3DDEVICE9 device, const ALLEGRO_VERTEX_DECL* decl, ALLEGRO_BITMAP* texture, ALLEGRO_DISPLAY *disp)
 {
-   D3D_STATE state;
+   D3D_STATE state = {0};
    ALLEGRO_DISPLAY_D3D *d3d_disp = (ALLEGRO_DISPLAY_D3D *)disp;
 
    if (!(disp->flags & ALLEGRO_PROGRAMMABLE_PIPELINE) && !use_fixed_pipeline)


### PR DESCRIPTION
Debug build with MSVC 2026 triggered an error dialog on first call to al_draw_filled_rectangle: "Run-Time Check Failure #3 - The variable 'state' is being used without being initialized.". Returning an uninitialized variable technically is UB.