### PR TITLE
Prevent buffer overflow in _al_bvcformata

### DIFF
--- a/src/misc/bstrlib.c
+++ b/src/misc/bstrlib.c
@@ -2946,6 +2946,7 @@ int n, r, l;
    if (_AL_BSTR_OK != _al_balloc (b, n + 2)) return _AL_BSTR_ERR;
 
    exvsnprintf (r, (char *) b->data + b->slen, count + 2, fmt, arg);
+   ((char*)b->data)[b->slen + count + 1] = '\0';
 
    /* Did the operation complete successfully within bounds? */
 


### PR DESCRIPTION
On Windows + ASAN, I got a report of a buffer overflow from this call to `al_ustr_newf`:

```
HRESULT _al_create_default_primitives_hlsl_vertex_shader(LPDIRECT3DDEVICE9 device, LPD3DXEFFECT *shader)
{
   ALLEGRO_USTR *full_source = al_ustr_newf("%s\n%s",
   _al_get_default_hlsl_vertex_shader(), technique_source_vertex_v2);
   LPD3DXBUFFER errors;
```

The cause was a missing null-terminator + usage of strlen in `_al_bvcformata`. With DEBUGMODE set, this string is grown one byte at a time (which is probably needed to repro). All other usages of `exvsnprintf` in this file set a null terminator after calling it, except for this one.

Gemini helped me diagnose this: https://gemini.google.com/share/ac2168d6f6ad