### PR TITLE
Fix encoding size description for pixel formats

### DIFF
--- a/docs/src/refman/graphics.txt
+++ b/docs/src/refman/graphics.txt
@@ -285,15 +285,15 @@ is typically impossible to create compressed memory bitmaps.
     with a pixel shader that maps indices to RGBA values.  Since 5.1.2.
 * ALLEGRO_PIXEL_FORMAT_COMPRESSED_RGBA_DXT1 -
     Compressed using the DXT1 compression algorithm. Each 4x4 pixel block is
-    encoded in 64 bytes, resulting in 6-8x compression ratio. Only a single bit
+    encoded in 64 bits (8 bytes), resulting in 6-8x compression ratio. Only a single bit
     of alpha per pixel is supported.  Since 5.1.9.
 * ALLEGRO_PIXEL_FORMAT_COMPRESSED_RGBA_DXT3 -
     Compressed using the DXT3 compression algorithm. Each 4x4 pixel block is
-    encoded in 128 bytes, resulting in 4x compression ratio. This format
+    encoded in 128 bits (16 bytes), resulting in 4x compression ratio. This format
     supports sharp alpha transitions.  Since 5.1.9.
 * ALLEGRO_PIXEL_FORMAT_COMPRESSED_RGBA_DXT5 -
     Compressed using the DXT5 compression algorithm. Each 4x4 pixel block is
-    encoded in 128 bytes, resulting in 4x compression ratio. This format
+    encoded in 128 bits (16 bytes), resulting in 4x compression ratio. This format
     supports smooth alpha transitions.  Since 5.1.9.
 
 See also: [al_set_new_bitmap_format], [al_get_bitmap_format]


### PR DESCRIPTION
Corrected the encoding size description for DXT1, DXT3, and DXT5 formats from bytes to bits.

See: https://developer.valvesoftware.com/wiki/DirectX_Texture_compression_5 https://en.wikipedia.org/wiki/S3_Texture_Compression