### PR TITLE
[osx] Fix crash when resizing a window while drawing

### DIFF
--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -236,6 +236,12 @@ static bool resize_display_win_main_thread(ALLEGRO_DISPLAY *d, int w, int h);
 
 static void clear_to_black(NSOpenGLContext *context)
 {
+   /* Only the thread the context is current on may issue GL commands against
+    * it - anywhere else this would race with whatever that thread is drawing.
+    */
+   if ([NSOpenGLContext currentContext] != context)
+      return;
+
    /* Clear and flush (for double buffering) */
    glClearColor(0, 0, 0, 1);
    glClear(GL_COLOR_BUFFER_BIT);

--- a/src/macosx/osxgl.m
+++ b/src/macosx/osxgl.m
@@ -27,6 +27,7 @@
 #include "allegro5/platform/aintosx.h"
 #include "./osxgl.h"
 #include "allegro5/allegro_osx.h"
+#include <pthread.h>
 #ifndef ALLEGRO_MACOSX
 #error something is wrong with the makefile
 #endif
@@ -153,11 +154,82 @@ static const char *allegro_pixel_format_names[] = {
    "ALLEGRO_DISPLAY_OPTIONS_COUNT"
 };
 
+/* ALOpenGLContext:
+ * An NSOpenGLContext that never reallocates its drawable behind the back of
+ * the thread that is drawing with it.
+ *
+ * Whenever the view geometry changes - a window resize, a move to a screen
+ * with a different backing scale, and so on - AppKit sends -update to the
+ * context from the main thread. That reallocates the context's drawable, which
+ * is not safe to do while another thread is issuing GL commands against the
+ * same context. Allegro runs the user's code, and hence all of its drawing, on
+ * a separate thread, so resizing a window while the program is drawing
+ * corrupts the GL driver's internal state and crashes.
+ *
+ * The update cannot simply be moved to the drawing thread either: -update
+ * insists on running on the main thread whenever the context has a view. So
+ * instead the spontaneous updates only take note that an update is due, and
+ * osx_update_context() below hands the work back to the main thread at a point
+ * where the drawing thread is blocked waiting for it.
+ *
+ * SDL marshals the update to the main thread the same way - see
+ * -[SDLOpenGLContext explicitUpdate] in its src/video/cocoa/SDL_cocoaopengl.m.
+ */
+@interface ALOpenGLContext : NSOpenGLContext
+{
+   volatile int update_pending;
+}
+-(BOOL) updatePending;
+-(void) reallyUpdate;
+@end
+
+@implementation ALOpenGLContext
+
+-(void) update
+{
+   __atomic_store_n(&update_pending, 1, __ATOMIC_SEQ_CST);
+}
+
+-(BOOL) updatePending
+{
+   return __atomic_load_n(&update_pending, __ATOMIC_SEQ_CST) != 0;
+}
+
+/* Main thread only, and only while the drawing thread is not drawing. */
+-(void) reallyUpdate
+{
+   /* Cleared first so that an update requested while this one is running is
+    * not lost.
+    */
+   __atomic_store_n(&update_pending, 0, __ATOMIC_SEQ_CST);
+   [super update];
+}
+
+@end
+
+/* osx_update_context:
+ * Apply a deferred -update, blocking until the main thread has done it.
+ * Call from the display's own thread only, and only in between frames: no GL
+ * command may be in flight while the drawable is reallocated.
+ */
+static void osx_update_context(ALLEGRO_DISPLAY_OSX_WIN *dpy, bool force)
+{
+   ALOpenGLContext *ctx = (ALOpenGLContext *) dpy->ctx;
+
+   if (ctx == nil || (!force && ![ctx updatePending]))
+      return;
+
+   if (pthread_main_np())
+      [ctx reallyUpdate];
+   else
+      dispatch_sync(dispatch_get_main_queue(), ^{ [ctx reallyUpdate]; });
+}
+
 /* Module functions */
 ALLEGRO_DISPLAY_INTERFACE* _al_osx_get_display_driver(void);
 ALLEGRO_DISPLAY_INTERFACE* _al_osx_get_display_driver_win(void);
 ALLEGRO_DISPLAY_INTERFACE* _al_osx_get_display_driver_fs(void);
-static NSOpenGLContext* osx_create_shareable_context(NSOpenGLPixelFormat* fmt, unsigned int* group);
+static ALOpenGLContext* osx_create_shareable_context(NSOpenGLPixelFormat* fmt, unsigned int* group);
 static bool set_display_flag(ALLEGRO_DISPLAY *display, int flag, bool onoff);
 static bool resize_display_win(ALLEGRO_DISPLAY *d, int w, int h);
 static bool resize_display_win_main_thread(ALLEGRO_DISPLAY *d, int w, int h);
@@ -754,6 +826,7 @@ static bool set_current_display(ALLEGRO_DISPLAY* d) {
    ALLEGRO_DISPLAY_OSX_WIN* dpy = (ALLEGRO_DISPLAY_OSX_WIN*) d;
    if (dpy->ctx != nil) {
       [dpy->ctx makeCurrentContext];
+      osx_update_context(dpy, false);
    }
    _al_ogl_set_extensions(d->ogl_extras->extension_api);
    return true;
@@ -763,7 +836,7 @@ static bool set_current_display(ALLEGRO_DISPLAY* d) {
 static void setup_gl(ALLEGRO_DISPLAY *d)
 {
    ALLEGRO_DISPLAY_OSX_WIN* dpy = (ALLEGRO_DISPLAY_OSX_WIN*) d;
-   [dpy->ctx performSelectorOnMainThread:@selector(update) withObject:nil waitUntilDone:YES];
+   osx_update_context(dpy, true);
    _al_ogl_setup_gl(d);
 }
 
@@ -1083,16 +1156,16 @@ static void osx_run_fullscreen_display(ALLEGRO_DISPLAY_OSX_WIN* dpy)
  * Returns:
  *  The new context or nil if it cannot be created.
  */
-static NSOpenGLContext* osx_create_shareable_context(NSOpenGLPixelFormat* fmt, unsigned int* group)
+static ALOpenGLContext* osx_create_shareable_context(NSOpenGLPixelFormat* fmt, unsigned int* group)
 {
    // Iterate through all existing displays and try and find one that's compatible
    _AL_VECTOR* dpys = &al_get_system_driver()->displays;
    unsigned int i;
-   NSOpenGLContext* compat = nil;
+   ALOpenGLContext* compat = nil;
 
    for (i = 0; i < _al_vector_size(dpys); ++i) {
       ALLEGRO_DISPLAY_OSX_WIN* other = *(ALLEGRO_DISPLAY_OSX_WIN**) _al_vector_ref(dpys, i);
-      compat = [[NSOpenGLContext alloc] initWithFormat:fmt shareContext: other->ctx];
+      compat = [[ALOpenGLContext alloc] initWithFormat:fmt shareContext: other->ctx];
       if (compat != nil) {
       // OK, we can share with this one
          *group = other->display_group;
@@ -1104,7 +1177,7 @@ static NSOpenGLContext* osx_create_shareable_context(NSOpenGLPixelFormat* fmt, u
       // Set to a new group
       *group = next_display_group++;
       ALLEGRO_DEBUG("Creating new display group %d\n", *group);
-      compat = [[NSOpenGLContext alloc] initWithFormat:fmt shareContext: nil];
+      compat = [[ALOpenGLContext alloc] initWithFormat:fmt shareContext: nil];
    }
    return compat;
 }


### PR DESCRIPTION
Fixes https://github.com/liballeg/allegro5/issues/1272 and https://github.com/liballeg/allegro5/issues/473 (all the same root cause).

Resizing a window while the program is drawing crashes inside the system OpenGL driver:

```
GLRResourceList::addResource
GLDContextRec::prepareResourceForGPUAccess
GLDContextRec::addRenderPassResources
gldClearFramebufferData
glClear_Exec
ogl_clear                    ogl_draw.c:949
al_clear_to_color            drawing.c:39
```

You can repro the crash easily on Mac with an existing demo:

1. run ex_windows
2. resize a bunch
3. should crash within a few seconds

My system info:

```
Apple M5 Pro
macOS 26.5.2
```

-----

AppKit sends `-[NSOpenGLContext update]` to the display's context from the main thread whenever the view geometry changes. That reallocates the context's drawable, and since Allegro runs user code - and therefore all drawing - on a secondary thread, a resize landing mid-frame corrupts the GL driver's state and crashes. It reproduces on any resizable `ALLEGRO_OPENGL` display with a plain `al_clear_to_color` / `al_flip_display` loop; a repro is below.

This adds an `ALOpenGLContext : NSOpenGLContext` subclass. AppKit's `-update` no longer does the work, it just records that an update is due. `flip_display` then applies it via `dispatch_sync` to the main thread - `-update` refuses to run anywhere else once the context has a view - and blocks while it runs. Since the drawing thread is parked inside that call, the drawable is only ever reallocated between frames. `setup_gl` forces the same path, so `al_resize_display` and `al_acknowledge_resize` behave as before.

Marshalling the update to the main thread is what SDL does as well, in `-[SDLOpenGLContext explicitUpdate]` - studying [SDL_cocoaopengl.m](https://github.com/libsdl-org/SDL/blob/SDL2/src/video/cocoa/SDL_cocoaopengl.m) helped reach this implementation.

A second commit makes `clear_to_black()` a no-op unless the context is current on the calling thread. `resize_display_win_main_thread()` calls it from the main thread, where the `glClear`s go to whatever context that thread happens to have current (usually none) and the `flushBuffer` touches a context owned by another thread.

### Testing

20,000 draw+resize iterations under ASan exit cleanly; unpatched it dies before iteration 500.

```c++
#import <Cocoa/Cocoa.h>
#include <allegro5/allegro.h>
#include <allegro5/allegro_osx.h>
#include <stdio.h>

int main(int argc, char **argv)
{
   (void)argc; (void)argv;
   if (!al_init()) { printf("al_init failed\n"); return 1; }
   al_set_new_display_flags(ALLEGRO_RESIZABLE | ALLEGRO_OPENGL | ALLEGRO_PROGRAMMABLE_PIPELINE);
   ALLEGRO_DISPLAY *d = al_create_display(640, 480);
   if (!d) { printf("no display\n"); return 1; }
   NSWindow *win = al_osx_get_window(d);
   printf("win=%p\n", win);

   for (int i = 0; i < 20000; i++) {
      if (i % 3 == 0) {
         int w = 400 + (i % 600);
         int h = 300 + (i % 400);
         dispatch_async(dispatch_get_main_queue(), ^{
            NSRect cur = [win frame];
            NSRect content = NSMakeRect(0, 0, w, h);
            NSRect fr = [win frameRectForContentRect: content];
            fr.origin = cur.origin;
            [win setFrame: fr display: YES animate: NO];
         });
      }
      al_clear_to_color(al_map_rgb(i % 255, 20, 40));
      al_flip_display();
      if (i % 500 == 0) { printf("iter %d\n", i); fflush(stdout); }
   }
   printf("survived\n");
   return 0;
}
```

I've also verified correctness w/ this patch in https://github.com/ZQuestClassic/ZQuestClassic/
