### PR TITLE
Fix static compile error in macos 11.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ if(MACOSX)
     # problems with global variables which are not explicitly initialised.
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-common")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-common")
+    set(CMAKE_EXE_LINKER_FLAGS "-framework AudioToolbox -framework CoreAudio")
 endif(MACOSX)
 
 if(IPHONE)


### PR DESCRIPTION
`cmake ../ -DCMAKE_BUILD_TYPE=Release -DSHARED=0`

>cmake compile error [ 28%] Linking C executable ex_acodec Undefined symbols for architecture x86_64: "_AudioObjectGetPropertyData", referenced from: __aqueue_open in liballegro_audio-static.a(aqueue.m.o) "_AudioObjectGetPropertyDataSize", referenced from: __aqueue_open in liballegro_audio-static.a(aqueue.m.o) ld: symbol(s) not found for architecture x86_64 clang: error: linker command failed with exit code 1 (use -v to see invocation)