### PR TITLE
[osx] Fix possible corruption when joystick connects early

### DIFF
--- a/src/macosx/hidjoy.m
+++ b/src/macosx/hidjoy.m
@@ -811,6 +811,8 @@ static bool init_joystick(void)
    CFRelease(criteria1);
    CFRelease(criteria);
 
+   _al_vector_init(&joysticks, sizeof(ALLEGRO_JOYSTICK_OSX *));
+
    /* Register for plug/unplug notifications */
    IOHIDManagerRegisterDeviceMatchingCallback(
       hidManagerRef,
@@ -835,8 +837,6 @@ static bool init_joystick(void)
       CFRunLoopGetMain(),
       kCFRunLoopDefaultMode
    );
-
-   _al_vector_init(&joysticks, sizeof(ALLEGRO_JOYSTICK_OSX *));
 
    al_lock_mutex(add_mutex);
 


### PR DESCRIPTION
Prevents this ASSERT from being hit:

```
Assertion failed: (vec->_itemsize > 0), function _al_vector_alloc_back, file vector.c, line 174.

__pthread_kill (@__pthread_kill:6)
pthread_kill (@pthread_kill:65)
abort (@abort:39)
__assert_rtn (@err:3)
_al_vector_alloc_back (/Users/connorclark/code/allegro5/src/misc/vector.c:174)
find_or_insert_joystick (/Users/connorclark/code/allegro5/src/macosx/hidjoy.m:176)
add_joystick_device (/Users/connorclark/code/allegro5/src/macosx/hidjoy.m:513)
device_add_callback (/Users/connorclark/code/allegro5/src/macosx/hidjoy.m:619)
__IOHIDManagerDeviceApplier (@__IOHIDManagerDeviceApplier:203)
__CFSetApplyFunction_block_invoke (@__CFSetApplyFunction_block_invoke:9)
CFBasicHashApply (@CFBasicHashApply:36)
CFSetApplyFunction (@CFSetApplyFunction:47)
__IOHIDManagerInitialEnumCallback (@__IOHIDManagerInitialEnumCallback:29)
...
```

(commit body)

> device_add_callback could fire before the joysticks vector is initialized if the controller is already enabled and connects instantly.

As far as I can tell, this bug has been present for 15+ years.