### PR TITLE
Add audio recorder getters

### DIFF
--- a/addons/audio/allegro5/allegro_audio.h
+++ b/addons/audio/allegro5/allegro_audio.h
@@ -432,6 +432,11 @@ ALLEGRO_KCM_AUDIO_FUNC(bool, al_is_audio_recorder_recording, (ALLEGRO_AUDIO_RECO
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_EVENT_SOURCE *, al_get_audio_recorder_event_source,
    (ALLEGRO_AUDIO_RECORDER *r));
 ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_RECORDER_EVENT *, al_get_audio_recorder_event, (ALLEGRO_EVENT *event));
+ALLEGRO_KCM_AUDIO_FUNC(unsigned int, al_get_audio_recorder_frequency, (const ALLEGRO_AUDIO_RECORDER *r));
+ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_AUDIO_DEPTH, al_get_audio_recorder_depth, (const ALLEGRO_AUDIO_RECORDER *r));
+ALLEGRO_KCM_AUDIO_FUNC(ALLEGRO_CHANNEL_CONF, al_get_audio_recorder_channels, (const ALLEGRO_AUDIO_RECORDER *r));
+ALLEGRO_KCM_AUDIO_FUNC(unsigned int, al_get_audio_recorder_fragment_count, (const ALLEGRO_AUDIO_RECORDER *r));
+ALLEGRO_KCM_AUDIO_FUNC(unsigned int, al_get_audio_recorder_samples, (const ALLEGRO_AUDIO_RECORDER *r));
 ALLEGRO_KCM_AUDIO_FUNC(void, al_destroy_audio_recorder, (ALLEGRO_AUDIO_RECORDER *r));
 
 #endif

--- a/addons/audio/recorder.c
+++ b/addons/audio/recorder.c
@@ -138,6 +138,46 @@ ALLEGRO_EVENT_SOURCE *al_get_audio_recorder_event_source(ALLEGRO_AUDIO_RECORDER 
    return &r->source;
 }
 
+/* Function: al_get_audio_recorder_frequency
+ */
+unsigned int al_get_audio_recorder_frequency(const ALLEGRO_AUDIO_RECORDER *r)
+{
+   ASSERT(r);
+   return r->frequency;
+}
+
+/* Function: al_get_audio_recorder_depth
+ */
+ALLEGRO_AUDIO_DEPTH al_get_audio_recorder_depth(const ALLEGRO_AUDIO_RECORDER *r)
+{
+   ASSERT(r);
+   return r->depth;
+}
+
+/* Function: al_get_audio_recorder_channels
+ */
+ALLEGRO_CHANNEL_CONF al_get_audio_recorder_channels(const ALLEGRO_AUDIO_RECORDER *r)
+{
+   ASSERT(r);
+   return r->chan_conf;
+}
+
+/* Function: al_get_audio_recorder_fragment_count
+ */
+unsigned int al_get_audio_recorder_fragment_count(const ALLEGRO_AUDIO_RECORDER *r)
+{
+   ASSERT(r);
+   return r->fragment_count;
+}
+
+/* Function: al_get_audio_recorder_samples
+ */
+unsigned int al_get_audio_recorder_samples(const ALLEGRO_AUDIO_RECORDER *r)
+{
+   ASSERT(r);
+   return r->samples;
+}
+
 /* Function: al_destroy_audio_recorder
  */
 void al_destroy_audio_recorder(ALLEGRO_AUDIO_RECORDER *r)

--- a/docs/src/refman/audio.txt
+++ b/docs/src/refman/audio.txt
@@ -1373,6 +1373,54 @@ Since: 5.1.1
 
 > *[Unstable API]:* The API may need a slight redesign.
 
+### API: al_get_audio_recorder_frequency
+
+Return the audio recorder frequency (in Hz), as passed to
+[al_create_audio_recorder].
+
+Since: 5.2.12
+
+> *[Unstable API]:* The API may need a slight redesign.
+
+### API: al_get_audio_recorder_depth
+
+Return the audio recorder depth, as passed to [al_create_audio_recorder].
+
+See also: [ALLEGRO_AUDIO_DEPTH].
+
+Since: 5.2.12
+
+> *[Unstable API]:* The API may need a slight redesign.
+
+### API: al_get_audio_recorder_channels
+
+Return the audio recorder channel configuration, as passed to
+[al_create_audio_recorder].
+
+See also: [ALLEGRO_CHANNEL_CONF].
+
+Since: 5.2.12
+
+> *[Unstable API]:* The API may need a slight redesign.
+
+### API: al_get_audio_recorder_fragment_count
+
+Return the number of fragment buffers used by the audio recorder, as passed
+to [al_create_audio_recorder].
+
+Since: 5.2.12
+
+> *[Unstable API]:* The API may need a slight redesign.
+
+### API: al_get_audio_recorder_samples
+
+Return the number of samples per fragment used by the audio recorder, as
+passed to [al_create_audio_recorder].
+
+Since: 5.2.12
+
+> *[Unstable API]:* The API may need a slight redesign.
+
 ### API: al_destroy_audio_recorder
 
 Destroys the audio recorder and frees all resources associated with it. It


### PR DESCRIPTION
## Summary

`ALLEGRO_AUDIO_RECORDER` is the only audio creator object in the
`allegro_audio` addon without post-creation getters. Every peer object
exposes its full configured state:

| Type | Frequency | Depth | Channels | Buffer |
|---|---|---|---|---|
| `ALLEGRO_SAMPLE` | ✅ `al_get_sample_frequency` | ✅ | ✅ | ✅ `_length` |
| `ALLEGRO_SAMPLE_INSTANCE` | ✅ | ✅ | ✅ | ✅ |
| `ALLEGRO_AUDIO_STREAM` | ✅ | ✅ | ✅ | ✅ `_fragments` |
| `ALLEGRO_MIXER` | ✅ | ✅ | ✅ | — |
| `ALLEGRO_VOICE` | ✅ | ✅ | ✅ | — |
| `ALLEGRO_AUDIO_RECORDER` | ❌ | ❌ | ❌ | ❌ |

The reference example `examples/ex_record.c` lives with the gap by
hardcoding the recorder parameters as module-level constants
(`frequency`, `audio_depth`, `samples_per_fragment` at file scope) and
referring back to those constants when sizing the WAV header and the
playback stream that mirrors the recorder. Application code following
that pattern has the same workaround.

This change adds:

- `al_get_audio_recorder_frequency`
- `al_get_audio_recorder_depth`
- `al_get_audio_recorder_channels`
- `al_get_audio_recorder_fragment_count`
- `al_get_audio_recorder_samples`

Each is a one-line accessor over a field the internal struct already
stores (see `addons/audio/allegro5/internal/aintern_audio.h`). No
behavioural change; the getters return the values the caller passed to
`al_create_audio_recorder`. Doc entries follow the same terse style as
the mixer/stream getters in the existing reference manual, and each new
function carries the existing `[Unstable API]` marker that the rest of
the recorder API has — this PR doesn't tighten or relax that marker.

## Test plan

- [x] `liballegro_audio.so.5.2.12` builds cleanly on Linux (CMake +
  Ninja, Release), with no new warnings on `recorder.c.o`.
- [x] `nm -D` confirms the five new symbols are exported.
- [ ] No new examples added (intentional — the existing `ex_record.c`
  demonstrates the use case and could be refactored to call the new
  getters in a separate change; this PR keeps the scope minimal).

## Notes for reviewers

- I did not touch `misc/liballegro_audio_abi.xml` since that file is
  regenerated from a built `.so` at release time (matches existing
  workflow visible in git history — `Prepare a summary of changes for
  5.2.x` commits).
- No `docs/src/changes-5.2.txt` entry: changelog is maintainer-curated
  at release time, same precedent.
- Choice of `unsigned int` for `frequency`, `fragment_count` and
  `samples` matches the types in `al_create_audio_recorder`'s
  signature and the corresponding fields on the internal struct.

## Motivation

Surfaced while integrating the recorder into a downstream voice-chat
pipeline (Opus encode at 48 kHz mono). The downstream code wanted to
assert at startup that the recorder's actual configuration matched what
its packet header expected. Without getters, that's only possible by
keeping a parallel copy of every value passed in. With these accessors,
the assertion becomes
`assert(al_get_audio_recorder_frequency(r) == 48000);`.