### PR TITLE
[SDL] Add unichar assignment for extra key character events

### DIFF
--- a/src/sdl/sdl_keyboard.c
+++ b/src/sdl/sdl_keyboard.c
@@ -100,6 +100,7 @@ void _al_sdl_keyboard_event(SDL_Event *e)
 
       if (keyboard->create_extra_char[e->key.keysym.scancode]) {
          event.keyboard.type = ALLEGRO_EVENT_KEY_CHAR;
+         event.keyboard.unichar = keyboard->unicode[e->key.keysym.scancode];
          _al_event_source_emit_event(es, &event);
       }
    }


### PR DESCRIPTION
I noticed that on the SDL backend, holding Backspace would randomly insert the last key I pressed. The reason is that the `ALLEGRO_EVENT event` local var is not fully initialized, and this particular code path doesn't set `event.keyboard.unichar` - so the event's state is a bit random.