### PR TITLE
Windows: Ignore first mouse event when window activates

### DIFF
--- a/src/win/wwindow.c
+++ b/src/win/wwindow.c
@@ -858,6 +858,17 @@ static LRESULT CALLBACK window_callback(HWND hWnd, UINT message,
                break;
          }
          return 1;
+      case WM_MOUSEACTIVATE:
+         /* By default a click on an inactive window both activates it and
+          * gets delivered to the window. Eat client-area clicks so the
+          * click that refocuses the window doesn't register as a mouse
+          * press. This matches OS X, where -acceptsFirstMouse: defaults
+          * to NO. Non-client clicks (title bar, borders) keep the default
+          * behavior so dragging/resizing works on the activating click.
+          */
+         if (LOWORD(lParam) == HTCLIENT)
+            return MA_ACTIVATEANDEAT;
+         break;
       case WM_ACTIVATE:
          if (HIWORD(wParam) && LOWORD(wParam) != WA_INACTIVE)
             break;


### PR DESCRIPTION
When the window is not active, clicking on it resulted in a mouse event being sent to the application. This is generally undesirable behavior, and others backends (at least OSX) already ignore such events.

You can validate this with ex_mouse demo:

1. Move some other window to the foreground
2. Click on the mouse demo

Before this commit, it will respond to that first click. After, it does not.

Dragging the window from an unfocused state also still works.

This is a regression relative to Allegro 4's Windows backend.