### PR TITLE
Accept (0, 0) with ALLEGRO_FULLSCREEN_WINDOW on X11 and macOS

### DIFF
--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -1534,6 +1534,21 @@ static ALLEGRO_DISPLAY* create_display_win(int w, int h) {
     * window can be created.
     */
    if (al_get_new_display_flags() & ALLEGRO_FULLSCREEN_WINDOW) {
+      /* FULLSCREEN_WINDOW ignores the passed size (see al_create_display
+       * docs); substitute the target adapter's desktop size so callers may
+       * pass (0, 0) and so the temporary view below is created at a sane
+       * extent.
+       */
+      if (w <= 0 || h <= 0) {
+         ALLEGRO_MONITOR_INFO mi;
+         int adapter = al_get_new_display_adapter();
+         if (adapter < 0)
+            adapter = 0;
+         if (al_get_monitor_info(adapter, &mi)) {
+            w = mi.x2 - mi.x1;
+            h = mi.y2 - mi.y1;
+         }
+      }
       __block BOOL ok;
       dispatch_sync(dispatch_get_main_queue(), ^{
          NSRect rc = NSMakeRect(0, 0, w,  h);

--- a/src/x/xdisplay.c
+++ b/src/x/xdisplay.c
@@ -634,11 +634,12 @@ static ALLEGRO_DISPLAY *xdpy_create_display(int w, int h)
       if (_al_xglx_get_monitor_info(system, a, &mi)) {
          w = mi.x2 - mi.x1;
          h = mi.y2 - mi.y1;
+         ALLEGRO_DEBUG("FULLSCREEN_WINDOW: using desktop size %dx%d from adapter %d\n", w, h, a);
       }
    }
 
    if (w <= 0 || h <= 0) {
-      ALLEGRO_ERROR("Invalid window size %dx%d\n", w, h);
+      ALLEGRO_ERROR("Failed to determine a reasonable window size, got: %dx%d\n", w, h);
       return NULL;
    }
 

--- a/src/x/xdisplay.c
+++ b/src/x/xdisplay.c
@@ -610,11 +610,6 @@ static ALLEGRO_DISPLAY *xdpy_create_display(int w, int h)
       return NULL;
    }
 
-   if (w <= 0 || h <= 0) {
-      ALLEGRO_ERROR("Invalid window size %dx%d\n", w, h);
-      return NULL;
-   }
-
    flags = al_get_new_display_flags();
    if (flags & ALLEGRO_GTK_TOPLEVEL_INTERNAL) {
       if (gtk_override_vt == NULL) {
@@ -627,9 +622,28 @@ static ALLEGRO_DISPLAY *xdpy_create_display(int w, int h)
       }
    }
 
+   adapter = al_get_new_display_adapter();
+
+   /* FULLSCREEN_WINDOW ignores the passed size (see al_create_display docs);
+    * substitute the desktop size of the target adapter so this path matches
+    * the wgl/d3d behaviour and (0, 0) is accepted as a "use desktop" request.
+    */
+   if ((w <= 0 || h <= 0) && (flags & ALLEGRO_FULLSCREEN_WINDOW)) {
+      ALLEGRO_MONITOR_INFO mi;
+      int a = (adapter < 0) ? _al_xglx_get_default_adapter(system) : adapter;
+      if (_al_xglx_get_monitor_info(system, a, &mi)) {
+         w = mi.x2 - mi.x1;
+         h = mi.y2 - mi.y1;
+      }
+   }
+
+   if (w <= 0 || h <= 0) {
+      ALLEGRO_ERROR("Invalid window size %dx%d\n", w, h);
+      return NULL;
+   }
+
    _al_mutex_lock(&system->lock);
 
-   adapter = al_get_new_display_adapter();
    display = xdpy_create_display_locked(system, flags, w, h, adapter);
 
    _al_mutex_unlock(&system->lock);


### PR DESCRIPTION
## Summary

`al_create_display` documents that under `ALLEGRO_FULLSCREEN_WINDOW` the passed
width and height are ignored initially and the display is sized to the
desktop. The Windows (wgl + d3d) backends already implement this by
substituting the target monitor's size during creation, so `(0, 0)` is a
valid "use the desktop size" request on Windows. The X11 and macOS
backends did not, so the documented contract was not delivered on those
platforms.

This change brings X11 and macOS in line:

- **X11 (`src/x/xdisplay.c`)**: `xdpy_create_display` rejected any `w <= 0
  || h <= 0` outright before it ever looked at the display flags. Resolve
  the target adapter's desktop dimensions via `_al_xglx_get_monitor_info`
  when `FULLSCREEN_WINDOW` is set and the caller passed a non-positive
  size; fall through to the existing `Invalid window size` error in all
  other cases.
- **macOS (`src/macosx/osxgl.m`)**: `create_display_win` built the
  temporary `NSWindow`/`ALOpenGLView` at the passed `(w, h)` — a 0-sized
  rect when callers relied on the documented contract — before later
  overwriting `display->w/h` with the screen size. Resolve the desktop
  size up front via `al_get_monitor_info` inside the existing
  `FULLSCREEN_WINDOW` branch.

Android (surface-driven sizing via JNI `onChange`) and the SDL backend
(`SDL_WINDOW_FULLSCREEN_DESKTOP`) already accept `(0, 0)` natively; no
changes needed.

Behaviour for non-zero sizes and for other flag combinations is
unchanged. The X11 `Invalid window size` error path still fires for plain
windowed/fullscreen requests with a non-positive size.

## Test plan

- [x] Builds cleanly on Linux/X11 (CMake + Ninja, Release): single
  rebuild of `liballegro.so.5.2.12`, no new warnings on `xdisplay.c.o`.
- [ ] Manual: `al_set_new_display_flags(ALLEGRO_FULLSCREEN_WINDOW);
  al_create_display(0, 0);` returns a display sized to the primary
  monitor on X11 (verified locally) and on macOS (needs reviewer
  verification — I don't have a macOS machine).
- [ ] Manual: `al_create_display(0, 0)` without `FULLSCREEN_WINDOW`
  continues to return `NULL` and log `Invalid window size 0x0` on X11.
- [ ] CI passes on the existing matrix.

## Notes for reviewers

- macOS `create_display_win` already substitutes the screen frame size
  into `display->w/h` after window creation (line 1704 in the
  pre-existing code). This change does the substitution earlier so the
  *initial* `NSRect` passed to `NSWindow initWithContentRect:` is also
  sane, which matters because `MINIMUM_WIDTH`/`MINIMUM_HEIGHT` clamping
  and the FULLSCREEN_WINDOW capability check via `ALOpenGLView` both
  occur on the original rect.
- The X11 `_al_xglx_get_monitor_info` / `_al_xglx_get_default_adapter`
  calls are made outside `system->lock`, which matches existing
  precedent: `xglx_get_monitor_info` and `xglx_get_num_video_adapters`
  in `src/x/xsystem.c` also call these helpers lock-free.
- No public API change, no header changes, no behavior change for
  existing well-formed callers.