### PR TITLE
prefer _fseeki64 and _ftelli64 if available

### DIFF
--- a/src/file_stdio.c
+++ b/src/file_stdio.c
@@ -219,10 +219,10 @@ static int64_t file_stdio_ftell(ALLEGRO_FILE *f)
    USERDATA *userdata = get_userdata(f);
    int64_t ret;
 
-#if defined(ALLEGRO_HAVE_FTELLO)
-   ret = ftello(userdata->fp);
-#elif defined(ALLEGRO_HAVE_FTELLI64)
+#if defined(ALLEGRO_HAVE_FTELLI64)
    ret = _ftelli64(userdata->fp);
+#elif defined(ALLEGRO_HAVE_FTELLO)
+   ret = ftello(userdata->fp);
 #else
    ret = ftell(userdata->fp);
 #endif
@@ -247,10 +247,10 @@ static bool file_stdio_fseek(ALLEGRO_FILE *f, int64_t offset,
       case ALLEGRO_SEEK_END: whence = SEEK_END; break;
    }
 
-#if defined(ALLEGRO_HAVE_FSEEKO)
-   rc = fseeko(userdata->fp, offset, whence);
-#elif defined(ALLEGRO_HAVE_FSEEKI64)
+#if defined(ALLEGRO_HAVE_FSEEKI64)
    rc = _fseeki64(userdata->fp, offset, whence);
+#elif defined(ALLEGRO_HAVE_FSEEKO)
+   rc = fseeko(userdata->fp, offset, whence);
 #else
    rc = fseek(userdata->fp, offset, whence);
 #endif


### PR DESCRIPTION
For mingw32 builds using fseeko gives an "Invalid argument" error due to conflicting definitions of off_t.
fixes: #1702 